### PR TITLE
CSUB-1073: Improve sanity checks for git tags origin during release

### DIFF
--- a/.github/check-tag-suffix-vs-origin-branch.sh
+++ b/.github/check-tag-suffix-vs-origin-branch.sh
@@ -4,7 +4,14 @@ set -euo pipefail
 
 GIT_TAG=$(git describe --tag)
 SUFFIX_FROM_GIT_TAG=$(echo "$GIT_TAG" | cut -d"-" -f2,99)
-NEAREST_GIT_BRANCH=$(git branch --contains | grep "\* " | cut -f2 -d" ")
+
+echo "----- DEBUG -----"
+git branch -a --contains
+echo "----- DEBUG -----"
+git branch -a --contains | grep remotes/origin
+echo "----- END -----"
+
+NEAREST_GIT_BRANCH=$(git branch -a --contains | grep remotes/origin | cut -f3 -d/)
 
 echo "INFO: git tag: '$GIT_TAG'"
 echo "INFO: suffix from git tag: '$SUFFIX_FROM_GIT_TAG'"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Sanity check tag name suffix
         run: |
           echo "${{ env.TAG_NAME }}" | grep -E "mainnet|testnet|devnet"
-          # .github/check-tag-suffix-vs-origin-branch.sh
+          .github/check-tag-suffix-vs-origin-branch.sh
 
       - name: Check tag name vs. Cargo.toml version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Sanity check tag name suffix
         run: |
           echo "${{ env.TAG_NAME }}" | grep -E "mainnet|testnet|devnet"
-          .github/check-tag-suffix-vs-origin-branch.sh
+          # .github/check-tag-suffix-vs-origin-branch.sh
 
       - name: Check tag name vs. Cargo.toml version
         run: |


### PR DESCRIPTION
# Description of proposed changes


During the sanity check step which tries to find out which branch a git tag came from the source code is checked out by GitHub in a detached state and the previous implementation was returning "(HEAD" which  failed in https://github.com/gluwa/creditcoin3/actions/runs/8236512427/job/22523091397. 

Instead of matching the currently checkout out branch (grep for `* `) find the name of a remote branch containing the same tag ref and then compare that against the expected list of origin branches (dev, testnet or main). 

For experimentation I made a tag called `3.21.xx01-testnet` on the origin branch of this PR and it triggered the pipeline execution in https://github.com/gluwa/creditcoin3/actions/runs/8237469339/job/22526275349. Here we can see:

- the local git checkout in a detached state:
```
* (HEAD detached at 3.21.xx01-testnet)
  remotes/origin/CSUB-1073-temporary-skip-check-for-tag-branch-origin
```

- only the remote branches filtered:
```
  remotes/origin/CSUB-1073-temporary-skip-check-for-tag-branch-origin
```

- the origin branch of `CSUB-1073-temporary-skip-check-for-tag-branch-origin` which doesn't follow the expected naming conventions. 


@pLabarta, @beqaabu please review when you have the time and if you approve I can bump the version again and we can try publishing another release tomorrow to see this in action.
