### PR TITLE
Execute chain-snapshots testing only on Monday & Thursday

### DIFF
--- a/.github/workflows/check-chain-snapshots.yml
+++ b/.github/workflows/check-chain-snapshots.yml
@@ -242,7 +242,7 @@ jobs:
             --prometheus-external --pruning archive \
             --telemetry-url "wss://telemetry.creditcoin.network/submit/ 0" \
             --public-addr "/dns4/$IP_ADDRESS/tcp/50555" \
-            --base-path /mnt/data \
+            --base-path /mnt \
             --port 50555 >creditcoin3-node-${{ env.target_chain }}.log 2>&1 &
 
       - name: Wait for creditcoin3-node to sync past block number ${{ env.last_block_number }}

--- a/.github/workflows/check-chain-snapshots.yml
+++ b/.github/workflows/check-chain-snapshots.yml
@@ -3,8 +3,8 @@ name: Check Chain Snapshots
 
 on:
   schedule:
-    # every morning at 6am, UTC time I belive
-    - cron: "0 6 * * *"
+    # every morning at 6am, Mon & Thu
+    - cron: "0 6 * * 1,4"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -210,7 +210,7 @@ jobs:
             --bootnodes "${{ needs.setup.outputs.boot_node }}" \
             --prometheus-external \
             --telemetry-url "wss://telemetry.creditcoin.network/submit/ 0" \
-            --base-path /mnt/data \
+            --base-path /mnt \
             --public-addr "/dns4/$IP_ADDRESS/tcp/50555" \
             --port 50555 >creditcoin3-node-used-for-fork.log 2>&1 &
 
@@ -317,7 +317,7 @@ jobs:
             --prometheus-external --pruning archive \
             --telemetry-url "wss://telemetry.creditcoin.network/submit/ 0" \
             --public-addr "/dns4/$IP_ADDRESS/tcp/50555" \
-            --base-path /mnt/data \
+            --base-path /mnt \
             --port 50555 >creditcoin3-node-initial-live-sync.log 2>&1 &
 
       - name: Wait for creditcoin3-node to sync past block number ${{ needs.setup.outputs.last_block_number }}
@@ -502,7 +502,7 @@ jobs:
             --validator --pruning archive \
             --prometheus-external \
             --telemetry-url "wss://telemetry.creditcoin.network/submit/ 0" \
-            --base-path /mnt/data >creditcoin3-node-disconnected-live-node.log 2>&1 &
+            --base-path /mnt >creditcoin3-node-disconnected-live-node.log 2>&1 &
 
       - name: Wait for blockchain to start
         run: |


### PR DESCRIPTION
b/c devops will be making new snapshots every 3 days so there's no need to execute this consistently every day

