### PR TITLE
fix: frontier backend no locks available fix.

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -241,11 +241,12 @@ pub fn run() -> sc_cli::Result<()> {
             runner.sync_run(|mut config| {
                 let (client, _, _, _, frontier_backend) =
                     service::new_chain_ops(&mut config, &cli.eth)?;
-                let frontier_backend = match frontier_backend {
+                let binding = frontier_backend.clone();
+                let frontier_backend = match &*binding {
                     fc_db::Backend::KeyValue(kv) => kv,
                     _ => panic!("Only fc_db::Backend::KeyValue supported"),
                 };
-                cmd.run(client, frontier_backend)
+                cmd.run(client, frontier_backend.clone())
             })
         }
         None => {

--- a/node/src/eth.rs
+++ b/node/src/eth.rs
@@ -153,7 +153,7 @@ pub async fn spawn_frontier_tasks<RuntimeApi, Executor>(
     task_manager: &TaskManager,
     client: Arc<FullClient<RuntimeApi, Executor>>,
     backend: Arc<FullBackend>,
-    frontier_backend: fc_db::Backend<Block, FullClient<RuntimeApi, Executor>>,
+    frontier_backend: Arc<fc_db::Backend<Block, FullClient<RuntimeApi, Executor>>>,
     filter_pool: Option<FilterPool>,
     // overrides: Arc<OverrideHandle<Block>>,
     overrides: Arc<dyn StorageOverride<Block>>,
@@ -172,7 +172,7 @@ pub async fn spawn_frontier_tasks<RuntimeApi, Executor>(
     Executor: NativeExecutionDispatch + 'static,
 {
     // Spawn main mapping sync worker background task.
-    match frontier_backend {
+    match &*frontier_backend {
         fc_db::Backend::KeyValue(b) => {
             task_manager.spawn_essential_handle().spawn(
                 "frontier-mapping-sync-worker",


### PR DESCRIPTION
# Description of proposed changes

It is important to use Arc for frontier back end and have only one instance. in other case chain will not start with an error `No locks available`
https://substrate.stackexchange.com/questions/8761/other-io-error-lock-hold-by-current-process-acquire-time-1685847508-acquiring 

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
