### PR TITLE
[CSUB-989] Fix babe consensus data provider (for pending eth RPCs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,7 +1513,6 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-babe",
  "sc-consensus-babe-rpc",
- "sc-consensus-epochs",
  "sc-consensus-grandpa",
  "sc-consensus-grandpa-rpc",
  "sc-consensus-manual-seal",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -34,7 +34,6 @@ sc-client-api = { workspace = true }
 sc-consensus = { workspace = true }
 sc-consensus-babe = { workspace = true }
 sc-consensus-babe-rpc = { workspace = true }
-sc-consensus-epochs = { workspace = true }
 sc-consensus-grandpa = { workspace = true }
 sc-consensus-grandpa-rpc = { workspace = true }
 sc-consensus-manual-seal = { workspace = true }

--- a/node/src/rpc/eth.rs
+++ b/node/src/rpc/eth.rs
@@ -67,8 +67,7 @@ pub struct EthDeps<B: BlockT, C, P, A: ChainApi, CT, CIDP> {
     /// Something that can create the inherent data providers for pending state
     pub pending_create_inherent_data_providers: CIDP,
 
-    pub pending_consensus_data_provider:
-        Option<consensus_data_provider::BabeConsensusDataProvider<B, C>>,
+    pub pending_consensus_data_provider: Option<consensus_data_provider::BabeConsensusDataProvider>,
 }
 
 /// Instantiate Ethereum-compatible RPC extensions.

--- a/node/src/rpc/eth/consensus_data_provider.rs
+++ b/node/src/rpc/eth/consensus_data_provider.rs
@@ -1,41 +1,12 @@
-use std::sync::Arc;
-
 use fc_rpc::pending::ConsensusDataProvider;
-use parity_scale_codec::Encode;
-use sc_client_api::{AuxStore, UsageProvider};
-use sc_consensus_babe::{
-    authorship::claim_slot, AuthorityId, BabeAuthorityWeight, BabeConfiguration,
-    CompatibleDigestItem, Epoch, NextEpochDescriptor, PreDigest, SecondaryPlainPreDigest,
-};
-use sc_consensus_epochs::{descendent_query, SharedEpochChanges, ViableEpochDescriptor};
-use sp_api::ProvideRuntimeApi;
-use sp_blockchain::{HeaderBackend, HeaderMetadata};
-use sp_consensus_babe::{inherents::BabeInherentData, BabeApi, ConsensusLog, Slot, BABE_ENGINE_ID};
-use sp_keystore::KeystorePtr;
-use sp_runtime::{
-    traits::{Block as BlockT, Header},
-    DigestItem,
-};
+use sc_consensus_babe::{CompatibleDigestItem, PreDigest, SecondaryPlainPreDigest};
+use sp_consensus_babe::inherents::BabeInherentData;
+use sp_runtime::{traits::Block as BlockT, DigestItem};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("BABE inherent data missing")]
     MissingInherent,
