### PR TITLE
CSUB-1090: Display current era and block info in status command

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -9,3 +9,4 @@ https://www.buymeacoffee.com/ricmoo
 git+https://github.com/paritytech/frontier.git
 https://github.com/gluwa/creditcoin3/security/advisories(.*)
 https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2
+https://feross.org/support

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -1,14 +1,12 @@
 import { Command, OptionValues } from 'commander';
 import { newApi } from '../lib';
 import { parseBoolean } from '../lib/parsing';
-import { getChainStatus, printChainStatus } from '../lib/chain/status';
 import { getValidatorStatus, printValidatorStatus } from '../lib/staking/validatorStatus';
 import { substrateAddressOption } from './options';
 
 export function makeStatusCommand() {
     const cmd = new Command('status');
     cmd.description('Get staking status for an address');
-    cmd.option('--chain', 'Show chain status');
     cmd.addOption(substrateAddressOption);
     cmd.action(statusAction);
     return cmd;
@@ -18,16 +16,6 @@ async function statusAction(options: OptionValues) {
     const { api } = await newApi(options.url as string);
 
     const showValidatorStatus = parseBoolean(options.substrateAddress);
-    let showChainStatus = parseBoolean(options.chain);
-
-    if (!showValidatorStatus && !showChainStatus) {
-        showChainStatus = true;
-    }
-
-    if (showChainStatus) {
-        const chainStatus = await getChainStatus(api);
-        printChainStatus(chainStatus);
-    }
 
     if (showValidatorStatus) {
         const validatorAddr = options.substrateAddress as string;

--- a/cli/src/lib/chain/status.ts
+++ b/cli/src/lib/chain/status.ts
@@ -8,13 +8,16 @@ interface ChainStatus {
 }
 
 export async function getChainStatus(api: ApiPromise): Promise<ChainStatus> {
-    const bestNumber = await api.derive.chain.bestNumber();
-    const bestFinalizedNumber = await api.derive.chain.bestNumberFinalized();
-    const eraInfo = await getEraInfo(api);
+    const [bestBlock, bestFinalized, eraInfo] = await Promise.all([
+        api.rpc.chain.getBlock(),
+        api.rpc.chain.getBlock(await api.rpc.chain.getFinalizedHead()),
+        getEraInfo(api),
+    ]);
+
     return {
         name: api.runtimeVersion.specName.toString(),
-        bestNumber: bestNumber.toNumber(),
-        bestFinalizedNumber: bestFinalizedNumber.toNumber(),
+        bestNumber: bestBlock.block.header.number.toNumber(),
+        bestFinalizedNumber: bestFinalized.block.header.number.toNumber(),
         eraInfo,
     };
 }

--- a/cli/src/lib/chain/status.ts
+++ b/cli/src/lib/chain/status.ts
@@ -20,8 +20,13 @@ export async function getChainStatus(api: ApiPromise): Promise<ChainStatus> {
 }
 
 interface EraInfo {
+    /// The active era is the era being currently rewarded. Validator set of this era must be
+    /// equal to [`SessionInterface::validators`].
     activeEra: number;
+    /// This is the latest planned era, depending on how the Session pallet queues the validator
+    /// set, it might be active or not.
     currentEra: number;
+    /// ^^^ NOTE: the name currentEra is misleading b/c the current one is the active one!
     currentSession: number;
     sessionsPerEra: number;
 }

--- a/cli/src/lib/chain/status.ts
+++ b/cli/src/lib/chain/status.ts
@@ -20,15 +20,18 @@ export async function getChainStatus(api: ApiPromise): Promise<ChainStatus> {
 }
 
 interface EraInfo {
-    era: number;
+    activeEra: number;
+    currentEra: number;
     currentSession: number;
     sessionsPerEra: number;
 }
 
 async function getEraInfo(api: ApiPromise): Promise<EraInfo> {
-    const session = await api.derive.session.info();
+    const [session, currentEra] = await Promise.all([api.derive.session.info(), api.query.staking.currentEra()]);
+
     return {
-        era: session.activeEra.toNumber(),
+        activeEra: session.activeEra.toNumber(),
+        currentEra: Number(currentEra),
         currentSession: (session.currentIndex.toNumber() % session.sessionsPerEra.toNumber()) + 1,
         sessionsPerEra: session.sessionsPerEra.toNumber(),
     };

--- a/cli/src/lib/chain/status.ts
+++ b/cli/src/lib/chain/status.ts
@@ -1,5 +1,4 @@
 import { ApiPromise } from '@polkadot/api';
-import Table from 'cli-table3';
 
 interface ChainStatus {
     name: string;
@@ -33,20 +32,4 @@ async function getEraInfo(api: ApiPromise): Promise<EraInfo> {
         currentSession: (session.currentIndex.toNumber() % session.sessionsPerEra.toNumber()) + 1,
         sessionsPerEra: session.sessionsPerEra.toNumber(),
     };
-}
-
-export function printChainStatus(status: ChainStatus) {
-    const { eraInfo } = status;
-    const table = new Table({
-        head: [status.name],
-    });
-
-    table.push(
-        ['Best Block', status.bestNumber],
-        ['Best Finalized Block', status.bestFinalizedNumber],
-        ['Era', eraInfo.era],
-        ['Session', `${eraInfo.currentSession}/${eraInfo.sessionsPerEra}`],
-    );
-    console.log('Chain status:');
-    console.log(table.toString());
 }

--- a/cli/src/lib/staking/validatorStatus.ts
+++ b/cli/src/lib/staking/validatorStatus.ts
@@ -3,6 +3,7 @@ import timeDelta = require('time-delta');
 import { ApiPromise } from '@polkadot/api';
 import { BN } from '..';
 import { readAmount, readAmountFromHex, toCTCString } from '../balance';
+import { getChainStatus } from '../chain/status';
 import { timeTillEra } from './era';
 import Table from 'cli-table3';
 import { PalletStakingUnlockChunk } from '@polkadot/types/lookup';
@@ -97,8 +98,14 @@ export async function validatorStatusTable(status: Status | undefined, api: ApiP
     if (!status) {
         throw new Error('Status was undefined');
     }
+
+    const [currentEra, chainStatus] = await Promise.all([api.query.staking.currentEra(), getChainStatus(api)]);
+
     const table = new Table({
-        head: ['Status'],
+        head: [
+            `Active: ${chainStatus.eraInfo.era}; Current: ${currentEra}; Session: ${chainStatus.eraInfo.currentSession}`,
+            `Block: ${chainStatus.bestNumber}; Finalized: ${chainStatus.bestFinalizedNumber}`,
+        ],
     });
     table.push(['Bonded', status.bonded ? 'Yes' : 'No']);
     table.push(['Validating', status.validating ? 'Yes' : 'No']);

--- a/cli/src/lib/staking/validatorStatus.ts
+++ b/cli/src/lib/staking/validatorStatus.ts
@@ -99,11 +99,11 @@ export async function validatorStatusTable(status: Status | undefined, api: ApiP
         throw new Error('Status was undefined');
     }
 
-    const [currentEra, chainStatus] = await Promise.all([api.query.staking.currentEra(), getChainStatus(api)]);
+    const chainStatus = await getChainStatus(api);
 
     const table = new Table({
         head: [
-            `Active: ${chainStatus.eraInfo.era}; Current: ${currentEra}; Session: ${chainStatus.eraInfo.currentSession}`,
+            `Active: ${chainStatus.eraInfo.activeEra}; Current: ${chainStatus.eraInfo.currentEra}; Session: ${chainStatus.eraInfo.currentSession}`,
             `Block: ${chainStatus.bestNumber}; Finalized: ${chainStatus.bestFinalizedNumber}`,
         ],
     });

--- a/cli/src/test/integration-tests/status.test.ts
+++ b/cli/src/test/integration-tests/status.test.ts
@@ -1,4 +1,4 @@
-import { ALICE_NODE_URL, BOB_NODE_URL, randomTestAccount, CLIBuilder } from './helpers';
+import { ALICE_NODE_URL, randomTestAccount, CLIBuilder } from './helpers';
 import { newApi, ApiPromise } from '../../lib';
 
 describe('status', () => {
@@ -23,7 +23,7 @@ describe('status', () => {
 
     it('should error when required option is not specified', () => {
         try {
-            CLI('status --chain');
+            CLI('status');
         } catch (error: any) {
             expect(error.exitCode).toEqual(1);
             expect(error.stderr).toContain("error: required option '--substrate-address [address]' not specified");
@@ -31,35 +31,15 @@ describe('status', () => {
     }, 30_000);
 
     it('should display validator & chain status when both are requested', () => {
-        const result = CLI(`status --chain --substrate-address ${randomAccount.address} --url ${ALICE_NODE_URL}`);
+        const result = CLI(`status --substrate-address ${randomAccount.address} --url ${ALICE_NODE_URL}`);
 
         expect(result.exitCode).toEqual(0);
 
-        expect(result.stdout).toContain('Chain status:');
-        expect(result.stdout).toContain('Best Block');
-        expect(result.stdout).toContain('Best Finalized Block');
-        expect(result.stdout).toContain('Era');
-        expect(result.stdout).toContain('Session');
-
-        expect(result.stdout).toContain(`Validator ${randomAccount.address}:`);
-        expect(result.stdout).toContain('Bonded');
-        expect(result.stdout).toContain('Validating');
-        expect(result.stdout).toContain('Waiting');
-        expect(result.stdout).toContain('Active');
-        expect(result.stdout).toContain('Can withdraw');
-        expect(result.stdout).toContain('Next unlocking');
-    }, 30_000);
-
-    it('should display only validator status when --chain is not specified', () => {
-        const result = CLI(`status --substrate-address ${randomAccount.address} --url ${BOB_NODE_URL}`);
-
-        expect(result.exitCode).toEqual(0);
-
-        expect(result.stdout).not.toContain('Chain status:');
-        expect(result.stdout).not.toContain('Best Block');
-        expect(result.stdout).not.toContain('Best Finalized Block');
-        expect(result.stdout).not.toContain('Era');
-        expect(result.stdout).not.toContain('Session');
+        expect(result.stdout).toContain('Active:');
+        expect(result.stdout).toContain('Current:');
+        expect(result.stdout).toContain('Session:');
+        expect(result.stdout).toContain('Block:');
+        expect(result.stdout).toContain('Finalized:');
 
         expect(result.stdout).toContain(`Validator ${randomAccount.address}:`);
         expect(result.stdout).toContain('Bonded');


### PR DESCRIPTION
# Description of proposed changes

will display new information in header which can be useful for debugging:

```
$ node dist/cli.js status --substrate-address 5EEoJZYPpTYGX1t3shaQbqhRmqvdvoaTycY1gJ4TB8spDgPp
Validator 5EEoJZYPpTYGX1t3shaQbqhRmqvdvoaTycY1gJ4TB8spDgPp:
┌───────────────────────┬─────────────────────────────┐
│ Current Era: 21       │ Block: 592; Finalized: 590  │
├───────────────────────┼─────────────────────────────┤
│ Bonded                │ Yes                         │
├───────────────────────┼─────────────────────────────┤
│ Validating            │ No                          │
├───────────────────────┼─────────────────────────────┤
│ Waiting               │ No                          │
├───────────────────────┼─────────────────────────────┤
│ Active                │ No                          │
├───────────────────────┼─────────────────────────────┤
│ Can withdraw          │ Yes                         │
├───────────────────────┼─────────────────────────────┤
│ Unlocked since era 18 │ 1000.000000000000000000 CTC │
├───────────────────────┼─────────────────────────────┤
│ Next unlocking        │ None                        │
└───────────────────────┴─────────────────────────────┘
```




---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
