### PR TITLE
Remove testnet-v1 from execution matrix for audit-automation.yml

### DIFF
--- a/.github/workflows/audit-automation.yml
+++ b/.github/workflows/audit-automation.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        config: [devnet, testnet, testnet-v1]
+        config: [devnet, testnet]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
USC Tesnet V1 chain has been decomissioned and the CI job for testnet-v1 itself has been failing since March 31st: https://github.com/gluwa/creditcoin3-next/actions/runs/23774624691
