### PR TITLE
fix: update runtime's polynomial fn to adjust formula of WeightToFeeCoef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-cli-opt"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "bip32",
  "clap",
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-client-evm-tracing"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "creditcoin3-rpc-primitives-debug",
  "ethereum-types",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-evm-tracer"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "creditcoin3-primitives-ext",
  "ethereum-types",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-node"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-primitives-ext"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "ethereum-types",
  "evm-tracing-events",
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-rpc-core-debug"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "creditcoin3-client-evm-tracing",
  "creditcoin3-rpc-core-types",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-rpc-core-trace"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "creditcoin3-client-evm-tracing",
  "creditcoin3-rpc-core-types",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-rpc-core-types"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "ethereum-types",
  "serde",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-rpc-debug"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "creditcoin3-client-evm-tracing",
  "creditcoin3-rpc-core-debug",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-rpc-primitives-debug"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "environmental",
  "ethereum",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-rpc-trace"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "creditcoin3-client-evm-tracing",
  "creditcoin3-rpc-core-trace",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-runtime"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "creditcoin3-evm-tracer",
  "creditcoin3-rpc-primitives-debug",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "evm-tracing-events"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "environmental",
  "ethereum",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "generate-bags"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "clap",
  "creditcoin3-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.37.0"
+version = "3.38.0"
 authors = ["Gluwa Inc. Developer Support <support.dev@gluwa.com>"]
 edition = "2021"
 license = "Unlicense"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -335,7 +335,6 @@ parameter_types! {
         Weight::from_parts(WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000), 0);
 }
 
-pub const TARGET_FEE_CREDO: Balance = 10_000_000_000_000_000;
 pub struct WeightToCtcFee<T>(PhantomData<T>);
 
 impl<T: frame_system::Config> WeightToFeePolynomial for WeightToCtcFee<T> {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -43,7 +43,8 @@ use frame_support::{
         OnTimestampSet,
     },
     weights::{
-        constants::WEIGHT_REF_TIME_PER_MILLIS, constants::WEIGHT_REF_TIME_PER_NANOS, ConstantMultiplier, Weight, WeightToFeeCoefficient,
+        constants::WEIGHT_REF_TIME_PER_MILLIS, constants::WEIGHT_REF_TIME_PER_NANOS,
+        ConstantMultiplier, Weight, WeightToFeeCoefficient,
     },
     PalletId,
 };
@@ -342,13 +343,13 @@ impl<T: frame_system::Config> WeightToFeePolynomial for WeightToCtcFee<T> {
 
     fn polynomial() -> frame_support::weights::WeightToFeeCoefficients<Self::Balance> {
         let p = MILLI_CTC / 2;
-		let q = 100 * Balance::from(ExtrinsicBaseWeight::get().ref_time());
-		smallvec::smallvec![WeightToFeeCoefficient {
-			degree: 1,
-			negative: false,
-			coeff_frac: Perbill::from_rational(p % q, q),
-			coeff_integer: p / q,
-		}]
+        let q = 100 * Balance::from(ExtrinsicBaseWeight::get().ref_time());
+        smallvec::smallvec![WeightToFeeCoefficient {
+            degree: 1,
+            negative: false,
+            coeff_frac: Perbill::from_rational(p % q, q),
+            coeff_integer: p / q,
+        }]
     }
 }
 
@@ -531,7 +532,6 @@ impl pallet_staking::BenchmarkingConfig for StakingBenchmarkingConfig {
 }
 
 pub const CTC: Balance = 1_000_000_000_000_000_000;
-
 
 const CTC_REWARD_PER_BLOCK: Balance = 2 * CTC;
 

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -7,7 +7,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("creditcoin3"),
     impl_name: create_runtime_str!("creditcoin3"),
     authoring_version: 3,
-    spec_version: 37,
+    spec_version: 38,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,


### PR DESCRIPTION
# Description of proposed changes

update runtime's polynomial fn to adjust formula of  WeightToFeeCoef to make tx fees on cc3 the same as it is on cc2.

with a new updated formula the fees on cc3 and cc2 are:
```
transfers tx: 9.8mili vs 11.35mili
staking payout_stakers: 10.27mili vs 11.38mili
```

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
