### PR TITLE
CSUB-2019: Rework the prod_or_fast! macro to prod_devnet_fast!

### DIFF
--- a/.github/check-for-changes-in-epoch-duration.sh
+++ b/.github/check-for-changes-in-epoch-duration.sh
@@ -25,11 +25,11 @@ check_blocks_for_faster_epoch() {
     from=$1
     to=$2
 
-    if git --no-pager diff "${from}...${to}" | grep 'BLOCKS_FOR_FASTER_EPOCH'; then
-        greenprint "FAIL: BLOCKS_FOR_FASTER_EPOCH has been modified! This will brick Devnet!"
+    if git --no-pager diff "${from}...${to}" | grep 'EPOCH_DURATION_IN_BLOCKS'; then
+        greenprint "FAIL: EPOCH_DURATION_IN_BLOCKS has been modified! This MAY brick existing chains!"
         exit 1
     else
-        greenprint "PASS: BLOCKS_FOR_FASTER_EPOCH has not been modified!"
+        greenprint "PASS: EPOCH_DURATION_IN_BLOCKS has not been modified!"
     fi
 }
 

--- a/.github/workflows/chainspec.yml
+++ b/.github/workflows/chainspec.yml
@@ -40,7 +40,7 @@ jobs:
       - deploy-runner-build-creditcoin-for
     uses: ./.github/workflows/build-native.yml
     with:
-      build-options: "--release --features=fast-runtime --features=devnet"
+      build-options: "--release --features=devnet"
       version-string: devnet
       cache-key-name: build-creditcoin-node
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-build-creditcoin-node-for-devnet']"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         id: set-build-options
         shell: bash
         run: |
-          echo "build_options=${{ contains( needs.sanity-check.outputs.TAG_NAME, 'devnet') && '--features devnet --features fast-runtime' || '' }}" >> "$GITHUB_OUTPUT"
+          echo "build_options=${{ contains( needs.sanity-check.outputs.TAG_NAME, 'devnet') && '--features devnet' || '' }}" >> "$GITHUB_OUTPUT"
 
       - name: View the build options
         shell: bash

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -44,7 +44,7 @@ jobs:
       - deploy-github-runner
     uses: ./.github/workflows/build-wasm.yml
     with:
-      build-options: "--features fast-runtime --features devnet"
+      build-options: "--features devnet"
       version-string: ${{ github.sha }}
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'type-wasm']"
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -142,26 +142,26 @@ pub mod opaque {
 mod version;
 pub use version::VERSION;
 
-macro_rules! prod_or_fast {
-    ($prod: expr, $fast: expr) => {
+macro_rules! prod_devnet_fast {
+    ($prod: expr, $devnet: expr, $fast: expr) => {
         if cfg!(feature = "fast-runtime") {
             $fast
+        } else if cfg!(feature = "devnet") {
+            $devnet
         } else {
             $prod
         }
     };
 }
 
-pub const MILLISECS_PER_BLOCK: u64 = prod_or_fast!(15_000, 5_000);
+pub const MILLISECS_PER_BLOCK: u64 = prod_devnet_fast!(15_000, 5_000, 5_000);
 
 pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
 
 // WARNING: the next should be defined on a single line b/c of
 // the assertions made in .github/check-for-changes-in-epoch-duration.sh
 #[rustfmt::skip]
-const BLOCKS_FOR_FASTER_EPOCH: u32 = if cfg!(feature = "devnet") { 2 * HOURS } else { 15 };
-
-pub const EPOCH_DURATION_IN_BLOCKS: u32 = prod_or_fast!(12 * HOURS, BLOCKS_FOR_FASTER_EPOCH);
+pub const EPOCH_DURATION_IN_BLOCKS: u32 = prod_devnet_fast!(12 * HOURS, 2 * HOURS, 15);
 
 parameter_types! {
     pub const EpochDuration: u64 = EPOCH_DURATION_IN_BLOCKS as u64; // Q: how long to make an epoch


### PR DESCRIPTION
which makes the features **devnet** & **fast-runtime** mutually exclusive in nature. (although given how the macro logic works if both are specified on the build command line it would take into account only devnet and ignore fast-runtime).

**WARNING:** b/c of ^^^ I've also updated build flags on all workflows to make things more clear!
