### PR TITLE
CSUB-1099: Short-circuit test execution if the chain has stopped finalizing

### DIFF
--- a/cli/src/test/integrationTestSetupAfterEnv.ts
+++ b/cli/src/test/integrationTestSetupAfterEnv.ts
@@ -1,4 +1,4 @@
-import { startAliceAndBob, killCreditcoinNodes } from './utils';
+import { expectIsFinalizing, startAliceAndBob, killCreditcoinNodes } from './utils';
 
 global.beforeAll(async () => {
     // alternatively we can duplicate utils.describeIf() and place this
@@ -9,4 +9,9 @@ global.beforeAll(async () => {
 
 global.afterAll(() => {
     killCreditcoinNodes();
+});
+
+global.beforeEach(async () => {
+    // short-circuit test execution if the chain has stopped finalizing
+    await expectIsFinalizing();
 });


### PR DESCRIPTION
splitting #290 into multiple parts in order to find out which commit causes the failure seen when executing `proxy=no` in #290. 
