### PR TITLE
CSUB-1322: Include repository name as part of self-hosted runner hostname

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 permissions: read-all
 
 env:
-  RUNNER_VM_NAME: "gh-runner-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT"
+  RUNNER_VM_NAME: "${{ github.event.repository.name }}-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT"
   LINODE_REGION: "nl-ams"
   # Shared CPU, Linode 8 GB, 4 vCPU, 96 $/mo
   LINODE_VM_SIZE: "g6-standard-4"

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -8,8 +8,8 @@ on:
 permissions: read-all
 
 env:
-  RUNNER_VM_NAME: "github-runner-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT"
-  RESOURCE_GROUP: "github-runner-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT"
+  RUNNER_VM_NAME: "${{ github.event.repository.name }}-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT"
+  RESOURCE_GROUP: "${{ github.event.repository.name }}-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT"
   AZ_LOCATION: "westus3"
 
 jobs:


### PR DESCRIPTION
# Description of proposed changes

Include the repository name as part of the self-hosted runner VM hostname, to make it easier to connect VM -> repository -> workflow:

Old names at top of image, new names below:
![image](https://github.com/user-attachments/assets/4bcd7ec6-9ff0-4e22-a2e2-dfea99e4af23)


NOTE: the reported MegaLinter failure is unrelated, see https://github.com/gluwa/creditcoin3/pull/483#discussion_r1796700865

NOTE: provisioning & running on Azure using the new naming scheme appears to be working as well, see:
https://github.com/gluwa/creditcoin3/actions/runs/11290155122/job/31401798798?pr=509

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
