### PR TITLE
feat: add max batch span in proof-gen-api-server

### DIFF
--- a/proof-gen-api-server/bin/server.rs
+++ b/proof-gen-api-server/bin/server.rs
@@ -87,6 +87,14 @@ pub struct ProofGenApiServer {
         help = "Archiver HTTP URL for the legacy single-chain mode (e.g. http://localhost:8080)."
     )]
     archiver_url: Option<String>,
+
+    #[arg(
+        long,
+        default_value = "10000",
+        env = "MAX_BATCH_SPAN",
+        help = "Maximum allowed block span (highest − lowest block) in a single batch request. Prevents small batches from forcing proof generation over extremely large ranges. Set to 0 to disable the limit."
+    )]
+    max_batch_span: u64,
 }
 
 #[tokio::main]
@@ -135,6 +143,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 c.max_batch_size = n;
             }
         }
+        // MAX_BATCH_SPAN env/CLI overrides YAML when explicitly set.
+        if let Ok(raw) = env::var("MAX_BATCH_SPAN") {
+            if let Ok(n) = raw.parse::<u64>() {
+                c.max_batch_span = n;
+            }
+        }
         c
     } else {
         // Legacy single-chain mode: chain key from CHAIN_KEY env (default 2).
@@ -156,6 +170,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             redis_cluster_mode: resolved_redis_cluster_mode,
 
             max_batch_size: args.max_batch_size,
+            max_batch_span: args.max_batch_span,
         }
     };
 

--- a/proof-gen-api-server/bin/server.rs
+++ b/proof-gen-api-server/bin/server.rs
@@ -90,7 +90,7 @@ pub struct ProofGenApiServer {
 
     #[arg(
         long,
-        default_value = "10000",
+        default_value = "1000",
         env = "MAX_BATCH_SPAN",
         help = "Maximum allowed block span (highest - lowest block) in a single batch request. Prevents small batches from forcing proof generation over extremely large ranges."
     )]

--- a/proof-gen-api-server/bin/server.rs
+++ b/proof-gen-api-server/bin/server.rs
@@ -92,7 +92,7 @@ pub struct ProofGenApiServer {
         long,
         default_value = "10000",
         env = "MAX_BATCH_SPAN",
-        help = "Maximum allowed block span (highest − lowest block) in a single batch request. Prevents small batches from forcing proof generation over extremely large ranges. Set to 0 to disable the limit."
+        help = "Maximum allowed block span (highest - lowest block) in a single batch request. Prevents small batches from forcing proof generation over extremely large ranges."
     )]
     max_batch_span: u64,
 }

--- a/proof-gen-api-server/config.example.yaml
+++ b/proof-gen-api-server/config.example.yaml
@@ -25,4 +25,4 @@ redis_cluster_mode: false
 max_batch_size: 10
 # Maximum allowed block span (highest − lowest block) in a single batch request.
 # Prevents small batches from forcing proof generation over extremely large ranges.
-max_batch_span: 10000
+max_batch_span: 1000

--- a/proof-gen-api-server/config.example.yaml
+++ b/proof-gen-api-server/config.example.yaml
@@ -23,3 +23,6 @@ chains:
 redis_cluster_mode: false
 
 max_batch_size: 10
+# Maximum allowed block span (highest − lowest block) in a single batch request.
+# Prevents small batches from forcing proof generation over extremely large ranges.
+max_batch_span: 10000

--- a/proof-gen-api-server/src/config.rs
+++ b/proof-gen-api-server/src/config.rs
@@ -11,6 +11,11 @@ pub const DEFAULT_MAX_BATCH_SIZE: NonZeroUsize = match NonZeroUsize::new(10) {
     None => panic!("10 is non-zero"),
 };
 
