### PR TITLE
CSUB-1715: Bump Linode VM b/c creditcoin-fork runs OOM

### DIFF
--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -10,8 +10,8 @@ permissions: read-all
 env:
   RUNNER_VM_NAME: "${{ github.event.repository.name }}-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT"
   LINODE_REGION: "us-ord"
-  # Shared CPU, Linode 32 GB, 8 vCPU, disk: 640 GB, 0.288 $/hr
-  LINODE_VM_SIZE: "g6-standard-8"
+  # Shared CPU, Linode 64 GB, 16 vCPU, disk: 1280 GB, 0.576 $/hr
+  LINODE_VM_SIZE: "g6-standard-16"
 
 jobs:
   setup:


### PR DESCRIPTION
# Description of proposed changes

Resolves an OOM issue, see
https://github.com/gluwa/creditcoin3/actions/runs/16932837109 (without this commit) vs
https://github.com/gluwa/creditcoin3/actions/runs/16937301609 (with this commit)

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
