### PR TITLE
CSUB-899: Revert "updated wasm workflow to use the scheduler pallet"

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -78,4 +78,4 @@ jobs:
           SUDO_SEED: ${{ secrets.DEVNET_SUDO_SEED }}
         run: |
           node dist/scripts/runtimeUpgrade.js "$DEVNET_URL" \
-          ../wasm/runtime/target/srtool/release/wbuild/creditcoin3-runtime/creditcoin3_runtime.compact.compressed.wasm "$SUDO_SEED" 5
+          ../wasm/runtime/target/srtool/release/wbuild/creditcoin3-runtime/creditcoin3_runtime.compact.compressed.wasm "$SUDO_SEED" 0


### PR DESCRIPTION
This reverts commit 1d71f9174af772751b4fb8ec30b54def74402205.

Note: we need to schedule the update with delay 0, so that the scheduler pallet makes it into Devnet. See failure in https://github.com/gluwa/creditcoin3/actions/runs/7557406838/job/20577164306

Once Devnet had been updated to v3.14 or later we can restore the original commit and exercise the scheduler functionality.

# Description of proposed changes

<describe what this PR is about and why we want it>

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
