### PR TITLE
Csub 1743: Update staking maxExposurePageSize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,14 +1345,14 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-cli-opt"
-version = "3.51.0"
+version = "3.52.0"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "creditcoin3-node"
-version = "3.51.0"
+version = "3.52.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-runtime"
-version = "3.51.0"
+version = "3.52.0"
 dependencies = [
  "ethereum",
  "evm-tracing-events",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "generate-bags"
-version = "3.51.0"
+version = "3.52.0"
 dependencies = [
  "clap",
  "creditcoin3-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.51.0"
+version = "3.52.0"
 authors = ["Gluwa Inc. Developer Support <support.dev@gluwa.com>"]
 edition = "2021"
 license = "Unlicense"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -462,7 +462,7 @@ impl pallet_dynamic_fee::Config for Runtime {
 parameter_types! {
     pub DefaultBaseFeePerGas: U256 = U256::from(1_000_000_000);
     pub DefaultElasticity: Permill = Permill::from_parts(125_000);
-    pub const MaxExposurePageSize: u32 = 64;
+    pub const MaxExposurePageSize: u32 = 512;
     pub const MaxControllersInDeprecationBatch: u32 = 751;
 }
 

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -7,7 +7,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("creditcoin3"),
     impl_name: create_runtime_str!("creditcoin3"),
     authoring_version: 3,
-    spec_version: 51,
+    spec_version: 52,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,


### PR DESCRIPTION
# Description of proposed changes

<describe what this PR is about and why we want it>

Updating `staking.MaxExposurePageSize` from 64 to 512. The variable had a different name before and its value was 512. its still 512 on mainnet. on dev and testnet this is causing us the issue of not seeing more than 64 nominators on staking tab

---


Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
