### PR TITLE
CSUB-1905: Adjust biweekly cron syntax for Testnet snapshots

### DIFF
--- a/.github/workflows/check-testnet-snapshot.yml
+++ b/.github/workflows/check-testnet-snapshot.yml
@@ -3,8 +3,8 @@ name: Check Testnet Snapshot
 
 on:
   schedule:
-    # at 8:30, on Tusday, 1st and 3rd week of the month
-    - cron: "30 8 1-7,15-21 * 2"
+    # at 08:30 on every 14th day-of-month
+    - cron: "30 8 */14 * *"
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
the previous syntax was wrong and resulted in jobs being scheduled every day between 1-7 of the month! This new syntax should schedule on every 14th day of the month!
