### PR TITLE
CSUB-861: Rename arguments in createSigner() function

### DIFF
--- a/cli/src/test/blockchain-tests/evm-tracing.test.ts
+++ b/cli/src/test/blockchain-tests/evm-tracing.test.ts
@@ -25,7 +25,7 @@ describe.only('EVM Tracing', (): void => {
         await response.wait();
 
         // call contract method sendForMe to bob
-        const bobKeyring = (global as any).CREDITCOIN_CREATE_SIGNER('borrower');
+        const bobKeyring = (global as any).CREDITCOIN_CREATE_SIGNER('bob');
 
         const call = await contract
             .getFunction('sendForMe')

--- a/cli/src/test/blockchainSetup.ts
+++ b/cli/src/test/blockchainSetup.ts
@@ -1,11 +1,11 @@
 import { KeyringPair, Wallet, POINT_01_CTC, mnemonicGenerate } from '../lib';
 import { initKeyringPair } from '../lib/account/keyring';
 
-const createSigner = (who: 'lender' | 'borrower' | 'random' | 'sudo'): KeyringPair => {
+const createSigner = (who: 'alice' | 'bob' | 'random' | 'sudo'): KeyringPair => {
     switch (who) {
-        case 'lender':
+        case 'alice':
             return initKeyringPair('//Alice');
-        case 'borrower':
+        case 'bob':
             return initKeyringPair('//Bob');
         case 'random':
             const secret = mnemonicGenerate();


### PR DESCRIPTION
there is no loan-flow in CC3 so lender & borrower don't make sense anymore. Rename them to `alice` and `bob` so we can still use them inside of tests!

