### PR TITLE
Disable @gluwa/evm-network-test execution until SMC-1036 is resolved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,6 +529,8 @@ jobs:
           path: target/release/wbuild/creditcoin3-runtime/creditcoin_next_runtime.compact.compressed.wasm
 
   integration-test-smart-contract:
+    # skipped until SMC-1036 is resolved
+    if: false
     needs:
       - build-creditcoin-node-for-testing
     runs-on: ubuntu-24.04

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -448,6 +448,8 @@ jobs:
           echo "private_key=$EVM_PRIVATE_KEY" >> "$GITHUB_OUTPUT"
 
       - name: Execute smart contract test tool
+        # skipped until SMC-1036 is resolved
+        if: false
         working-directory: ./testing
         run: |
           ./evm-network-test.sh ${{ steps.test-env.outputs.url }} ${{ steps.test-env.outputs.private_key }}
@@ -585,6 +587,8 @@ jobs:
           echo "private_key=$EVM_PRIVATE_KEY" >> "$GITHUB_OUTPUT"
 
       - name: Execute smart contract test tool
+        # skipped until SMC-1036 is resolved
+        if: false
         working-directory: ./testing
         run: |
           ./evm-network-test.sh ${{ steps.test-env.outputs.url }} ${{ steps.test-env.outputs.private_key }}


### PR DESCRIPTION
a previous effort to fix some issues and bump the version was attempted in https://github.com/gluwa/creditcoin3/pull/556 however the original issue wasn't solved.

Disabling these tests because they are always failing with false positives!

# Description of proposed changes

<describe what this PR is about and why we want it>

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