+/// Default `max_batch_span` (10 000 blocks) - maximum distance between the
+/// lowest and highest block in a single batch request. Prevents a small batch
+/// from forcing proof generation over an extremely large block range.
+pub const DEFAULT_MAX_BATCH_SPAN: u64 = 10_000;
+
 /// One source chain (EVM) served by this process, keyed on Creditcoin3.
 #[derive(Debug, Clone)]
 pub struct ChainConfig {
@@ -30,6 +35,7 @@ pub struct Config {
     pub redis_url: Option<String>,
     pub redis_cluster_mode: bool,
     pub max_batch_size: NonZeroUsize,
+    pub max_batch_span: u64,
 }
 
 impl Config {
@@ -48,6 +54,7 @@ impl Config {
             redis_url: None,
             redis_cluster_mode: false,
             max_batch_size: DEFAULT_MAX_BATCH_SIZE,
+            max_batch_span: DEFAULT_MAX_BATCH_SPAN,
         }
     }
 
@@ -86,6 +93,8 @@ pub struct ConfigFile {
     pub indexer_url: Option<String>,
     #[serde(default = "default_max_batch_size")]
     pub max_batch_size: NonZeroUsize,
+    #[serde(default = "default_max_batch_span")]
+    pub max_batch_span: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -98,6 +107,10 @@ pub struct ChainConfigFile {
 
 fn default_max_batch_size() -> NonZeroUsize {
     DEFAULT_MAX_BATCH_SIZE
+}
+
+fn default_max_batch_span() -> u64 {
+    DEFAULT_MAX_BATCH_SPAN
 }
 
 impl ConfigFile {
@@ -126,6 +139,7 @@ impl ConfigFile {
             redis_url: self.redis_url,
             redis_cluster_mode: self.redis_cluster_mode,
             max_batch_size: self.max_batch_size,
+            max_batch_span: self.max_batch_span,
         })
     }
 }

--- a/proof-gen-api-server/src/config.rs
+++ b/proof-gen-api-server/src/config.rs
@@ -11,10 +11,10 @@ pub const DEFAULT_MAX_BATCH_SIZE: NonZeroUsize = match NonZeroUsize::new(10) {
     None => panic!("10 is non-zero"),
 };
 
-/// Default `max_batch_span` (10 000 blocks) - maximum distance between the
+/// Default `max_batch_span` (1 000 blocks) - maximum distance between the
 /// lowest and highest block in a single batch request. Prevents a small batch
 /// from forcing proof generation over an extremely large block range.
-pub const DEFAULT_MAX_BATCH_SPAN: u64 = 10_000;
+pub const DEFAULT_MAX_BATCH_SPAN: u64 = 1_000;
 
 /// One source chain (EVM) served by this process, keyed on Creditcoin3.
 #[derive(Debug, Clone)]

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -268,6 +268,7 @@ impl Server {
             self.builders.clone(),
             metrics.clone(),
             self.config.max_batch_size.get(),
+            self.config.max_batch_span,
         )
         .await?;
 

--- a/proof-gen-api-server/src/prom/mod.rs
+++ b/proof-gen-api-server/src/prom/mod.rs
@@ -469,6 +469,7 @@ mod labels {
         TooManyTxQueriesInProofQuery,
         EmptyTxHashes,
         TooManyTxHashes,
+        BatchSpanTooLarge,
         Internal,
     }
 

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -328,6 +328,13 @@ mod tests {
     }
 
     async fn make_service(eth_provider: Arc<dyn EthRpcProvider>) -> ContinuityService {
+        make_service_with_batch_span(eth_provider, 10_000).await
+    }
+
+    async fn make_service_with_batch_span(
+        eth_provider: Arc<dyn EthRpcProvider>,
+        max_batch_span: u64,
+    ) -> ContinuityService {
         let chain_key = 2;
         let (cc_provider, _) = make_mock_providers(chain_key);
         let builder = Arc::new(ContinuityBuilder::new_with_providers(
@@ -335,7 +342,7 @@ mod tests {
             cc_provider,
             eth_provider,
         ));
-        ContinuityService::new(vec![builder], NoopMetrics::new(), 10)
+        ContinuityService::new(vec![builder], NoopMetrics::new(), 10, max_batch_span)
             .await
             .expect("service init should succeed with mocks")
     }
@@ -436,5 +443,89 @@ mod tests {
             cp_bounds.is_none(),
             "no checkpoint upper bound beyond range"
         );
+    }
+
+    #[tokio::test]
+    async fn batch_span_exceeding_limit_is_rejected() {
+        // Set a tight max_batch_span of 50 blocks
+        let svc = make_service_with_batch_span(Arc::new(FoundEthProvider), 50).await;
+        let chain = svc.chain_state(2).unwrap();
+
+        // Blocks 100 and 200 are 100 apart, which exceeds the 50-block limit
+        let queries = vec![
+            ProofQuery {
+                header_number: 100,
+                tx_indexes: vec![],
+            },
+            ProofQuery {
+                header_number: 200,
+                tx_indexes: vec![],
+            },
+        ];
+        let err = svc
+            .get_proof_batch(chain, &queries)
+            .await
+            .expect_err("should reject span > max_batch_span");
+        assert!(
+            matches!(
+                err,
+                ServiceError::BatchSpanTooLarge {
+                    span: 100,
+                    max_span: 50,
+                    ..
+                }
+            ),
+            "expected BatchSpanTooLarge, got {err:?}"
+        );
+        assert!(!err.retriable());
+        assert_eq!(err.code(), "BatchSpanTooLarge");
+    }
+
+    #[tokio::test]
+    async fn batch_span_within_limit_is_accepted() {
+        // Set max_batch_span of 50 blocks
+        let svc = make_service_with_batch_span(Arc::new(FoundEthProvider), 50).await;
+        let chain = svc.chain_state(2).unwrap();
+
+        // Blocks 100 and 140 are 40 apart, which is within the 50-block limit.
+        // The request will still fail (boundary lookup / RPC) but NOT with BatchSpanTooLarge.
+        let queries = vec![
+            ProofQuery {
+                header_number: 100,
+                tx_indexes: vec![],
+            },
+            ProofQuery {
+                header_number: 140,
+                tx_indexes: vec![],
+            },
+        ];
+        let result = svc.get_proof_batch(chain, &queries).await;
+        // It may fail for other reasons (mock doesn't serve real blocks) but
+        // it must NOT fail with BatchSpanTooLarge.
+        if let Err(err) = result {
+            assert!(
+                !matches!(err, ServiceError::BatchSpanTooLarge { .. }),
+                "span within limit should not be rejected, got {err:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn single_block_batch_always_passes_span_check() {
+        // Even with max_batch_span = 0, a single-block batch has span 0 and should pass.
+        let svc = make_service_with_batch_span(Arc::new(FoundEthProvider), 0).await;
+        let chain = svc.chain_state(2).unwrap();
+
+        let queries = vec![ProofQuery {
+            header_number: 100,
+            tx_indexes: vec![],
+        }];
+        let result = svc.get_proof_batch(chain, &queries).await;
+        if let Err(err) = result {
+            assert!(
+                !matches!(err, ServiceError::BatchSpanTooLarge { .. }),
+                "single-block batch should never fail span check, got {err:?}"
+            );
+        }
     }
 }

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -328,7 +328,7 @@ mod tests {
     }
 
     async fn make_service(eth_provider: Arc<dyn EthRpcProvider>) -> ContinuityService {
-        make_service_with_batch_span(eth_provider, 10_000).await
+        make_service_with_batch_span(eth_provider, 1_000).await
     }
 
     async fn make_service_with_batch_span(

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -157,6 +157,10 @@ pub struct ContinuityService {
     metrics: Metrics,
     /// Maximum amount of concurrent futures spawned when generating proofs for batch requests or when extracting transaction indexes from transaction hashes.
     max_batch_size: usize,
+    /// Maximum allowed span (highest block − lowest block) in a single batch
+    /// request.  Prevents a small batch from forcing proof generation over an
+    /// extremely large block range.
+    max_batch_span: u64,
 }
 
 impl ContinuityService {
@@ -168,6 +172,7 @@ impl ContinuityService {
         builders: Vec<Arc<ContinuityBuilder>>,
         metrics: Metrics,
         max_batch_size: usize,
+        max_batch_span: u64,
     ) -> anyhow::Result<Self> {
         if builders.is_empty() {
             anyhow::bail!("ContinuityService requires at least one ContinuityBuilder");
@@ -271,6 +276,7 @@ impl ContinuityService {
             total_proof_requests: AtomicU64::new(0),
             metrics,
             max_batch_size,
+            max_batch_span,
         })
     }
 
@@ -667,6 +673,18 @@ impl ContinuityService {
         // We can safely unwrap header_numbers here because the API layer guarantees at least one query is present.
         let from_header = *header_numbers.iter().min().unwrap();
         let to_header = *header_numbers.iter().max().unwrap();
+
+        // Enforce maximum batch span to prevent extremely expensive proof
+        // generation when a small batch contains widely separated block heights.
+        let span = to_header - from_header;
+        if span > self.max_batch_span {
+            return Err(ServiceError::BatchSpanTooLarge {
+                from_block: from_header,
+                to_block: to_header,
+                span,
+                max_span: self.max_batch_span,
+            });
+        }
 
         // Record block range metric
         for &header_number in header_numbers.iter() {

--- a/proof-gen-api-server/src/services/errors.rs
+++ b/proof-gen-api-server/src/services/errors.rs
@@ -102,6 +102,13 @@ pub enum ServiceError {
     EmptyTxHashes,
     #[error("Batch request cannot contain more than 100 tx hashes")]
     TooManyTxHashes,
+    #[error("Batch span too large: requested span {span} blocks (from block {from_block} to {to_block}) exceeds the maximum allowed span of {max_span} blocks")]
+    BatchSpanTooLarge {
+        from_block: u64,
+        to_block: u64,
+        span: u64,
+        max_span: u64,
+    },
 }
 
 impl ServiceError {
@@ -133,6 +140,7 @@ impl ServiceError {
             ServiceError::TooManyTxQueriesInProofQuery => "TooManyTxQueriesInProofQuery",
             ServiceError::TooManyTxHashes => "TooManyTxHashes",
             ServiceError::EmptyTxHashes => "EmptyTxHashes",
+            ServiceError::BatchSpanTooLarge { .. } => "BatchSpanTooLarge",
         }
     }
 
@@ -148,7 +156,8 @@ impl ServiceError {
             | Self::TooManyProofQueries
             | Self::TooManyTxQueriesInProofQuery
             | Self::EmptyTxHashes
-            | Self::TooManyTxHashes => StatusCode::BAD_REQUEST,
+            | Self::TooManyTxHashes
+            | Self::BatchSpanTooLarge { .. } => StatusCode::BAD_REQUEST,
             Self::RpcUnavailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
             Self::TxHashLookupUnavailable { .. } => StatusCode::NOT_IMPLEMENTED,
             Self::TxHashNotFound { .. }
@@ -271,6 +280,7 @@ impl GetErrorType for ServiceError {
             ServiceError::TooManyTxQueriesInProofQuery => ErrorType::TooManyTxQueriesInProofQuery,
             ServiceError::EmptyTxHashes => ErrorType::EmptyTxHashes,
             ServiceError::TooManyTxHashes => ErrorType::TooManyTxHashes,
+            ServiceError::BatchSpanTooLarge { .. } => ErrorType::BatchSpanTooLarge,
         }
     }
 }

--- a/proof-gen-api-server/tests/test_utils.rs
+++ b/proof-gen-api-server/tests/test_utils.rs
@@ -202,7 +202,7 @@ mod anvil_integration {
         }
 
         let service = Arc::new(
-            ContinuityService::new(builders, NoopMetrics::new(), 10, 10_000)
+            ContinuityService::new(builders, NoopMetrics::new(), 10, 1_000)
                 .await
                 .expect("service init"),
         );

--- a/proof-gen-api-server/tests/test_utils.rs
+++ b/proof-gen-api-server/tests/test_utils.rs
@@ -202,7 +202,7 @@ mod anvil_integration {
         }
 
         let service = Arc::new(
-            ContinuityService::new(builders, NoopMetrics::new(), 10)
+            ContinuityService::new(builders, NoopMetrics::new(), 10, 10_000)
                 .await
                 .expect("service init"),
         );


### PR DESCRIPTION
# Description of proposed changes

<describe what this PR is about and why we want it>

Introduces a `max_batch_span` argument to limit the max spanning size of batch proof requests in proof-gen-api server. the span defaults to 10_000 blocks. fixed https://github.com/chainlight-io/2026-q1-ctc-usc-phase2-audit-issues/issues/14

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
