### PR TITLE
CSUB-1734: Drop MacOS and Windows release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,7 @@ jobs:
     needs:
       - sanity-check
       - setup
-    strategy:
-      fail-fast: false
-      matrix:
-        operating-system: [ubuntu-24.04, windows-2022, macos-13]
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -86,15 +82,6 @@ jobs:
           targets: wasm32-unknown-unknown
           components: rust-src
 
-      - name: Install MacOS aarch64 target
-        if: matrix.operating-system == 'macos-13'
-        uses: gluwa/toolchain@dev
-        with:
-          toolchain: ${{ env.RUSTC_VERSION }}
-          target: aarch64-apple-darwin
-          profile: minimal
-          override: true
-
       - uses: Swatinem/rust-cache@v2
 
       - name: Figure out platform
@@ -115,14 +102,6 @@ jobs:
           command: build
           args: --release --features metadata-hash ${{ needs.setup.outputs.build_options}}
 
-      - name: Build MacOS aarch64 target
-        if: matrix.operating-system == 'macos-13'
-        continue-on-error: true
-        uses: gluwa/cargo@dev
-        with:
-          command: build
-          args: --release --features metadata-hash --target aarch64-apple-darwin
-
       - name: Compress
         continue-on-error: true
         uses: thedoctor0/zip-release@0.7.6
@@ -133,22 +112,10 @@ jobs:
           filename: "../../creditcoin-${{ needs.sanity-check.outputs.TAG_NAME  }}-${{ env.PLATFORM }}.zip"
           exclusions: "creditcoin3-node.d"
 
-      - name: Compress MacOS aarch64 target
-        if: matrix.operating-system == 'macos-13'
-        continue-on-error: true
-        uses: thedoctor0/zip-release@0.7.6
-        with:
-          type: "zip"
-          directory: "target/aarch64-apple-darwin/release/"
-          path: "creditcoin3-node*"
-          filename: "../../../creditcoin-${{ needs.sanity-check.outputs.TAG_NAME  }}-aarch64-apple-darwin.zip"
-          exclusions: "creditcoin3-node.d"
-
       - name: Upload binary
-        if: matrix.operating-system != 'windows-2022'
         uses: actions/upload-artifact@v4
         with:
-          name: binary-for-${{ matrix.operating-system }}
+          name: binary-for-linux
           path: "creditcoin-${{ needs.sanity-check.outputs.TAG_NAME  }}-*.zip"
           if-no-files-found: warn
 


### PR DESCRIPTION
because they are unnecessary

- Windows is unsupported anyway, see https://github.com/gluwa/creditcoin/security/advisories/GHSA-cx5c-xwcv-vhmq
- There is no official statement for MacOS native, however Cairo doesn't work on anything but Linux x86_64 and MacOS users will not be able to transition from Creditcoin3 to Creditcoin Next. So dropping the builds b/c sooner or later we will have to do so.

This change also simplifies the release workflow and makes it easier to unify with the build workflows exercised on pull requests as a follow-up step.