### PR TITLE
CSUB-1026, CSUB-1030: Assert the correct error message when proxy doesn't have enough CTC

### DIFF
--- a/cli/src/test/integration-tests/bond.test.ts
+++ b/cli/src/test/integration-tests/bond.test.ts
@@ -50,14 +50,14 @@ describe('bond', () => {
 
     testIf(
         process.env.PROXY_ENABLED === 'yes' && process.env.PROXY_SECRET_VARIANT === 'no-funds',
-        'should error with account balance too low message',
+        'should error with "Caller has insufficient funds" message',
         () => {
             try {
                 CLI('bond --amount 111');
             } catch (error: any) {
                 expect(error.exitCode).toEqual(1);
                 expect(error.stderr).toContain(
-                    'Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
+                    `Caller ${proxy.address} has insufficient funds to send the transaction`,
                 );
             }
         },

--- a/cli/src/test/integration-tests/chill.test.ts
+++ b/cli/src/test/integration-tests/chill.test.ts
@@ -85,14 +85,14 @@ describe('chill', () => {
 
         testIf(
             process.env.PROXY_ENABLED === 'yes' && process.env.PROXY_SECRET_VARIANT === 'no-funds',
-            'should error with account balance too low message',
+            'should error with "Caller has insufficient funds" message',
             () => {
                 try {
                     CLI('chill');
                 } catch (error: any) {
                     expect(error.exitCode).toEqual(1);
                     expect(error.stderr).toContain(
-                        'Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
+                        `Caller ${proxy.address} has insufficient funds to send the transaction`,
                     );
                 }
             },

--- a/cli/src/test/integration-tests/distribute-rewards.test.ts
+++ b/cli/src/test/integration-tests/distribute-rewards.test.ts
@@ -51,7 +51,7 @@ describe('distribute-rewards', () => {
 
     testIf(
         process.env.PROXY_ENABLED === 'yes' && process.env.PROXY_SECRET_VARIANT === 'no-funds',
-        'should error with account balance too low message',
+        'should error with "Caller has insufficient funds" message',
         () => {
             try {
                 // Alice is always a validator
@@ -59,7 +59,7 @@ describe('distribute-rewards', () => {
             } catch (error: any) {
                 expect(error.exitCode).toEqual(1);
                 expect(error.stderr).toContain(
-                    'Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
+                    `Caller ${proxy.address} has insufficient funds to send the transaction`,
                 );
             }
         },

--- a/cli/src/test/integration-tests/send.test.ts
+++ b/cli/src/test/integration-tests/send.test.ts
@@ -61,14 +61,14 @@ describe('Send command', () => {
 
     testIf(
         process.env.PROXY_ENABLED === 'yes' && process.env.PROXY_SECRET_VARIANT === 'no-funds',
-        'should error with account balance too low message',
+        'should error with "Caller has insufficient funds" message',
         () => {
             try {
                 CLI('send --amount 1 --substrate-address 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY');
             } catch (error: any) {
                 expect(error.exitCode).toEqual(1);
                 expect(error.stderr).toContain(
-                    'Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
+                    `Caller ${proxy.address} has insufficient funds to send the transaction`,
                 );
             }
         },

--- a/cli/src/test/integration-tests/set-keys.test.ts
+++ b/cli/src/test/integration-tests/set-keys.test.ts
@@ -79,14 +79,14 @@ describe('set-keys', () => {
 
         testIf(
             process.env.PROXY_ENABLED === 'yes' && process.env.PROXY_SECRET_VARIANT === 'no-funds',
-            'should error with account balance too low message',
+            'should error with "Caller has insufficient funds" message',
             () => {
                 try {
                     CLI('set-keys --rotate');
                 } catch (error: any) {
                     expect(error.exitCode).toEqual(1);
                     expect(error.stderr).toContain(
-                        'Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
+                        `Caller ${proxy.address} has insufficient funds to send the transaction`,
                     );
                 }
             },

--- a/cli/src/test/integration-tests/unbond.test.ts
+++ b/cli/src/test/integration-tests/unbond.test.ts
@@ -71,14 +71,14 @@ describe('unbond', () => {
 
         testIf(
             process.env.PROXY_ENABLED === 'yes' && process.env.PROXY_SECRET_VARIANT === 'no-funds',
-            'should error with account balance too low message',
+            'should error with "Caller has insufficient funds" message',
             () => {
                 try {
                     CLI('unbond --amount 123');
                 } catch (error: any) {
                     expect(error.exitCode).toEqual(1);
                     expect(error.stderr).toContain(
-                        'Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
+                        `Caller ${proxy.address} has insufficient funds to send the transaction`,
                     );
                 }
             },

--- a/cli/src/test/integration-tests/validate.test.ts
+++ b/cli/src/test/integration-tests/validate.test.ts
@@ -79,14 +79,14 @@ describe('validate', () => {
 
         testIf(
             process.env.PROXY_ENABLED === 'yes' && process.env.PROXY_SECRET_VARIANT === 'no-funds',
-            'should error with account balance too low message',
+            'should error with "Caller has insufficient-funds" message',
             () => {
                 try {
                     CLI('validate');
                 } catch (error: any) {
                     expect(error.exitCode).toEqual(1);
                     expect(error.stderr).toContain(
-                        'Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
+                        `Caller ${proxy.address} has insufficient funds to send the transaction`,
                     );
                 }
             },

--- a/cli/src/test/integration-tests/withdraw-unbonded.test.ts
+++ b/cli/src/test/integration-tests/withdraw-unbonded.test.ts
@@ -92,14 +92,14 @@ describe('withdraw-unbonded', () => {
 
         testIf(
             process.env.PROXY_ENABLED === 'yes' && process.env.PROXY_SECRET_VARIANT === 'no-funds',
-            'should error with account balance too low message',
+            'should error with "Caller has insufficient funds" message',
             () => {
                 try {
                     CLI('withdraw-unbonded');
                 } catch (error: any) {
                     expect(error.exitCode).toEqual(1);
                     expect(error.stderr).toContain(
-                        'Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
+                        `Caller ${proxy.address} has insufficient funds to send the transaction`,
                     );
                 }
             },

--- a/cli/src/test/integration-tests/wizard.test.ts
+++ b/cli/src/test/integration-tests/wizard.test.ts
@@ -51,14 +51,14 @@ describe('wizard', () => {
 
     testIf(
         process.env.PROXY_ENABLED === 'yes' && process.env.PROXY_SECRET_VARIANT === 'no-funds',
-        'should error with account balance too low message',
+        'should error with "Caller has insufficient funds" message',
         () => {
             try {
                 CLI('wizard --amount 900');
             } catch (error: any) {
                 expect(error.exitCode).toEqual(1);
                 expect(error.stdout).toContain(
-                    'Account does not have enough funds, it requires 2.000000000000000000 CTC',
+                    `Caller ${proxy.address} has insufficient funds to send the transaction`,
                 );
             }
         },


### PR DESCRIPTION
when executing commands with a proxy configured the check for enough funds should check that:

 - proxy account has enough funds to pay transaction fees
 - delegate account has enough funds for the actual amount used by the transaction, e.g. a bond amount!

The command should print a human readable error coming from: lib/tx.ts::requireKeyringHasSufficientFunds() -> requireEnoughFundsToSend()

instead of sending the transaction and then crashing with a traceback:

Sending transaction...
2024-04-05 14:56:03        RPC-CORE: submitAndWatchExtrinsic(extrinsic: Extrinsic): ExtrinsicStatus:: 1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low
2024-04-05 14:56:03        RPC-CORE: submitAndWatchExtrinsic(extrinsic: Extrinsic): ExtrinsicStatus:: 1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low
/home/gluwa/creditcoin-3.0/creditcoin3/cli/node_modules/@polkadot/rpc-provider/cjs/coder/index.js:23
        throw new error_js_1.default(`${code}: ${message}${formatErrorData(data)}`, code, data);
              ^

RpcError: 1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low
    at checkError (/home/gluwa/creditcoin-3.0/creditcoin3/cli/node_modules/@polkadot/rpc-provider/cjs/coder/index.js:23:15)
    at RpcCoder.decodeResponse (/home/gluwa/creditcoin-3.0/creditcoin3/cli/node_modules/@polkadot/rpc-provider/cjs/coder/index.js:39:9)
    at WsProvider.__internal__onSocketMessageResult (/home/gluwa/creditcoin-3.0/creditcoin3/cli/node_modules/@polkadot/rpc-provider/cjs/ws/index.js:413:51)
    at WebSocket.__internal__onSocketMessage (/home/gluwa/creditcoin-3.0/creditcoin3/cli/node_modules/@polkadot/rpc-provider/cjs/ws/index.js:402:20)
    at callListener (/home/gluwa/creditcoin-3.0/creditcoin3/cli/node_modules/ws/lib/event-target.js:290:14)
    at WebSocket.onMessage (/home/gluwa/creditcoin-3.0/creditcoin3/cli/node_modules/ws/lib/event-target.js:209:9)
    at WebSocket.emit (node:events:518:28)
    at Receiver.receiverOnMessage (/home/gluwa/creditcoin-3.0/creditcoin3/cli/node_modules/ws/lib/websocket.js:1209:20)
    at Receiver.emit (node:events:518:28)
    at /home/gluwa/creditcoin-3.0/creditcoin3/cli/node_modules/ws/lib/receiver.js:608:16

Node.js v20.12.0

WARNING: this change will cause tests to fail b/c the current implementation is incorrect. This is documented in more details in CSUB-1030.

# Description of proposed changes

<describe what this PR is about and why we want it>

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
