### PR TITLE
Filter out extra line when searching for release origin branch

### DIFF
--- a/.github/check-tag-suffix-vs-origin-branch.sh
+++ b/.github/check-tag-suffix-vs-origin-branch.sh
@@ -11,7 +11,7 @@ echo "----- DEBUG -----"
 git branch -a --contains | grep remotes/origin
 echo "----- END -----"
 
-NEAREST_GIT_BRANCH=$(git branch -a --contains | grep remotes/origin | cut -f3 -d/)
+NEAREST_GIT_BRANCH=$(git branch -a --contains | grep -v remotes/origin/HEAD | grep remotes/origin | cut -f3 -d/)
 
 echo "INFO: git tag: '$GIT_TAG'"
 echo "INFO: suffix from git tag: '$SUFFIX_FROM_GIT_TAG'"


### PR DESCRIPTION
lately, but not always, the output of `git branch -a --contains` started to include one extra line:

```
  remotes/origin/HEAD -> origin/dev
  remotes/origin/dev
```

The `remotes/origin/HEAD -> origin/dev` is what breaks the sanity check script b/c this is something new, that git has started to report in its output. For example broke here:
https://github.com/gluwa/creditcoin3/actions/runs/12985577903/job/36210711957

but not here:
https://github.com/gluwa/creditcoin3/actions/runs/12914730298/job/36014957248

# Description of proposed changes

<describe what this PR is about and why we want it>

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
