### PR TITLE
CSUB-1071: dry-run install subwasm and then update it

### DIFF
--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -374,7 +374,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --locked --git https://github.com/chevdor/subwasm --tag v0.17.1
+          args: --locked --git https://github.com/chevdor/subwasm --tag v0.19.0
 
       - name: Download WASM runtime from current PR
         id: download-wasm
@@ -498,7 +498,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --locked --git https://github.com/chevdor/subwasm --tag v0.17.1
+          args: --locked --git https://github.com/chevdor/subwasm --tag v0.19.0
 
       - name: Download WASM runtime
         id: download-wasm

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -77,6 +77,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure rustc version
+        run: |
+          RUSTC_VERSION=$(grep channel rust-toolchain.toml | tail -n1 | tr -d " " | cut -f2 -d'"')
+          echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUSTC_VERSION }}
+          profile: minimal
+          override: true
+
       - name: Install Subwasm
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --locked --git https://github.com/chevdor/subwasm --tag v0.17.1
+          args: --locked --git https://github.com/chevdor/subwasm --tag v0.19.0
 
   upgrade-devnet:
     runs-on: ubuntu-22.04
@@ -93,7 +93,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --locked --git https://github.com/chevdor/subwasm --tag v0.17.1
+          args: --locked --git https://github.com/chevdor/subwasm --tag v0.19.0
 
       - name: Install JS Dependencies
         uses: actions/setup-node@v4

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -45,16 +45,37 @@ jobs:
             ${{ steps.srtool_build.outputs.wasm_compressed }}
             creditcoin-srtool-digest.json
 
+  # try installing subwasm b/c we use this version in multiple places
+  # and need to know whether it builds with current rustc
+  dry-run-install-subwasm:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure rustc version
+        run: |
+          RUSTC_VERSION=$(grep channel rust-toolchain.toml | tail -n1 | tr -d " " | cut -f2 -d'"')
+          echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUSTC_VERSION }}
+          profile: minimal
+          override: true
+
+      - name: Install Subwasm
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --locked --git https://github.com/chevdor/subwasm --tag v0.17.1
+
   upgrade-devnet:
     runs-on: ubuntu-22.04
     needs: build
     if: github.ref == 'refs/heads/dev'
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: creditcoin-runtime-${{ github.sha }}
-          path: wasm
 
       - name: Install Subwasm
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
# Description of proposed changes

currently we've pinned the version to 0.17.1 which fails to build with rustc 1.77.0:
https://github.com/gluwa/creditcoin3/actions/runs/8832658427/job/24251068397

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
