### PR TITLE
CSUB-1132: Configure runner name explicitly, do not rely on hostname

### DIFF
--- a/.github/provision-github-runner.sh
+++ b/.github/provision-github-runner.sh
@@ -23,5 +23,6 @@ REGISTRATION_TOKEN=$(curl --silent -X POST \
 # Important: ephemeral runners are removed after a single job is executed on them
 # which is inline with the VM lifecycle
 ./config.sh --unattended --ephemeral "$EPHEMERAL" --url "$REPOSITORY_URL" --token "$REGISTRATION_TOKEN" \
+    --name "$LC_RUNNER_VM_NAME" \
     --labels "$LC_RUNNER_VM_NAME,workflow-$LC_WORKFLOW_ID,proxy-$LC_PROXY_ENABLED,secret-$LC_PROXY_SECRET_VARIANT,type-$LC_PROXY_TYPE"
 nohup ./run.sh >/dev/null 2>&1 </dev/null &


### PR DESCRIPTION
# Description of proposed changes

because in some environments hostname isn't configured automatically and defaults to `localhost`, which causes GitHub runner provisioning to fail when you have more than one runner.

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
