### PR TITLE
CSUB-1103: Do not force new eras during tests

### DIFF
--- a/cli/src/test/integration-tests/helpers.ts
+++ b/cli/src/test/integration-tests/helpers.ts
@@ -30,10 +30,7 @@ export async function fundAddressesFromSudo(addresses: string[], amount: BN, url
     return tx;
 }
 
-export async function waitEras(eras: number, api: ApiPromise, force = true) {
-    if (force) {
-        await forceNewEra(api);
-    }
+export async function waitEras(eras: number, api: ApiPromise) {
     let eraInfo = await api.derive.session.info();
     let currentEra = eraInfo.currentEra.toNumber();
     const targetEra = currentEra + eras;

--- a/cli/src/test/integration-tests/validatorCycle.test.ts
+++ b/cli/src/test/integration-tests/validatorCycle.test.ts
@@ -172,7 +172,7 @@ describeIf(
             // the unbonded amount and end up with more funds than the initial funding
             const unbondingPeriod: number = api.consts.staking.bondingDuration.toNumber();
             console.log('Unbonding period: ', unbondingPeriod);
-            await waitEras(unbondingPeriod + 1, api, true);
+            await waitEras(unbondingPeriod + 1, api);
 
             result = CLI('withdraw-unbonded');
             expect(result.exitCode).toEqual(0);

--- a/cli/src/test/integration-tests/validatorCycle.test.ts
+++ b/cli/src/test/integration-tests/validatorCycle.test.ts
@@ -75,8 +75,8 @@ describeIf(
             expect(result.exitCode).toEqual(0);
             expect(result.stdout).toContain('Transaction included at block');
 
-            // wait 5 seconds for nodes to sync
-            await sleep(5000);
+            // wait 2 seconds for nodes to sync
+            await sleep(2000);
             const stashStatus = await getValidatorStatus(caller.address, api);
             expect(stashStatus?.bonded).toBe(true);
 
@@ -95,8 +95,8 @@ describeIf(
             expect(result.exitCode).toEqual(0);
             expect(result.stdout).toContain('Transaction included at block');
 
-            // wait 5 seconds for nodes to sync
-            await sleep(5000);
+            // wait 2 seconds for nodes to sync
+            await sleep(2000);
             const validatorSessionKeys = await api.query.session.nextKeys(caller.address);
             expect(validatorSessionKeys.toHex()).toBe(newKeys);
             const bobApi = (await newApi(BOB_NODE_URL)).api;
@@ -131,8 +131,8 @@ describeIf(
             expect(result.exitCode).toEqual(0);
             expect(result.stdout).toContain('Transaction included at block');
 
-            // wait 5 seconds for nodes to sync
-            await sleep(5000);
+            // wait 2 seconds for nodes to sync
+            await sleep(2000);
             const balanceAfterRewards = await getBalance(caller.address, api);
             console.log(balanceAfterRewards.bonded.toString());
             const balanceIncreased = balanceAfterRewards.bonded.gt(balanceBeforeRewards.bonded);
@@ -157,8 +157,8 @@ describeIf(
             expect(result.exitCode).toEqual(0);
             expect(result.stdout).toContain('Transaction included at block');
 
-            // wait 5 seconds for nodes to sync
-            await sleep(5000);
+            // wait 2 seconds for nodes to sync
+            await sleep(2000);
             const balanceAfterUnbonding = await getBalance(caller.address, api);
             const isUnbonding = balanceAfterUnbonding.unbonding.gt(new BN(0));
             printBalance(balanceAfterRewards);
@@ -177,8 +177,8 @@ describeIf(
             expect(result.exitCode).toEqual(0);
             expect(result.stdout).toContain('Transaction included at block');
 
-            // wait 5 seconds for nodes to sync
-            await sleep(5000);
+            // wait 2 seconds for nodes to sync
+            await sleep(2000);
             const balanceAfterWithdraw = await getBalance(caller.address, api);
             printBalance(balanceAfterWithdraw);
             const stashAmount = parseAmount('10000');

--- a/cli/src/test/integration-tests/validatorCycle.test.ts
+++ b/cli/src/test/integration-tests/validatorCycle.test.ts
@@ -172,7 +172,7 @@ describeIf(
             // the unbonded amount and end up with more funds than the initial funding
             const unbondingPeriod: number = api.consts.staking.bondingDuration.toNumber();
             console.log('Unbonding period: ', unbondingPeriod);
-            await waitEras(unbondingPeriod + 1, api);
+            await waitEras(unbondingPeriod, api);
 
             result = CLI('withdraw-unbonded');
             expect(result.exitCode).toEqual(0);

--- a/cli/src/test/integration-tests/validatorCycle.test.ts
+++ b/cli/src/test/integration-tests/validatorCycle.test.ts
@@ -37,7 +37,8 @@ describeIf(
 
             // Create a reference to sudo for funding accounts
             sudoSigner = initAliceKeyring();
-        });
+            await increaseValidatorCount(api, sudoSigner);
+        }, 20_000);
 
         beforeEach(async () => {
             const stashSecret = CLIBuilder({})('new').stdout.split('Seed phrase: ')[1];
@@ -111,9 +112,7 @@ describeIf(
             const stashStatusAfterValidating = await getValidatorStatus(caller.address, api);
             expect(stashStatusAfterValidating?.waiting).toBe(true);
 
-            // After increasing the validator count, (forcing an era- currently not) and waiting for the next era,
-            // the validator should become elected & active.
-            await increaseValidatorCount(api, initAliceKeyring(), 2);
+            // wait for the next era, the validator should become elected & active.
             await waitEras(2, api);
             const stashStatusAfterEra = await getValidatorStatus(caller.address, api);
             expect(stashStatusAfterEra?.active).toBe(true);

--- a/cli/src/test/integration-tests/withdraw-unbonded.test.ts
+++ b/cli/src/test/integration-tests/withdraw-unbonded.test.ts
@@ -78,7 +78,7 @@ describe('withdraw-unbonded', () => {
 
             // wait for funds to become unlocked
             const unbondingPeriod: number = api.consts.staking.bondingDuration.toNumber();
-            await waitEras(unbondingPeriod, api, true);
+            await waitEras(unbondingPeriod, api);
 
             // configure proxy
             proxy = await randomFundedAccount(api, sudoSigner);
@@ -178,7 +178,7 @@ describe('withdraw-unbonded', () => {
 
             // wait for funds to become unlocked
             const unbondingPeriod: number = api.consts.staking.bondingDuration.toNumber();
-            await waitEras(unbondingPeriod, api, true);
+            await waitEras(unbondingPeriod, api);
 
             // configure proxy
             proxy = await randomFundedAccount(api, sudoSigner);


### PR DESCRIPTION
when calling waitEras() during the integration tests we shouldn't be forcing new eras by default because this is not what the standard chain behvior is.

For the situation where we know what we're doing and really want to force a new era there is the function `forceNewEra()` which the scenario should be calling directly!

# Description of proposed changes

<describe what this PR is about and why we want it>

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
