### PR TITLE
CSUB-1180: Add continue-on-error flags for 2 more steps in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
 
       - name: Build MacOS aarch64 target
         if: matrix.operating-system == 'macos-11'
+        continue-on-error: true
         uses: gluwa/cargo@dev
         with:
           command: build
@@ -132,6 +133,7 @@ jobs:
 
       - name: Compress MacOS aarch64 target
         if: matrix.operating-system == 'macos-11'
+        continue-on-error: true
         uses: thedoctor0/zip-release@0.7.6
         with:
           type: "zip"


### PR DESCRIPTION
these are conditionally executed on macos (cross arch builds) and I've missed them the first time around.

# Description of proposed changes

<describe what this PR is about and why we want it>

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
