### PR TITLE
fix: verify continuity proof consistency across quorum votes (attestor)

### DIFF
--- a/attestor/attestor/src/worker/p2p/mod.rs
+++ b/attestor/attestor/src/worker/p2p/mod.rs
@@ -102,8 +102,6 @@ pub struct Config {
     #[default(false)]
     no_mdns: bool,
     #[specify_later]
-    bls: std::sync::Arc<crate::bls::BlsStore>,
-    #[specify_later]
     keypair: libp2p::identity::Keypair,
     #[specify_later]
     receiver_p2p: tokio::sync::broadcast::Receiver<common::types::Attestation>,
@@ -125,8 +123,6 @@ pub(crate) struct WorkerP2P {
     listen_addr: libp2p::Multiaddr,
 
     chain_key: attestor_primitives::ChainKey,
-    // CC3 CONNECTION
-    bls: std::sync::Arc<crate::bls::BlsStore>,
 
     // METRICS
     metrics: common::types::Metrics,
@@ -137,7 +133,7 @@ pub(crate) struct WorkerP2P {
 }
 
 impl WorkerP2P {
-    pub(crate) async fn new(config: Config) -> anyhow::Result<Self> {
+    pub(crate) fn new(config: Config) -> anyhow::Result<Self> {
         let enable_mdns = !config.no_mdns;
         let mut swarm = libp2p::SwarmBuilder::with_existing_identity(config.keypair)
             .with_tokio()
@@ -192,7 +188,6 @@ impl WorkerP2P {
             listen_addr,
 
             chain_key: config.chain_key,
-            bls: config.bls,
 
             metrics: config.metrics,
 
@@ -231,7 +226,7 @@ impl super::Worker for WorkerP2P {
                     self.handle_event_attestation(attestation).await.map_err(Interrupt::Cont)?;
                 }
                 event = self.swarm.select_next_some() => {
-                    self.handle_event_p2p(event).await?;
+                    self.handle_event_p2p(event).await.map_err(Interrupt::Cont)?;
                 }
             }
         }
@@ -276,7 +271,7 @@ impl WorkerP2P {
     async fn handle_event_p2p(
         &mut self,
         event: libp2p::swarm::SwarmEvent<behavior::P2PBehaviorEvent>,
-    ) -> Result<(), Interrupt<Error>> {
+    ) -> Result<(), Error> {
         use parity_scale_codec::Decode as _;
 
         match event {
@@ -384,8 +379,8 @@ impl WorkerP2P {
                 let decode = common::types::Attestation::decode(&mut message.data.as_ref());
                 let Ok(attestation) = decode else {
                     tracing::error!(peer_id = %propagation_source, "⛔ Received invalid attestation");
-
                     self.metrics.increase_invalid_gossipsub_count();
+
                     self.swarm
                         .behaviour_mut()
                         .gossipsub
@@ -399,43 +394,35 @@ impl WorkerP2P {
                 };
 
                 let digest = attestation.digest();
-                let height = attestation.header_number();
-                let attestor_id = attestation.attestor_id();
 
                 tracing::info!(
                     peer_id = %propagation_source,
                     ?digest,
-                    height,
-                    %attestor_id,
+                    height = attestation.header_number(),
+                    attestor_id = %attestation.attestor,
                     "📩 Received attestation"
                 );
 
-                match self.validate_attestation(&attestation).await {
-                    Err(Interrupt::Cont(err)) => {
-                        tracing::error!(?err, "⛔ Invalid attestation");
+                // WARNING: while we use the chain_key as the topic id for gossip propagation, this
+                // does not enforce that attestations received correspond to the correct chain key!
+                // A malicious or dysfunctional attestor is still able to send attestation with a
+                // chain key than the gossip topic, so this needs to be checked before pool
+                // insertion.
+                if attestation.chain_key() != self.chain_key {
+                    tracing::error!(peer_id = %propagation_source, "⛔ Unsupported chain key");
+                    self.metrics.increase_invalid_gossipsub_count();
 
-                        self.metrics.increase_invalid_gossipsub_count();
-                        self.swarm
-                            .behaviour_mut()
-                            .gossipsub
-                            .report_message_validation_result(
-                                &message_id,
-                                &propagation_source,
-                                libp2p::gossipsub::MessageAcceptance::Reject,
-                            );
-
-                        return Ok(());
-                    }
-                    Err(Interrupt::Stop) => return Err(Interrupt::Stop),
-                    _ => {
-                        tracing::debug!(
-                            ?digest,
-                            height,
-                            %attestor_id,
-                            "Valid attestation BLS signature"
+                    self.swarm
+                        .behaviour_mut()
+                        .gossipsub
+                        .report_message_validation_result(
+                            &message_id,
+                            &propagation_source,
+                            libp2p::gossipsub::MessageAcceptance::Reject,
                         );
-                    }
-                };
+
+                    return Ok(());
+                }
 
                 match self.sender_validation.send(attestation).transpose() {
                     // CASE 1] ACCEPT
@@ -495,7 +482,8 @@ impl WorkerP2P {
                     //
                     // Failures which depend solely on the sender are considered malicious. They are
                     // not propagated to the rest of the network.
-                    Err(err @ crate::worker::validation::pool::Error::Unauthorized(..)) => {
+                    Err(err @ crate::worker::validation::pool::Error::Unauthorized(..))
+                    | Err(err @ crate::worker::validation::pool::Error::InvalidProof(..)) => {
                         err.log_error(digest);
                         self.swarm
                             .behaviour_mut()
@@ -641,44 +629,5 @@ impl WorkerP2P {
         };
 
         Ok(())
-    }
-
-    /// Verifies attestor eligibility and attestation bls signature before submitting to the
-    /// [attestation pool].
-    ///
-    /// [attestation pool]: crate::worker::validation::pool
-    async fn validate_attestation(
-        &mut self,
-        attestation: &common::types::Attestation,
-    ) -> Result<(), Interrupt<Error>> {
-        let attestor_id = attestation.attestor_id();
-        let digest = attestation.digest();
-        let chain_key = attestation.chain_key();
-
-        // WARNING: while we use the chain_key as the topic id for gossip propagation, this
-        // does not enforce that attestations received correspond to the correct chain key!
-        // A malicious or dysfunctional attestor is still able to send attestation with a
-        // chain key than the gossip topic, so this needs to be checked before pool
-        // insertion.
-        if chain_key != self.chain_key {
-            return Err(Interrupt::Cont(Error::InvalidAttestation(
-                InvalidCause::Unsupported(chain_key),
-            )));
-        }
-
-        let Some(pubkey) = self.bls.pubkey(attestor_id.account_id()).await else {
-            return Err(Interrupt::Cont(Error::InvalidAttestation(
-                InvalidCause::Unregistered(attestor_id),
-            )));
-        };
-
-        let msg = attestation.attestation_data.serialize();
-        if pubkey.verify(attestation.signature_bls.0, &msg) {
-            Ok(())
-        } else {
-            Err(Interrupt::Cont(Error::InvalidAttestation(
-                InvalidCause::InvalidBls(digest),
-            )))
-        }
     }
 }

--- a/attestor/attestor/src/worker/validation/error.rs
+++ b/attestor/attestor/src/worker/validation/error.rs
@@ -34,6 +34,7 @@ pub enum InvalidCause {
     Unsupported(attestor_primitives::ChainKey),
     Duplicate,
     InvalidVrf,
+    InvalidBls,
     EmptyContinuityProof,
     EmptyPrevDigest,
     InvalidContinuityHeadDigest {
@@ -46,6 +47,8 @@ pub enum InvalidCause {
         actual: cc_client::H256,
         expected: cc_client::H256,
     },
+    /// Quorum votes carry different continuity proofs, which should never happen.
+    InconsistentContinuityProofs,
 }
 
 impl std::fmt::Display for InvalidCause {
@@ -54,6 +57,7 @@ impl std::fmt::Display for InvalidCause {
             Self::Unsupported(chain_key) => write!(f, "Usupported source chain: {chain_key}"),
             Self::Duplicate => write!(f, "Attestation already exists in the runtime"),
             Self::InvalidVrf => write!(f, "Invalid attestation VRF"),
+            Self::InvalidBls => write!(f, "Invalid attestation BLS"),
             Self::EmptyContinuityProof => write!(f, "Empty attestation continuity proof"),
             Self::EmptyPrevDigest => write!(f, "Empty previous digest"),
             Self::InvalidContinuityHeadDigest { actual, expected } => write!(
@@ -64,6 +68,9 @@ impl std::fmt::Display for InvalidCause {
                 f,
                 "Invalid continuity proof tail digest, expected {expected}, got {actual}"
             ),
+            Self::InconsistentContinuityProofs => {
+                write!(f, "Quorum votes contain inconsistent continuity proofs")
+            }
         }
     }
 }

--- a/attestor/attestor/src/worker/validation/mod.rs
+++ b/attestor/attestor/src/worker/validation/mod.rs
@@ -580,6 +580,26 @@ impl WorkerAttestationValidation {
             .first()
             .expect("Invariant violated: quorum must always contain at least one vote");
 
+        // Audit finding: all votes counted toward quorum must carry an identical continuity proof.
+        // The pool guarantees the same *digest* in each vote, but we also verify the proof bytes
+        // are identical so that no single attestor can sneak in a different Merkle chain.
+        if votes.len() > 1 {
+            let reference_proof = &attestation.continuity_proof;
+            if votes[1..]
+                .iter()
+                .any(|v| &v.continuity_proof != reference_proof)
+            {
+                tracing::error!(
+                    ?digest,
+                    height,
+                    "⛔ Quorum votes contain inconsistent continuity proofs"
+                );
+                return Err(Interrupt::Cont(Error::InvalidAttestation(
+                    InvalidCause::InconsistentContinuityProofs,
+                )));
+            }
+        }
+
         // Every attestation must have a continuity proof except for the first attestation in the
         // chain
         if attestation.continuity_proof.is_empty() && height != self.start_height {

--- a/attestor/attestor/src/worker/validation/pool/error.rs
+++ b/attestor/attestor/src/worker/validation/pool/error.rs
@@ -15,6 +15,9 @@ pub enum Error {
         common::types::Height,
         attestor_primitives::Digest,
     ),
+    /// The continuity proof length exceeds the attestation height, indicating the proof
+    /// reaches before genesis — an invalid attestation that must be rejected.
+    InvalidProof(attestor_primitives::AttestorId, common::types::Height),
 }
 
 impl Error {
@@ -63,6 +66,14 @@ impl Error {
                     "⛔ Unauthorized attestor vote rejected"
                 );
             }
+            Self::InvalidProof(attestor_id, height) => {
+                tracing::error!(
+                    %attestor_id,
+                    ?digest,
+                    height,
+                    "⛔ Continuity proof length exceeds attestation height (reaches before genesis)"
+                );
+            }
         }
     }
 }
@@ -107,6 +118,14 @@ impl std::fmt::Display for Error {
                     "Attestor {address} \
                     for source chain height {height} \
                     with known invalid digest {digest}"
+                )
+            }
+            Error::InvalidProof(address, height) => {
+                write!(
+                    f,
+                    "Attestor {address} \
+                    submitted an attestation at height {height} \
+                    with a continuity proof that reaches before genesis"
                 )
             }
         }

--- a/attestor/attestor/src/worker/validation/pool/mod.rs
+++ b/attestor/attestor/src/worker/validation/pool/mod.rs
@@ -427,32 +427,47 @@ impl AttestationPoolInner {
         Ok(removed)
     }
 
-    fn peek(&mut self) -> Option<(Quorum, Permit)> {
-        self.forks.peek().map(|fork| {
-            let quorum = Quorum(fork.votes.clone());
-            let height = fork.attestation.header_number();
-            let digest = fork.attestation.digest();
-            let header_hash = fork.attestation.attestation_data.header_hash;
+    fn peek(&mut self) -> Result<Option<(Quorum, Permit)>, Error> {
+        let Some(fork) = self.forks.peek() else {
+            return Ok(None);
+        };
 
-            let permit = Permit(CompoundInfo {
-                height,
-                digest,
-                header_hash,
-            });
-
-            // Only update metrics the first time quorum is reached at that height
-            if let Some(elapsed) = self.attestation_delay.pop(height) {
-                tracing::debug!(
-                    ?digest,
-                    height,
-                    elapsed_ms = elapsed.as_millis(),
-                    "⏱️ Time from first vote to quorum"
-                );
-                self.metrics.update_attestation_delay_quorum(elapsed);
+        let quorum = Quorum(fork.votes.clone());
+        let height = fork.attestation.header_number();
+        let digest = fork.attestation.digest();
+        let header_hash = fork.attestation.attestation_data.header_hash;
+        let proof = &fork.attestation.continuity_proof;
+        let attestor = fork.attestation.attestor_id();
+        let start_block = match height.checked_sub(proof.len() as u64) {
+            Some(s) => s,
+            None => {
+                // The best fork has an invalid proof (proof longer than its height).
+                // Evict it from the pool so we don't loop on this fork forever.
+                self.forks.pop_best();
+                return Err(Error::InvalidProof(attestor, height));
             }
+        };
+        let continuity_digest = proof.compute_continuity_digest(start_block);
 
-            (quorum, permit)
-        })
+        let permit = Permit(CompoundInfo {
+            height,
+            digest,
+            header_hash,
+            continuity_digest,
+        });
+
+        // Only update metrics the first time quorum is reached at that height
+        if let Some(elapsed) = self.attestation_delay.pop(height) {
+            tracing::debug!(
+                ?digest,
+                height,
+                elapsed_ms = elapsed.as_millis(),
+                "⏱️ Time from first vote to quorum"
+            );
+            self.metrics.update_attestation_delay_quorum(elapsed);
+        }
+
+        Ok(Some((quorum, permit)))
     }
 
     fn mark_valid(&mut self, Permit(info): Permit) {
@@ -535,6 +550,11 @@ struct KeyDigestPending {
 /// attestation digest alone is not a guarantee of uniqueness, and must be paired with the header
 /// hash to avoid collisions.
 ///
+/// Additionally, the continuity proof bytes are not committed to by the attestation digest. We
+/// pair in a `continuity_digest` (computed via [`ContinuityProof::compute_continuity_digest`]) so that
+/// attestors carrying different continuity proofs for the same block/digest can never merge toward
+/// quorum.
+///
 /// [digest computation]: attestor_primitives::Attestation::digest
 /// [`AttestationData`]:  attestor_primitives::AttestationData
 /// [attestation data serialization]: attestor_primitives::AttestationData::serialize
@@ -542,6 +562,8 @@ struct KeyDigestPending {
 struct CompoundDigest {
     digest: attestor_primitives::Digest,
     header_hash: attestor_primitives::Digest,
+    /// Hash of the continuity proof chain (prevents quorum on competing proofs).
+    continuity_digest: attestor_primitives::Digest,
 }
 
 impl CompoundDigest {
@@ -549,6 +571,7 @@ impl CompoundDigest {
         Self {
             digest: attestor_primitives::Digest::zero(),
             header_hash: attestor_primitives::Digest::zero(),
+            continuity_digest: attestor_primitives::Digest::zero(),
         }
     }
 
@@ -556,13 +579,8 @@ impl CompoundDigest {
         Self {
             digest: attestor_primitives::Digest::from([u8::MAX; 32]),
             header_hash: attestor_primitives::Digest::from([u8::MAX; 32]),
+            continuity_digest: attestor_primitives::Digest::from([u8::MAX; 32]),
         }
-    }
-}
-
-impl From<CompoundDigest> for attestor_primitives::Digest {
-    fn from(digest: CompoundDigest) -> Self {
-        digest.digest
     }
 }
 
@@ -574,6 +592,8 @@ struct CompoundInfo {
     height: common::types::Height,
     digest: attestor_primitives::Digest,
     header_hash: attestor_primitives::Digest,
+    /// Hash of the continuity proof chain (prevents quorum on competing proofs).
+    continuity_digest: attestor_primitives::Digest,
 }
 
 impl From<CompoundInfo> for CompoundDigest {
@@ -581,6 +601,7 @@ impl From<CompoundInfo> for CompoundDigest {
         Self {
             digest: info.digest,
             header_hash: info.header_hash,
+            continuity_digest: info.continuity_digest,
         }
     }
 }
@@ -665,17 +686,24 @@ impl AttestationPoolForks {
         let digest = attestation.digest();
         let attestor = attestation.attestor_id();
         let header_hash = attestation.attestation_data.header_hash;
+        let proof = &attestation.continuity_proof;
+        // A proof whose length exceeds the attestation height would reach before genesis.
+        let start_block = height
+            .checked_sub(proof.len() as u64)
+            .ok_or(Error::InvalidProof(attestor.clone(), height))?;
+        let continuity_digest = proof.compute_continuity_digest(start_block);
 
         tracing::debug!("Checking for known invalids");
 
         let digest = CompoundDigest {
             digest,
             header_hash,
+            continuity_digest,
         };
 
         let key_digest = KeyDigest { height, digest };
         if self.votes_invalid.contains(&key_digest) {
-            return Err(Error::InvalidDigest(attestor, height, digest.into()));
+            return Err(Error::InvalidDigest(attestor, height, digest.digest));
         }
 
         tracing::debug!("Validating attestation height");
@@ -880,6 +908,21 @@ impl AttestationPoolForks {
         self.forks_best
             .as_ref()
             .and_then(|best| self.validate_quorum.validate(best).then(|| best.clone()))
+    }
+
+    /// Evict the current best fork (the one `peek` would return) from the pool.
+    ///
+    /// Used when `peek`'s caller detects that the best fork is invalid and needs to be removed
+    /// so the pool advances to the next candidate instead of re-surfacing the same bad fork.
+    fn pop_best(&mut self) {
+        let digest = self
+            .quorums_by_height
+            .first()
+            .map(|k| k.digest)
+            .or_else(|| self.forks_by_size.last().map(|k| k.digest));
+        if let Some(digest) = digest {
+            self.pop(digest);
+        }
     }
 
     fn pop(&mut self, digest: CompoundDigest) {
@@ -1689,12 +1732,21 @@ impl futures::Stream for AttestationPoolReceiver {
     ) -> std::task::Poll<Option<Self::Item>> {
         match &mut *self.common.pool.lock() {
             AttestationPool::Open(inner) => match inner.peek() {
-                Some((quorum, permit)) => {
+                Ok(Some((quorum, permit))) => {
                     tracing::debug!(height = quorum.header_number(), "Found a quorum");
                     std::task::Poll::Ready(Some((quorum, permit, inner.digest_local)))
                 }
-                None => {
+                Ok(None) => {
                     tracing::debug!("No quorum found, waiting for new attestations...");
+                    inner.wakers.push_front(cx.waker().clone());
+                    std::task::Poll::Pending
+                }
+                Err(err) => {
+                    err.log_error(Default::default());
+                    // Register a waker so the stream is re-polled immediately.
+                    // The bad fork was already evicted above; the next best fork may
+                    // already be valid and should not wait for a new attestation to
+                    // trigger a wake.
                     inner.wakers.push_front(cx.waker().clone());
                     std::task::Poll::Pending
                 }
@@ -1952,10 +2004,12 @@ mod constants {
     pub const DIGEST_0: CompoundDigest = CompoundDigest {
         digest: sp_core::H256(*b"digest_0________________________"),
         header_hash: attestor_primitives::Digest::zero(),
+        continuity_digest: attestor_primitives::Digest::zero(),
     };
     pub const DIGEST_1: CompoundDigest = CompoundDigest {
         digest: sp_core::H256(*b"digest_1________________________"),
         header_hash: attestor_primitives::Digest::zero(),
+        continuity_digest: attestor_primitives::Digest::zero(),
     };
 
     pub const TIMEOUT: std::time::Duration = std::time::Duration::from_millis(10);
@@ -1982,8 +2036,8 @@ mod fixtures {
                 common::types::Attestation {
                     attestation_data: attestor_primitives::AttestationData {
                         header_number,
-                        prev_digest: Some(prev_digest.into()),
-                        header_hash: header_hash.into(),
+                        prev_digest: Some(prev_digest.digest),
+                        header_hash: header_hash.digest,
                         ..Default::default()
                     },
                     attestor,
@@ -1993,7 +2047,7 @@ mod fixtures {
                             .sign(b"0xdeadbeef"),
                     ),
                     continuity_proof: attestor_primitives::block::ContinuityProof::new(
-                        prev_digest.into(),
+                        prev_digest.digest,
                         vec![attestor_primitives::Digest::default()],
                     ),
                 }
@@ -2101,7 +2155,7 @@ mod fixtures {
             .with_quorum(validate_quorum.target_quorum)
             .with_attestation_interval(std::num::NonZero::<common::types::Height>::MIN)
             .with_start_attestation(Some(stream::util::AttestationInfo {
-                digest: DIGEST_0.into(),
+                digest: DIGEST_0.digest,
                 height: common::types::Height::MIN,
             }))
             .with_start_height(1u64)
@@ -2120,10 +2174,23 @@ mod fixtures {
         #[with(_attestors.clone(), _header_number, _prev_digest, _header_hash)]
         attestation: AttestationVote,
     ) -> Permit {
+        let att = &attestation.attestation;
+        let proof = &att.continuity_proof;
+        let height = att.header_number();
+        let attestor = att.attestor_id();
+        let start_block = height.checked_sub(proof.len() as u64).unwrap_or_else(|| {
+            panic!(
+                "fixture: proof length {} exceeds height {} for attestor {:?}",
+                proof.len(),
+                height,
+                attestor
+            )
+        });
         Permit(CompoundInfo {
-            height: attestation.attestation.header_number(),
-            digest: attestation.attestation.digest(),
-            header_hash: attestation.attestation.attestation_data.header_hash,
+            height,
+            digest: att.digest(),
+            header_hash: att.attestation_data.header_hash,
+            continuity_digest: proof.compute_continuity_digest(start_block),
         })
     }
 }
@@ -2137,6 +2204,27 @@ mod test {
     use super::constants::*;
     use super::fixtures::*;
     use super::*;
+
+    impl From<&common::types::Attestation> for CompoundDigest {
+        fn from(attestation: &common::types::Attestation) -> Self {
+            let proof = &attestation.continuity_proof;
+            let height = attestation.header_number();
+            let attestor = attestation.attestor_id();
+            let start_block = height.checked_sub(proof.len() as u64).unwrap_or_else(|| {
+                panic!(
+                    "test CompoundDigest: proof length {} exceeds height {} for attestor {:?}",
+                    proof.len(),
+                    height,
+                    attestor
+                )
+            });
+            CompoundDigest {
+                digest: attestation.digest(),
+                header_hash: attestation.attestation_data.header_hash,
+                continuity_digest: proof.compute_continuity_digest(start_block),
+            }
+        }
+    }
 
     #[tokio::test]
     #[rstest::rstest]
@@ -2216,12 +2304,10 @@ mod test {
         let mut pool = rx.common.pool.lock();
         let inner = pool.expect_open();
 
+        let att0 = &attestation_0.attestation;
         assert!(inner.forks.votes_invalid.contains(&KeyDigest {
-            height: attestation_0.attestation.header_number(),
-            digest: CompoundDigest {
-                digest: attestation_0.attestation.digest(),
-                header_hash: attestation_0.attestation.attestation_data.header_hash
-            }
+            height: att0.header_number(),
+            digest: att0.into(),
         }));
     }
 
@@ -2254,10 +2340,7 @@ mod test {
             inner
                 .forks
                 .forks_by_digest
-                .get(&CompoundDigest {
-                    digest: attestation_0.attestation.digest(),
-                    header_hash: attestation_0.attestation.attestation_data.header_hash
-                })
+                .get(&(&attestation_0.attestation).into())
                 .unwrap(),
             &attestation_0
         );
@@ -2266,10 +2349,7 @@ mod test {
             inner
                 .forks
                 .forks_by_digest
-                .get(&CompoundDigest {
-                    digest: attestation_1.attestation.digest(),
-                    header_hash: attestation_1.attestation.attestation_data.header_hash
-                })
+                .get(&(&attestation_1.attestation).into())
                 .unwrap(),
             &attestation_1
         );
@@ -2277,19 +2357,13 @@ mod test {
         assert!(inner.forks.forks_by_size.contains(&KeySize {
             size: 1,
             height: 1,
-            digest: CompoundDigest {
-                digest: attestation_0.attestation.digest(),
-                header_hash: attestation_0.attestation.attestation_data.header_hash
-            }
+            digest: (&attestation_0.attestation).into(),
         }));
 
         assert!(inner.forks.forks_by_size.contains(&KeySize {
             size: 1,
             height: 1,
-            digest: CompoundDigest {
-                digest: attestation_1.attestation.digest(),
-                header_hash: attestation_1.attestation.attestation_data.header_hash
-            }
+            digest: (&attestation_1.attestation).into(),
         }));
     }
 
@@ -2385,17 +2459,14 @@ mod test {
                 .forks
                 .pending_by_prev_digest_tail
                 .contains(&KeyTailPending {
-                    prev_digest_tail: PrevDigestTail(DIGEST_1.into()),
+                    prev_digest_tail: PrevDigestTail(DIGEST_1.digest),
                     height: 2,
-                    digest: CompoundDigest {
-                        digest: attestation_pending.attestation.digest(),
-                        header_hash: attestation_pending.attestation.attestation_data.header_hash
-                    },
+                    digest: (&attestation_pending.attestation).into(),
                 }));
         }
 
         sx.note_attestation_finalization(stream::util::AttestationInfo {
-            digest: DIGEST_1.into(),
+            digest: DIGEST_1.digest,
             height: 1,
         })
         .unwrap();
@@ -2595,18 +2666,12 @@ mod test {
         assert!(inner.forks.forks_by_height.contains(&KeyHeight {
             height: 1,
             size: 2,
-            digest: CompoundDigest {
-                digest: attestation_0.attestation.digest(),
-                header_hash: attestation_0.attestation.attestation_data.header_hash
-            }
+            digest: (&attestation_0.attestation).into(),
         }));
         assert!(inner.forks.forks_by_size.contains(&KeySize {
             size: 2,
             height: 1,
-            digest: CompoundDigest {
-                digest: attestation_0.attestation.digest(),
-                header_hash: attestation_0.attestation.attestation_data.header_hash
-            }
+            digest: (&attestation_0.attestation).into(),
         }));
     }
 
@@ -2668,31 +2733,25 @@ mod test {
             let mut pool = rx.common.pool.lock();
             let inner = pool.expect_open();
 
-            assert!(!inner.forks.forks_by_digest.contains_key(&CompoundDigest {
-                digest: attestation_2.attestation.digest(),
-                header_hash: attestation_2.attestation.attestation_data.header_hash
-            }));
-            assert!(inner.forks.forks_by_digest.contains_key(&CompoundDigest {
-                digest: attestation_3.attestation.digest(),
-                header_hash: attestation_3.attestation.attestation_data.header_hash
-            }));
+            assert!(!inner
+                .forks
+                .forks_by_digest
+                .contains_key(&(&attestation_2.attestation).into()));
+            assert!(inner
+                .forks
+                .forks_by_digest
+                .contains_key(&(&attestation_3.attestation).into()));
             assert_eq!(inner.forks.forks_by_height.len(), 1);
             assert_eq!(inner.forks.forks_by_size.len(), 1);
             assert!(inner.forks.forks_by_height.contains(&KeyHeight {
                 height: 1,
                 size: 3,
-                digest: CompoundDigest {
-                    digest: attestation_0.attestation.digest(),
-                    header_hash: attestation_0.attestation.attestation_data.header_hash
-                }
+                digest: (&attestation_0.attestation).into(),
             }));
             assert!(inner.forks.forks_by_size.contains(&KeySize {
                 size: 3,
                 height: 1,
-                digest: CompoundDigest {
-                    digest: attestation_0.attestation.digest(),
-                    header_hash: attestation_0.attestation.attestation_data.header_hash
-                }
+                digest: (&attestation_0.attestation).into(),
             }));
         }
     }
@@ -2748,18 +2807,12 @@ mod test {
         assert!(inner.forks.forks_by_height.contains(&KeyHeight {
             height: 1,
             size: 2,
-            digest: CompoundDigest {
-                digest: attestation_0.attestation.digest(),
-                header_hash: attestation_0.attestation.attestation_data.header_hash
-            }
+            digest: (&attestation_0.attestation).into(),
         }));
         assert!(inner.forks.forks_by_size.contains(&KeySize {
             size: 2,
             height: 1,
-            digest: CompoundDigest {
-                digest: attestation_0.attestation.digest(),
-                header_hash: attestation_0.attestation.attestation_data.header_hash
-            }
+            digest: (&attestation_0.attestation).into(),
         }));
     }
 
@@ -2981,7 +3034,7 @@ mod test {
         // ------------------------------------------------------------------------
         let reversion_info = stream::util::AttestationInfo {
             height: 50,
-            digest: DIGEST_1.into(),
+            digest: DIGEST_1.digest,
         };
 
         sx.note_attestation_chain_reversion(reversion_info);
@@ -3008,7 +3061,7 @@ mod test {
             assert!(inner.forks.quorums_by_height.is_empty());
 
             // Reversion should set the new finalized digest
-            assert_eq!(inner.forks.last_finalized_digest, Some(DIGEST_1.into()));
+            assert_eq!(inner.forks.last_finalized_digest, Some(DIGEST_1.digest));
 
             // Valid queue reset
             assert!(inner.valid.quorums_valid.is_empty());


### PR DESCRIPTION
## Summary

Splits audit finding USC-003 out of #827 into its own PR.

### Changes

- **** — new error variant in `validation/error.rs` for when quorum votes carry different proof bytes
- **Quorum proof byte check** — in `validation/mod.rs`, after quorum is reached, verify all votes carry the same `continuity_proof`. The pool already guarantees the same attestation digest per fork, but proof bytes were not committed to, allowing a rogue attestor to slip in a different Merkle chain without detection.
- **`continuity_digest` in `CompoundDigest`/`CompoundInfo`** — in `pool/mod.rs`, attestors with different continuity proofs for the same `(height, digest)` now occupy separate fork entries and cannot merge toward quorum. Computed via `ContinuityProof::compute_continuity_digest`.
- **`peek()` returns `Result`** — surfaces `InvalidProof` (proof length exceeds attestation height) instead of silently returning `Pending` forever.
- **`InvalidProof` error variant** — in `pool/error.rs`; treated as `Reject` in `p2p/mod.rs` alongside `Unauthorized` (malicious sender).

### Relationship to #827

This PR contains only the continuity-proof-consistency fix. The remaining findings in #827 (AttestorsCount O(1), typo fix, EVM reorg mitigation, upper boundary digest check) stay in that PR.