-
-    #[error("Failed to get BABE config")]
-    MissingConfig(#[source] sp_blockchain::Error),
-
-    #[error("Failed to get epoch descriptor: {0}")]
-    EpochDataQuery(String),
-
-    #[error("Failed to get viable epoch")]
-    NoViableEpoch,
-
-    #[error("Consensus error: {0}")]
-    Consensus(#[from] sp_consensus::Error),
-
-    #[error("{0}")]
-    Other(String),
 }
 
 impl From<Error> for sp_inherents::Error {
@@ -44,96 +15,21 @@ impl From<Error> for sp_inherents::Error {
     }
 }
 
-impl From<Error> for sc_service::Error {
-    fn from(err: Error) -> Self {
-        sc_service::Error::Application(Box::new(err))
+pub struct BabeConsensusDataProvider {}
+
+impl BabeConsensusDataProvider {
+    pub fn new() -> Self {
+        Self {}
     }
 }
 
-fn application_error(err: impl std::error::Error + Send + Sync + 'static) -> sp_inherents::Error {
-    sp_inherents::Error::Application(Box::new(err))
-}
-
-pub struct BabeConsensusDataProvider<B: BlockT, C> {
-    /// shared reference to keystore
-    keystore: KeystorePtr,
-
-    /// Shared reference to the client.
-    client: Arc<C>,
-
-    /// Shared epoch changes
-    epoch_changes: SharedEpochChanges<B, Epoch>,
-
-    /// BABE config, gotten from the runtime.
-    /// NOTE: This is used to fetch `slot_duration` and `epoch_length` in the
-    /// `ConsensusDataProvider` implementation. Correct as far as these values
-    /// are not changed during an epoch change.
-    config: BabeConfiguration,
-
-    /// Authorities to be used for this babe chain.
-    authorities: Vec<(AuthorityId, BabeAuthorityWeight)>,
-}
-
-impl<B, C> BabeConsensusDataProvider<B, C>
+impl<B> ConsensusDataProvider<B> for BabeConsensusDataProvider
 where
     B: BlockT,
-    C: AuxStore
-        + ProvideRuntimeApi<B>
-        + UsageProvider<B>
-        + HeaderBackend<B>
-        + HeaderMetadata<B, Error = sp_blockchain::Error>,
-    C::Api: BabeApi<B>,
-{
-    pub fn new(
-        client: Arc<C>,
-        keystore: KeystorePtr,
-        epoch_changes: SharedEpochChanges<B, Epoch>,
-        authorities: Vec<(AuthorityId, BabeAuthorityWeight)>,
-    ) -> Result<Self, Error> {
-        let config = sc_consensus_babe::configuration(&*client).map_err(Error::MissingConfig)?;
-
-        Ok(Self {
-            client,
-            epoch_changes,
-            authorities,
-            keystore,
-            config,
-        })
-    }
-
-    fn epoch(&self, parent: &<B as BlockT>::Header, slot: Slot) -> Result<Epoch, Error> {
-        let epoch_changes = self.epoch_changes.shared_data();
-        let epoch_descriptor = epoch_changes
-            .epoch_descriptor_for_child_of(
-                descendent_query(&*self.client),
-                &parent.hash(),
-                *parent.number(),
-                slot,
-            )
-            .map_err(|e| Error::EpochDataQuery(e.to_string()))?
-            .ok_or(Error::Consensus(sp_consensus::Error::InvalidAuthoritiesSet))?;
-
-        let epoch = epoch_changes
-            .viable_epoch(&epoch_descriptor, |slot| Epoch::genesis(&self.config, slot))
-            .ok_or(Error::NoViableEpoch)?;
-
-        Ok(epoch.as_ref().clone())
-    }
-}
-
-impl<B, C> ConsensusDataProvider<B> for BabeConsensusDataProvider<B, C>
-where
-    B: BlockT,
-    C: AuxStore
-        + ProvideRuntimeApi<B>
-        + UsageProvider<B>
-        + HeaderBackend<B>
-        + HeaderMetadata<B, Error = sp_blockchain::Error>,
-    C::Api: BabeApi<B>,
 {
     fn create_digest(
         &self,
-        parent: &<B as BlockT>::Header,
+        _parent: &<B as BlockT>::Header,
         data: &sp_inherents::InherentData,
     ) -> Result<sp_runtime::Digest, sp_inherents::Error> {
         let slot = data
@@ -142,65 +38,14 @@ where
                 Error::MissingInherent,
             )))?;
 
-        let epoch = self
-            .epoch(parent, slot)
-            .map_err(|e| sp_inherents::Error::Application(Box::new(e)))?;
+        let predigest = PreDigest::SecondaryPlain(SecondaryPlainPreDigest {
+            slot,
+            authority_index: 0,
+        });
 
-        let logs =
-            if let Some((pre_digest, _authority_id)) = claim_slot(slot, &epoch, &self.keystore) {
-                vec![<DigestItem as CompatibleDigestItem>::babe_pre_digest(
-                    pre_digest,
-                )]
-            } else {
-                // well we couldn't claim a slot because this is an existing chain and we're not in the
-                // authorities. we need to tell BabeBlockImport that the epoch has changed, and we put
-                // ourselves in the authorities.
-                let predigest = PreDigest::SecondaryPlain(SecondaryPlainPreDigest {
-                    slot,
-                    authority_index: 0_u32,
-                });
-
-                let mut epoch_changes = self.epoch_changes.shared_data();
-                let epoch_descriptor = epoch_changes
-                    .epoch_descriptor_for_child_of(
-                        descendent_query(&*self.client),
-                        &parent.hash(),
-                        *parent.number(),
-                        slot,
-                    )
-                    .map_err(|e| Error::Other(format!("failed to fetch epoch_descriptor: {}", e)))?
-                    .ok_or(application_error(
-                        sp_consensus::Error::InvalidAuthoritiesSet,
-                    ))?;
-
-                match epoch_descriptor {
-                    ViableEpochDescriptor::Signaled(identifier, _epoch_header) => {
-                        let epoch_mut = epoch_changes.epoch_mut(&identifier).ok_or(
-                            sp_inherents::Error::Application(Box::new(
-                                sp_consensus::Error::InvalidAuthoritiesSet,
-                            )),
-                        )?;
-
-                        // mutate the current epoch
-                        epoch_mut.authorities = self.authorities.clone();
-
-                        let next_epoch = ConsensusLog::NextEpochData(NextEpochDescriptor {
-                            authorities: self.authorities.clone(),
-                            // copy the old randomness
-                            randomness: epoch_mut.randomness,
-                        });
-
-                        vec![
-                            DigestItem::PreRuntime(BABE_ENGINE_ID, predigest.encode()),
-                            DigestItem::Consensus(BABE_ENGINE_ID, next_epoch.encode()),
-                        ]
-                    }
-                    ViableEpochDescriptor::UnimportedGenesis(_) => {
-                        // since this is the genesis, secondary predigest works for now.
-                        vec![DigestItem::PreRuntime(BABE_ENGINE_ID, predigest.encode())]
-                    }
-                }
-            };
+        let logs = vec![<DigestItem as CompatibleDigestItem>::babe_pre_digest(
+            predigest,
+        )];
 
         Ok(sp_runtime::Digest { logs })
     }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -501,7 +501,6 @@ where
         };
         let select_chain = select_chain.clone();
         let keystore = keystore_container.keystore();
