### PR TITLE
CSUB-1020: Fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload binary
         if: matrix.operating-system != 'windows-2022'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           path: "creditcoin-${{ env.TAG_NAME }}-*.zip"
           if-no-files-found: error
@@ -169,7 +169,7 @@ jobs:
           mv ${{ steps.srtool_build.outputs.wasm }} creditcoin-${{ env.TAG_NAME }}-runtime.wasm
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           path: "*.wasm"
           if-no-files-found: error
@@ -223,7 +223,7 @@ jobs:
           echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
 
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
 
       - name: DEBUG
         shell: bash


### PR DESCRIPTION
# Description of proposed changes

Upgrading to `upload-artifact@v4` and `download-artifact@v4` broke the release pipeline, as it included breaking changes: ([failed run](https://github.com/gluwa/creditcoin3/actions/runs/7465483455/job/20318088171)). This reverts back to v3 to fix it

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
