### PR TITLE
CSUB-1180: Remove Windows and MacOS binary artifacts build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ubuntu-24.04, windows-2022, macos-11]
+        operating-system: [ubuntu-24.04]
     runs-on: ${{ matrix.operating-system }}
 
     steps:
@@ -84,15 +84,6 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Install MacOS aarch64 target
-        if: matrix.operating-system == 'macos-11'
-        uses: gluwa/toolchain@dev
-        with:
-          toolchain: ${{ env.RUSTC_VERSION }}
-          target: aarch64-apple-darwin
-          profile: minimal
-          override: true
-
       - uses: Swatinem/rust-cache@v2
 
       - name: Figure out platform
@@ -113,13 +104,6 @@ jobs:
           command: build
           args: --release ${{ needs.setup.outputs.build_options}}
 
-      - name: Build MacOS aarch64 target
-        if: matrix.operating-system == 'macos-11'
-        uses: gluwa/cargo@dev
-        with:
-          command: build
-          args: --release --target aarch64-apple-darwin
-
       - name: Compress
         continue-on-error: true
         uses: thedoctor0/zip-release@0.7.6
@@ -130,18 +114,7 @@ jobs:
           filename: "../../creditcoin-${{ needs.sanity-check.outputs.TAG_NAME  }}-${{ env.PLATFORM }}.zip"
           exclusions: "creditcoin3-node.d"
 
-      - name: Compress MacOS aarch64 target
-        if: matrix.operating-system == 'macos-11'
-        uses: thedoctor0/zip-release@0.7.6
-        with:
-          type: "zip"
-          directory: "target/aarch64-apple-darwin/release/"
-          path: "creditcoin3-node*"
-          filename: "../../../creditcoin-${{ needs.sanity-check.outputs.TAG_NAME  }}-aarch64-apple-darwin.zip"
-          exclusions: "creditcoin3-node.d"
-
       - name: Upload binary
-        if: matrix.operating-system != 'windows-2022'
         uses: actions/upload-artifact@v4
         with:
           name: binary-for-${{ matrix.operating-system }}


### PR DESCRIPTION
- Windows isn't supported at all
- Latest MacOS build failed in https://github.com/gluwa/creditcoin3/actions/runs/9548663425:

> build-native-runtime (macos-11)
> GitHub Actions has encountered an internal error when running your job.

without any more information so remove these in order not to break the release process.

These binary artifacts aren't officially supported anyway.





# Description of proposed changes

<describe what this PR is about and why we want it>

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