-        let epoch_changes = babe_link.epoch_changes().clone();
 
         let shared_authority_set = grandpa_link.shared_authority_set().clone();
         let finality_provider = sc_consensus_grandpa::FinalityProofProvider::new_for_service(
@@ -536,12 +535,7 @@ where
                     forced_parent_hashes: None,
                     pending_create_inherent_data_providers,
                     pending_consensus_data_provider: Some(
-                        crate::rpc::BabeConsensusDataProvider::new(
-                            client.clone(),
-                            keystore.clone(),
-                            epoch_changes.clone(),
-                            vec![],
-                        )?,
+                        crate::rpc::BabeConsensusDataProvider::new(),
                     ),
                 };
                 let deps = crate::rpc::FullDeps {


### PR DESCRIPTION
# Description of proposed changes
This fixes the issue where RPC nodes ban other peers and become isolated on the network. Pablo had a hunch that it was related to ethereum/EVM interactions, and it turns out that was the case!

Some of the ethereum RPCs which take a block number/hash as a parameter also permit you to specify `"pending"`. For instance the second parameter on `eth_getBalance`:

```json
{"jsonrpc": "2.0", "method": "eth_getBalance", "params": ["0x77777FeDdddFfC19Ff86DB637967013e6C6A116C", "pending"],"id": 1}
```

The expected behavior is to run the RPC against the next, pending block (which has not been created yet!) but has pending transactions included in its state.

How this works in frontier is to basically create a new block that "looks" like a legitimate block, and then create a runtime API to execute calls against. To do that, you need to know how to create a valid (ish) block header for the `pending` block. Since the various consensus algorithms use block headers to store consensus-critical data, frontier needs to know how to provide that data to make the header. That happens through the `ConsensusDataProvider` trait. The frontier template starts on AURA, whereas we're using babe, so there isn't a `BABE` implementation of `ConsensusDataProvider`. When doing the initial work to get babe up and running with frontier, I noticed I needed a BABE implementation, and found one in substrate that looked legit. So I adapted that implementation from substrate to get things working. The idea was to test how things work, and if the RPCs seemed broken I would revisit it in more depth.

During testing, it all seemed to work fine, so I figured I could just forget about it. Well, it turns out it _does_ work fine, but only if you're a validator node. That `ConsensusDataProvider` impl from substrate has two codepaths, depending on whether the current node is a validator. It turns out the non-validator code path basically makes no sense for us! It has this sketchy code which mutates the node's current idea of who the validators are to add a dummy validator. Since I rarely run more than 1 dev node (and the dev node I run is always a validator) I never saw the bad behavior locally.

Effectively that means that if you were to call an eth RPC with a `pending` block tag, and the RPC node was not a validator, the node would fork off (because it's current validator set got modified by the sketchy code) and then ban peers because their blocks seemed "invalid".

As it turns out, that `BABE` implementation of `ConsensusDataProvider` that I adapted from substrate doesn't make sense here (honestly I'm not sure it makes sense anywhere, but that's another story). Even though it's the same trait, it's used slightly differently in frontier than it is in substrate. In substrate, it's used to create a block that will pass block import (for manual seal, to be able to mine blocks on demand). In frontier, it's used just to create a block that will have runtime APIs called against it - that means it just needs to satisfy the invariants of on-chain hooks. In the case of BABE, that just means having a digest that indicates the current slot - it doesn't really matter if the "creator" of the block isn't a valid authority.

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
