### PR TITLE
CSUB-1374: Tell gitleaks to scan only commits in the current PR

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -42,6 +42,10 @@ jobs:
           # All available variables are described at https://megalinter.io/latest/configuration/
           # and configured in .mega-linter.yml
           VALIDATE_ALL_CODEBASE: true
+          # tells gitleaks to scan only commits in the current PR without setting VALIDATE_ALL_CODEBASE==false
+          # which has other side effects. See https://github.com/oxsecurity/megalinter/issues/2487 and
+          # https://megalinter.io/8.2.0/descriptors/repository_gitleaks/
+          REPOSITORY_GITLEAKS_ARGUMENTS: --log-opts '--no-merges --first-parent ${{ github.event.pull_request.base.sha }}^..${{ github.event.pull_request.head.sha }}'
           JSON_JSONLINT_FILTER_REGEX_EXCLUDE: (chainspecs/dryRun*)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
# Description of proposed changes

<describe what this PR is about and why we want it>

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
