### PR TITLE
CSUB-1011: Make EVM tracing testing conditional

### DIFF
--- a/cli/src/test/blockchain-tests/evm-tracing.test.ts
+++ b/cli/src/test/blockchain-tests/evm-tracing.test.ts
@@ -1,8 +1,9 @@
+import { WebSocketProvider, ethers, parseEther } from 'ethers';
 import { substrateAddressToEvmAddress } from '../../lib/evm/address';
 import { deployContract } from './helpers';
-import { WebSocketProvider, ethers, parseEther } from 'ethers';
+import { describeIf } from '../utils';
 
-describe.only('EVM Tracing', (): void => {
+describeIf((global as any).CREDITCOIN_HAS_EVM_TRACING, 'EVM Tracing', (): void => {
     let provider: WebSocketProvider;
     let deployedContractAddress: string;
     let txHash: string;

--- a/cli/src/test/blockchainSetup.ts
+++ b/cli/src/test/blockchainSetup.ts
@@ -66,6 +66,10 @@ const setup = () => {
     if ((global as any).CREDITCOIN_USES_FAST_RUNTIME === undefined) {
         (global as any).CREDITCOIN_USES_FAST_RUNTIME = true;
     }
+
+    if ((global as any).CREDITCOIN_HAS_EVM_TRACING === undefined) {
+        (global as any).CREDITCOIN_HAS_EVM_TRACING = true;
+    }
 };
 
 export default setup;


### PR DESCRIPTION
b/c none of our production nodes are executed with this functionality. This is only used by Subscan.

During runtime upgrade testing and/or testing against Testnet/Devnet/Mainnet these EVM tracing tests will not be executed.