### PR TITLE
CSUB-1273: Enable PR groupping for github-actions & docker updates too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 5
     rebase-strategy: "disabled"
+    groups:
+      all-dependencies:
+        applies-to: version-updates
 
   # Maintain dependencies for Docker images
   - package-ecosystem: "docker"
@@ -16,6 +19,9 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 5
     rebase-strategy: "disabled"
+    groups:
+      all-dependencies:
+        applies-to: version-updates
 
   # Maintain dependencies for Rust
   # Note: Dependabot can't recursively search directories at the moment


### PR DESCRIPTION
As soon as PR #464 was metged it triggered Dependabot to scan for new updates which opened
https://github.com/gluwa/creditcoin3/pull/465 and https://github.com/gluwa/creditcoin3/pull/466.

We can do better and group github-actions and docker updates too. 