### PR TITLE
CSUB-865: Re-enable pushing docker images built from tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,14 +176,14 @@ jobs:
         run: |
           docker build -t gluwa/creditcoin-next:${{ env.TAG_NAME }} .
 
-          # echo "${{ secrets.DOCKER_PUSH_PASSWORD }}" | docker login -u="${{ secrets.DOCKER_PUSH_USERNAME }}" --password-stdin
-          # docker push gluwa/creditcoin-next:${{ env.TAG_NAME }}
+          echo "${{ secrets.DOCKER_PUSH_PASSWORD }}" | docker login -u="${{ secrets.DOCKER_PUSH_USERNAME }}" --password-stdin
+          docker push gluwa/creditcoin-next:${{ env.TAG_NAME }}
 
           # only -mainnet images are tagged as :latest
           # shellcheck disable=SC2046,SC2143
           if [ $(echo "${{ env.TAG_NAME}}" | grep "mainnet") ]; then
               docker tag gluwa/creditcoin-next:${{ env.TAG_NAME }} gluwa/creditcoin-next:latest
-              # docker push gluwa/creditcoin-next:latest
+              docker push gluwa/creditcoin-next:latest
           fi
 
           docker logout


### PR DESCRIPTION
For tag [0.0.2.99-testnet](https://github.com/gluwa/creditcoin-next/releases/tag/0.0.2.99-testnet), will be removed:

Passing container build & push job:
https://github.com/gluwa/creditcoin-next/actions/runs/6655191643/job/18084911587

The rest of CI jobs were canceled. 

Container image was pushed to Docker Hub:
![image](https://github.com/gluwa/creditcoin-next/assets/1002300/232c0d33-1534-45ed-b947-d832ed16b567)
