### PR TITLE
CSUB-862: Auto-commit typedefs updates only if submitter has sufficient priviledges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,7 +437,9 @@ jobs:
           yarn test:integration
 
       - name: Commit changes for typedefs
-        if: ${{ success() && steps.update_typedefs.outputs.git_diff == 'true' }}
+        if: ${{ env.GITHUB_TOKEN && success() && steps.update_typedefs.outputs.git_diff == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: EndBug/add-and-commit@v9
         with:
           add: 'cli/creditcoin.json cli/src/lib/interfaces/'


### PR DESCRIPTION
Should avoid errors like this one:
https://github.com/gluwa/creditcoin3/actions/runs/7167855981/job/19515123149?pr=81
