### PR TITLE
Allow workflows using azure/login to be triggered from any branch

### DIFF
--- a/.github/workflows/check-snapshot.yml
+++ b/.github/workflows/check-snapshot.yml
@@ -18,6 +18,8 @@ permissions:
 
 jobs:
   check-snapshot:
+    # b/c of azure/login
+    environment: snapshot
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     name: check snapshot for ${{ inputs.target-chain }}
     steps:


### PR DESCRIPTION
- check devnet snapshot triggered from a non `dev` branch - PASS - https://github.com/gluwa/creditcoin3/actions/runs/21025825098