### PR TITLE
CSUB-1012: Rename validatorAddress() to delegateAddress()

### DIFF
--- a/cli/src/commands/staking/bond.ts
+++ b/cli/src/commands/staking/bond.ts
@@ -5,7 +5,7 @@ import { promptContinue, setInteractivity } from '../../lib/interactive';
 import { AccountBalance, getBalance, toCTCString, checkAmount } from '../../lib/balance';
 
 import { inputOrDefault, parseBoolean, parseChoiceOrExit } from '../../lib/parsing';
-import { initKeyring, validatorAddress } from '../../lib/account/keyring';
+import { initKeyring, delegateAddress } from '../../lib/account/keyring';
 import { amountOption, useProxyOption } from '../options';
 
 export function makeBondCommand() {
@@ -28,7 +28,7 @@ async function bondAction(options: OptionValues) {
     const { amount, rewardDestination, extra, interactive } = parseOptions(options);
 
     const callerKeyring = await initKeyring(options);
-    const callerAddress = validatorAddress(callerKeyring);
+    const callerAddress = delegateAddress(callerKeyring);
 
     // Check if caller has enough balance, caller may be a proxy account
     await checkBalance(amount, api, callerAddress);

--- a/cli/src/commands/staking/chill.ts
+++ b/cli/src/commands/staking/chill.ts
@@ -1,7 +1,7 @@
 import { Command, OptionValues } from 'commander';
 import { getValidatorStatus, newApi, requireStatus } from '../../lib';
 import { chill } from '../../lib/staking/chill';
-import { initKeyring, validatorAddress } from '../../lib/account/keyring';
+import { initKeyring, delegateAddress } from '../../lib/account/keyring';
 import { useProxyOption } from '../options';
 
 export function makeChillCommand() {
@@ -17,7 +17,7 @@ async function chillAction(options: OptionValues) {
 
     const keyring = await initKeyring(options);
 
-    const address = validatorAddress(keyring);
+    const address = delegateAddress(keyring);
 
     const status = await getValidatorStatus(address, api);
 

--- a/cli/src/commands/staking/unbond.ts
+++ b/cli/src/commands/staking/unbond.ts
@@ -7,7 +7,7 @@ import { getBalance } from '../../lib/balance';
 import { promptContinue, setInteractivity } from '../../lib/interactive';
 import { requireKeyringHasSufficientFunds, signSendAndWatchCcKeyring } from '../../lib/tx';
 import { getValidatorStatus, requireStatus } from '../../lib/staking';
-import { initKeyring, validatorAddress } from '../../lib/account/keyring';
+import { initKeyring, delegateAddress } from '../../lib/account/keyring';
 import { amountOption, useProxyOption } from '../options';
 
 export function makeUnbondCommand() {
@@ -30,7 +30,7 @@ async function unbondAction(options: OptionValues) {
     const caller = await initKeyring(options);
 
     // We need to check the staking ledger of the caller even if we are using a proxy
-    const validatorAddr = validatorAddress(caller);
+    const validatorAddr = delegateAddress(caller);
     const status = await getValidatorStatus(validatorAddr, api);
     requireStatus(status, 'bonded');
 

--- a/cli/src/commands/staking/withdraw.ts
+++ b/cli/src/commands/staking/withdraw.ts
@@ -1,7 +1,7 @@
 import { Command, OptionValues } from 'commander';
 import { getValidatorStatus, newApi, requireStatus } from '../../lib';
 import { requireKeyringHasSufficientFunds, signSendAndWatchCcKeyring } from '../../lib/tx';
-import { initKeyring, validatorAddress } from '../../lib/account/keyring';
+import { initKeyring, delegateAddress } from '../../lib/account/keyring';
 import { useProxyOption } from '../options';
 
 export function makeWithdrawUnbondedCommand() {
@@ -17,7 +17,7 @@ async function withdrawUnbondedAction(options: OptionValues) {
 
     const keyring = await initKeyring(options);
 
-    const validatorAddr = validatorAddress(keyring);
+    const validatorAddr = delegateAddress(keyring);
     const status = await getValidatorStatus(validatorAddr, api);
     requireStatus(status, 'canWithdraw', 'Cannot perform action, there are no unlocked funds to withdraw');
 

--- a/cli/src/commands/staking/wizard.ts
+++ b/cli/src/commands/staking/wizard.ts
@@ -4,7 +4,7 @@ import { parseChoiceOrExit, inputOrDefault, parsePercentAsPerbillOrExit, parseBo
 import { StakingPalletValidatorPrefs } from '../../lib/staking/validate';
 import { TxStatus, requireKeyringHasSufficientFunds, signSendAndWatchCcKeyring } from '../../lib/tx';
 import { percentFromPerbill } from '../../lib/perbill';
-import { CcKeyring, initKeyring, isProxy, validatorAddress } from '../../lib/account/keyring';
+import { CcKeyring, initKeyring, isProxy, delegateAddress } from '../../lib/account/keyring';
 import { AccountBalance, getBalance, parseCTCString, printBalance, toCTCString } from '../../lib/balance';
 import { promptContinue, promptContinueOrSkip, setInteractivity } from '../../lib/interactive';
 import { amountOption, useProxyOption } from '../options';
@@ -34,7 +34,7 @@ export function makeWizardCommand() {
         // Generate keyring
         const keyring = await initKeyring(options);
 
-        const address = validatorAddress(keyring);
+        const address = delegateAddress(keyring);
 
         // Validate prefs
         const preferences: StakingPalletValidatorPrefs = {

--- a/cli/src/lib/account/keyring.ts
+++ b/cli/src/lib/account/keyring.ts
@@ -7,7 +7,7 @@ import { parseBoolean } from '../parsing';
 
 // return the underlying address from a keyring, if this is a non proxied keyring it is just the address of the keypair
 // If it is a proxy then the proxied address is the one that we want to check for available funds and validator status etc
-export function validatorAddress(keyring: CcKeyring) {
+export function delegateAddress(keyring: CcKeyring) {
     return isProxy(keyring) ? (keyring as ProxyKeyring).proxiedAddress : keyring.pair.address;
 }
 

--- a/cli/src/lib/tx.ts
+++ b/cli/src/lib/tx.ts
@@ -3,7 +3,7 @@ import { ISubmittableResult } from '@polkadot/types/types';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { AccountBalance, getBalance, toCTCString } from './balance';
 import { ApiPromise, BN, KeyringPair } from '.';
-import { CcKeyring, validatorAddress } from './account/keyring';
+import { CcKeyring, delegateAddress } from './account/keyring';
 
 export async function signSendAndWatch(
     tx: SubmittableExtrinsic<'promise', ISubmittableResult>,
@@ -132,7 +132,7 @@ export async function requireKeyringHasSufficientFunds(
     api: ApiPromise,
     amount = new BN(0),
 ) {
-    const address = validatorAddress(keyring);
+    const address = delegateAddress(keyring);
     return requireEnoughFundsToSend(tx, address, api, amount);
 }
 


### PR DESCRIPTION
in the terminology of the proxy pallet the original account is called a delegate, so trying to match this terminology.

Also there is a function called `validateAddress` which is used for input validation and the names are rather similar and IMO that's a bit confusing.
