### PR TITLE
Force rustup to install missing toolchain b/c it broke all of our builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,11 +289,9 @@ jobs:
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          profile: minimal
-          override: true
           components: rustfmt
 
       - name: Check formatting
@@ -321,13 +319,11 @@ jobs:
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
-          components: clippy
+          targets: wasm32-unknown-unknown
+          components: clippy, rust-src
       - uses: Swatinem/rust-cache@v2
 
       - name: Run Clippy
@@ -358,12 +354,10 @@ jobs:
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
+          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
 
       - name: Check Build
@@ -392,12 +386,11 @@ jobs:
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
+          targets: wasm32-unknown-unknown
+          components: rust-src
       - uses: Swatinem/rust-cache@v2
 
       - name: Run tests
@@ -434,12 +427,11 @@ jobs:
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
+          targets: wasm32-unknown-unknown
+          components: rust-src
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: build-creditcoin-node
@@ -498,12 +490,11 @@ jobs:
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
+          targets: wasm32-unknown-unknown
+          components: rust-src
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: build-creditcoin-node
@@ -1072,12 +1063,10 @@ jobs:
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
+          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
 
       - name: Install cargo audit

--- a/.github/workflows/llvm-cov.yml
+++ b/.github/workflows/llvm-cov.yml
@@ -33,13 +33,11 @@ jobs:
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          components: llvm-tools-preview
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
+          components: llvm-tools-preview, rust-src
+          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-llvm-cov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,12 +80,11 @@ jobs:
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
+          targets: wasm32-unknown-unknown
+          components: rust-src
 
       - name: Install MacOS aarch64 target
         if: matrix.operating-system == 'macos-13'

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -124,12 +124,11 @@ jobs:
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
+          targets: wasm32-unknown-unknown
+          components: rust-src
       - uses: Swatinem/rust-cache@v2
 
       - name: Build SUT
@@ -404,11 +403,9 @@ jobs:
           sudo apt install -y gcc
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          profile: minimal
-          override: true
 
       - name: Install Subwasm
         uses: gluwa/cargo@dev
@@ -534,11 +531,9 @@ jobs:
           sudo apt install -y gcc
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          profile: minimal
-          override: true
 
       - name: Install Subwasm
         uses: gluwa/cargo@dev

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -62,11 +62,9 @@ jobs:
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          profile: minimal
-          override: true
 
       - name: Install Subwasm
         uses: gluwa/cargo@dev
@@ -93,11 +91,9 @@ jobs:
           echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: gluwa/toolchain@dev
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
-          profile: minimal
-          override: true
 
       - name: Install Subwasm
         uses: gluwa/cargo@dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | /bin/sh -s -- -y
 COPY --chown=creditcoin:creditcoin . /creditcoin-node/
 # shellcheck source=/dev/null
 RUN source ~/.cargo/env && \
+    rustup toolchain install && \
     cargo build --release ${BUILD_ARGS}
 
 


### PR DESCRIPTION
From its changelog:
https://github.com/rust-lang/rustup/blob/master/CHANGELOG.md#1280---2025-03-04

> rustup will no longer automatically install the active toolchain if it is not installed. pr#3985
> To ensure its installation, run rustup toolchain install with no arguments.

# Description of proposed changes

<describe what this PR is about and why we want it>

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
