### PR TITLE
fix: rename fetch_babe_randomness_two_epoch_ego -> ago (typo)

### DIFF
--- a/attestor/attestor/src/worker/validation/mod.rs
+++ b/attestor/attestor/src/worker/validation/mod.rs
@@ -810,7 +810,7 @@ impl WorkerAttestationValidation {
         use futures::TryStreamExt as _;
 
         let (randomness, epoch_index) = loop {
-            match self.cc3.fetch_babe_randomness_two_epoch_ego().await {
+            match self.cc3.fetch_babe_randomness_two_epoch_ago().await {
                 Ok(babe) => break babe,
                 Err(err) => {
                     self.reconnect(Error::Client(err)).await?;

--- a/common/cc-client/src/lib.rs
+++ b/common/cc-client/src/lib.rs
@@ -217,7 +217,7 @@ impl Client {
 
     /// Fetches the babe randomness from 2 epochs ago
     /// Returns the random a time + the current block number (where it was calculated from)
-    pub async fn fetch_babe_randomness_two_epoch_ego(&self) -> Result<(Randomness, u64), Error> {
+    pub async fn fetch_babe_randomness_two_epoch_ago(&self) -> Result<(Randomness, u64), Error> {
         let epoch_index = self
             .api()
             .storage()


### PR DESCRIPTION
Fixes a typo in the function name: `ego` → `ago`.

Updated both the definition in `common/cc-client/src/lib.rs` and the call site in `attestor/attestor/src/worker/validation/mod.rs`.

Addresses https://github.com/chainlight-io/2026-q1-ctc-usc-phase2-audit-issues/issues/15 point 2