### PR TITLE
CSUB-1734: Share locally built docker image between CI jobs

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -23,8 +23,20 @@ jobs:
 
       - name: Build docker image
         run: |
-          docker build -t gluwa/creditcoin3:${{ inputs.version-string }} --build-arg="${{ inputs.build-options }}" .
+          docker build -t ${{ github.repository }}:${{ inputs.version-string }} --build-arg="${{ inputs.build-options }}" .
           docker images
+
+      - name: Export docker image into a file
+        run: |
+          mkdir -p "${{ runner.temp }}/gluwa/"
+          docker image save ${{ github.repository }}:${{ inputs.version-string }} > ${{ runner.temp }}/${{ github.repository }}.tar
+
+      - name: Upload exported image for use by other CI jobs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: locally-built-docker-image
+          path: ${{ runner.temp }}/${{ github.repository }}.tar
 
       - name: Push docker image
         # executes only when credentials are specified in the caller workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,17 @@ jobs:
       - docker-build
     runs-on: ubuntu-24.04
     steps:
+      - name: Download locally built docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: locally-built-docker-image
+          path: ${{ runner.temp }}/gluwa/
+
+      - name: Load locally built docker image
+        run: |
+          docker load --input ${{ runner.temp }}/${{ github.repository }}.tar
+          docker images
+
       - uses: actions/checkout@v4
         with:
           lfs: true


### PR DESCRIPTION
Otherwise the docker-test job will pull the image from the Internet and not exercise the image which was built from the pull request!

# Description of proposed changes

<describe what this PR is about and why we want it>

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
