### PR TITLE
CSUB-905: Use `MultiAddress` as the runtime's address type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-node"
-version = "3.6.3"
+version = "3.7.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-runtime"
-version = "3.6.3"
+version = "3.7.0"
 dependencies = [
  "fp-evm",
  "fp-rpc",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "generate-bags"
-version = "3.6.3"
+version = "3.7.0"
 dependencies = [
  "clap",
  "creditcoin3-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["node", "runtime", "runtime/generate-bags"]
 resolver = "2"
 
 [workspace.package]
-version = "3.6.3"
+version = "3.7.0"
 authors = ["Gluwa Inc.", "Nathan Whitaker <nathan.whitaker@gluwa.com>"]
 edition = "2021"
 license = "Unlicense"

--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -27,9 +27,9 @@ use sc_cli::Result;
 use sc_client_api::BlockBackend;
 use sp_core::{sr25519, Pair};
 use sp_inherents::{InherentData, InherentDataProvider};
-use sp_runtime::{generic::Era, AccountId32, OpaqueExtrinsic, SaturatedConversion};
+use sp_runtime::{generic::Era, AccountId32, MultiAddress, OpaqueExtrinsic, SaturatedConversion};
 // Frontier
-use creditcoin3_runtime::{self as runtime, AccountId, Balance, BalancesCall, SystemCall};
+use creditcoin3_runtime::{self as runtime, AccountId, Address, Balance, BalancesCall, SystemCall};
 
 use crate::client::Client;
 
@@ -75,7 +75,7 @@ impl frame_benchmarking_cli::ExtrinsicBuilder for RemarkBuilder {
 /// Note: Should only be used for benchmarking.
 pub struct TransferKeepAliveBuilder {
     client: Arc<Client>,
-    dest: AccountId,
+    dest: Address,
     value: Balance,
 }
 
@@ -84,7 +84,7 @@ impl TransferKeepAliveBuilder {
     pub fn new(client: Arc<Client>, dest: AccountId, value: Balance) -> Self {
         Self {
             client,
-            dest,
+            dest: MultiAddress::Id(dest),
             value,
         }
     }
@@ -170,7 +170,7 @@ pub fn create_benchmark_extrinsic(
 
     runtime::UncheckedExtrinsic::new_signed(
         call,
-        AccountId32::from(sender.public()),
+        Address::Id(AccountId32::from(sender.public())),
         runtime::Signature::from(signature),
         extra,
     )

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -21,9 +21,9 @@ use sp_core::{
 use sp_runtime::{
     generic, impl_opaque_keys,
     traits::{
-        BlakeTwo256, Block as BlockT, Convert, DispatchInfoOf, Dispatchable, Get, IdentifyAccount,
-        IdentityLookup, NumberFor, One, OpaqueKeys, PostDispatchInfoOf, UniqueSaturatedInto,
-        Verify,
+        AccountIdLookup, BlakeTwo256, Block as BlockT, Convert, DispatchInfoOf, Dispatchable, Get,
+        IdentifyAccount, IdentityLookup, NumberFor, One, OpaqueKeys, PostDispatchInfoOf,
+        UniqueSaturatedInto, Verify,
     },
     transaction_validity::{
         TransactionPriority, TransactionSource, TransactionValidity, TransactionValidityError,
@@ -213,7 +213,7 @@ impl frame_system::Config for Runtime {
     /// The identifier used to distinguish between accounts.
     type AccountId = AccountId;
     /// The lookup mechanism to get account ID from whatever is passed in dispatchers.
-    type Lookup = IdentityLookup<AccountId>;
+    type Lookup = AccountIdLookup<AccountId, AccountIndex>;
     /// The block type.
     type Block = Block;
     /// Maximum number of block number to block hash mappings to keep (oldest pruned first).
@@ -874,7 +874,7 @@ impl fp_rpc::ConvertTransaction<opaque::UncheckedExtrinsic> for TransactionConve
 }
 
 /// The address format for describing accounts.
-pub type Address = AccountId;
+pub type Address = sp_runtime::MultiAddress<AccountId, AccountIndex>;
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -22,8 +22,8 @@ use sp_runtime::{
     generic, impl_opaque_keys,
     traits::{
         AccountIdLookup, BlakeTwo256, Block as BlockT, Convert, DispatchInfoOf, Dispatchable, Get,
-        IdentifyAccount, IdentityLookup, NumberFor, One, OpaqueKeys, PostDispatchInfoOf,
-        UniqueSaturatedInto, Verify,
+        IdentifyAccount, NumberFor, One, OpaqueKeys, PostDispatchInfoOf, UniqueSaturatedInto,
+        Verify,
     },
     transaction_validity::{
         TransactionPriority, TransactionSource, TransactionValidity, TransactionValidityError,

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -7,9 +7,9 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("creditcoin3"),
     impl_name: create_runtime_str!("creditcoin3"),
     authoring_version: 3,
-    spec_version: 6,
-    impl_version: 3,
+    spec_version: 7,
+    impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 1,
+    transaction_version: 2,
     state_version: 1,
 };


### PR DESCRIPTION
# Description of proposed changes
This is what we had on CC2, and it's strictly more flexible than the status quo.

This also fixes the rebased staking dashboard without requiring changes on that side, since that code assumes that the address type is `MultiAddress`. There isn't really any downside to this change, as far as I'm aware.

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
