### PR TITLE
Testing: When precompiles/ changes ask for mandatory version bump!

### DIFF
--- a/.github/check-version.sh
+++ b/.github/check-version.sh
@@ -61,6 +61,12 @@ else
         echo "INFO: Cargo.lock references to dependencies via GitHub have been modified"
         check_version "${FROM}" "${TO}"
     else
-        greenprint "INFO: Cargo.lock references to Substrate did not change"
+        greenprint "INFO: Cargo.lock references to Substrate did not change. Will inspect precompiles/"
+        if git --no-pager diff --name-only "${FROM}"..."${TO}" | grep -e '^precompiles/'; then
+            greenprint "INFO: precompiles/ has been modified"
+            check_version "${FROM}" "${TO}"
+        else
+            greenprint "INFO: precompiles/ did not change."
+        fi
     fi
 fi


### PR DESCRIPTION
# Description of proposed changes

Require a mandatory version bump when we change anything in `precompiles/`, similar to `runtime/`. 

Detecting a change -> https://github.com/gluwa/creditcoin3/actions/runs/9403560833/job/25900388284?pr=387
(#387 this is a copy of #385 + the current commit).


---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
