### PR TITLE
CSUB-1026: Rename internal variables for future compatibility

### DIFF
--- a/cli/src/commands/staking/chill.ts
+++ b/cli/src/commands/staking/chill.ts
@@ -17,9 +17,8 @@ async function chillAction(options: OptionValues) {
 
     const keyring = await initKeyring(options);
 
-    const address = delegateAddress(keyring);
-
-    const status = await getValidatorStatus(address, api);
+    const validatorAddr = delegateAddress(keyring);
+    const status = await getValidatorStatus(validatorAddr, api);
 
     requireStatus(status, 'validating');
 

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -30,9 +30,9 @@ async function statusAction(options: OptionValues) {
     }
 
     if (showValidatorStatus) {
-        const validator = options.substrateAddress as string;
-        const validatorStatus = await getValidatorStatus(validator, api);
-        console.log(`Validator ${validator}:`);
+        const validatorAddr = options.substrateAddress as string;
+        const validatorStatus = await getValidatorStatus(validatorAddr, api);
+        console.log(`Validator ${validatorAddr}:`);
         await printValidatorStatus(validatorStatus, api);
     }
 


### PR DESCRIPTION
it looks like that getValidatorStatus() is always being called correctly with the address of an expected validator regardless of whether or not we are using proxy accounts.

This change just makes all of the invocations consistent with one another in case we'd like to somehow assert/grep on these calls in the future!


---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
