### PR TITLE
fix: actually flip a bit in signature-verifier tests

### DIFF
--- a/cli/src/test/blockchain-tests/ed25519-verifier.test.ts
+++ b/cli/src/test/blockchain-tests/ed25519-verifier.test.ts
@@ -211,7 +211,8 @@ describe('Precompile: Ed25519Verifier.verify()', (): void => {
 
             // Tamper with the signature (flip a bit)
             const tamperedSignature = new Uint8Array(signature);
-            tamperedSignature[0] = 0x01;
+            // eslint-disable-next-line no-bitwise
+            tamperedSignature[0] ^= 0x01;
 
             // Convert to hex strings
             const messageHex = u8aToHex(messageBytes);

--- a/cli/src/test/blockchain-tests/sr25519-verifier.test.ts
+++ b/cli/src/test/blockchain-tests/sr25519-verifier.test.ts
@@ -211,7 +211,8 @@ describe('Precompile: Sr25519Verifier.verify()', (): void => {
 
             // Tamper with the signature (flip a bit)
             const tamperedSignature = new Uint8Array(signature);
-            tamperedSignature[0] = 0x01;
+            // eslint-disable-next-line no-bitwise
+            tamperedSignature[0] ^= 0x01;
 
             // Convert to hex strings
             const messageHex = u8aToHex(messageBytes);


### PR DESCRIPTION
# Description of proposed changes

<describe what this PR is about and why we want it>


first byte assignment will result in the same signature as the original one in 1 out of 256 cases. updating the test to actually flip the bit
---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
