### PR TITLE
Local Dev: Avoid staking all of Alice funds

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -236,7 +236,7 @@ fn testnet_genesis(
         BalancesConfig, EVMChainIdConfig, EVMConfig, SudoConfig, SystemConfig,
     };
 
-    const STASH: u128 = 1_000_000 * UNITS;
+    const STASH: u128 = 100_000 * UNITS;
     const ENDOWMENT: u128 = 1_000_000 * UNITS;
 
     RuntimeGenesisConfig {

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -236,6 +236,8 @@ fn testnet_genesis(
         BalancesConfig, EVMChainIdConfig, EVMConfig, SudoConfig, SystemConfig,
     };
 
+    // STASH must be less than ENDOWMENT to avoid having
+    // all funds locked in staking.
     const STASH: u128 = 100_000 * UNITS;
     const ENDOWMENT: u128 = 1_000_000 * UNITS;
 


### PR DESCRIPTION
# Description of proposed changes

Currently when spinning up a local dev chain, the Sudo account (Alice) starts with all funds locked by staking and it cannot even pay for Sudo transaction fees. This PR lowers initial staking in fresh local devnets from 1M (100%)  to 100k (10%).

It does not change the public devnet specs.

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
