### PR TITLE
CSUB-1021: CC3 Clarify proxy combinations

### DIFF
--- a/cli/src/lib/proxy/index.ts
+++ b/cli/src/lib/proxy/index.ts
@@ -24,3 +24,15 @@ export function filterProxiesByAddress(
 export function hasProxyType(delegates: PalletProxyProxyDefinition[], type: string): boolean {
     return delegates.find((delegate) => delegate.proxyType.toString() === type) !== undefined;
 }
+
+// Checks if 'addr' is found in any of the proxies storage map entries and returns true if so false otherwise
+export async function addressIsAlreadyProxy(addr: string, api: ApiPromise): Promise<boolean> {
+    const allProxies = await api.query.proxy.proxies.entries();
+    for (const [_, [entries, __]] of allProxies) {
+        const matchingProxies = entries.filter((p) => p.delegate.toString() === addr);
+        if (matchingProxies.length > 0) {
+            return true;
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
From the ticket:

Code to change : 
1. Limit a validator account to 1 type of proxy (All OR staking OR non-transfer)
3. Limit a proxy account to one validator only (disable multiple validators assigned to a single proxy)

All of the changes are limited to the `setProxyAction` in `src/commands/proxy/action.ts` and `src/lib/proxy`

TODO: Rebase after CSUB-102 is merged