### PR TITLE
Stricter control over git tag name suffixes

### DIFF
--- a/.github/check-tag-suffix-vs-origin-branch.sh
+++ b/.github/check-tag-suffix-vs-origin-branch.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+GIT_TAG=$(git describe --tag)
+SUFFIX_FROM_GIT_TAG=$(echo "$GIT_TAG" | cut -d"-" -f2,99)
+NEAREST_GIT_BRANCH=$(git branch --contains | grep "\* " | cut -f2 -d" ")
+
+echo "INFO: git tag: '$GIT_TAG'"
+echo "INFO: suffix from git tag: '$SUFFIX_FROM_GIT_TAG'"
+echo "INFO: nearest git branch '$NEAREST_GIT_BRANCH'"
+
+if [[ "$SUFFIX_FROM_GIT_TAG" == "devnet" && "$NEAREST_GIT_BRANCH" == "dev" ]]; then
+    echo "PASS: good match for -devnet releases"
+    exit 0
+fi
+
+if [[ "$SUFFIX_FROM_GIT_TAG" == "testnet" && "$NEAREST_GIT_BRANCH" == "testnet" ]]; then
+    echo "PASS: good match for -testnet releases"
+    exit 0
+fi
+
+if [[ "$SUFFIX_FROM_GIT_TAG" == "mainnet" && "$NEAREST_GIT_BRANCH" == "main" ]]; then
+    echo "PASS: good match for -mainnet releases"
+    exit 0
+fi
+
+echo "FAIL: Looks like tag name doesn't match the branch it came from"
+exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Sanity check tag name suffix
         run: |
           echo "${{ env.TAG_NAME }}" | grep -E "mainnet|testnet|devnet"
+          .github/check-tag-suffix-vs-origin-branch.sh
 
       - name: Check tag name vs. Cargo.toml version
         run: |


### PR DESCRIPTION
to avoid the situation where a release is tagged as x.y.z-testnet but the release artifacts are actually built from the `dev` branch!


If I execute from the topic branch:
```
.github/check-tag-suffix-vs-origin-branch.sh 
INFO: git tag: '3.18.0-devnet'
INFO: suffix from git tag: 'devnet'
INFO: nearest git branch 'testing/stricter-control-over-tag-suffixes'
FAIL: Looks like tag name doesn't match the branch it came from
```

When I execute the same script from the `testnet` branch

```
INFO: git tag: '3.15.3-testnet-22-g2481f3f'
INFO: suffix from git tag: 'testnet'
INFO: nearest git branch 'testnet'
PASS: good match for -testnet releases
```


When I execute the same script from the `dev` branch:

```
INFO: git tag: '3.18.0-devnet'
INFO: suffix from git tag: 'devnet'
INFO: nearest git branch 'dev'
PASS: good match for -devnet releases
```

- if I do a `git tag && git push` before this PR is merged we should see the release action running and then failing
- if I do a `git tag && git push` after this PR has been merged to `dev` we should see all green