### PR TITLE
CSUB-1100: Halve the number of blocks/epoch for `fast-runtime` feature

### DIFF
--- a/cli/src/test/blockchainSetup.ts
+++ b/cli/src/test/blockchainSetup.ts
@@ -64,7 +64,7 @@ const setup = () => {
     }
 
     if ((global as any).CREDITCOIN_EXPECTED_EPOCH_DURATION === undefined) {
-        (global as any).CREDITCOIN_EXPECTED_EPOCH_DURATION = 15;
+        (global as any).CREDITCOIN_EXPECTED_EPOCH_DURATION = 8;
     }
 
     if ((global as any).CREDITCOIN_EXPECTED_BLOCK_TIME === undefined) {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -152,7 +152,7 @@ pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
 // WARNING: the next should be defined on a single line b/c of
 // the assertions made in .github/check-for-changes-in-epoch-duration.sh
 #[rustfmt::skip]
-const BLOCKS_FOR_FASTER_EPOCH: u32 = if cfg!(feature = "devnet") { 2 * HOURS } else { 15 };
+const BLOCKS_FOR_FASTER_EPOCH: u32 = if cfg!(feature = "devnet") { 2 * HOURS } else { 8 };
 
 pub const EPOCH_DURATION_IN_BLOCKS: u32 = prod_or_fast!(12 * HOURS, BLOCKS_FOR_FASTER_EPOCH);
 


### PR DESCRIPTION
this should speed up integration tests in CI b/c we'd have to wait less time for unbonded funds to be unlocked

# Description of proposed changes

<describe what this PR is about and why we want it>

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
