### PR TITLE
CSUB-2023: Reduce number of self-hosted runners for integration-test-cli & attestor-cli CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1259,8 +1259,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-  deploy-runner-attestor-cli:
+  attestor-cli-testing:
     needs:
+      - build-creditcoin-node-for-testing-ci
       - trigger-attestor-cli
     strategy:
       fail-fast: false
@@ -1278,46 +1279,8 @@ jobs:
             secret: valid-proxy
             proxy_type: All
 
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}-attestor-cli"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-4"
-      WORKFLOW_ID: "${{ github.run_id }}-attestor-cli"
-      proxy: ${{ matrix.proxy }}
-      secret: ${{ matrix.secret }}
-      proxy_type: ${{ matrix.proxy_type }}
-    secrets: inherit
-
-  attestor-cli-testing:
-    needs:
-      - build-creditcoin-node-for-testing-ci
-      - deploy-runner-attestor-cli
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - proxy: "no"
-
-          - proxy: "yes"
-            secret: no-funds
-
-          - proxy: "yes"
-            secret: not-a-proxy
-
-          - proxy: "yes"
-            secret: valid-proxy
-            proxy_type: All
-
     name: attestor-cli-testing / proxy=${{ matrix.proxy }} / ${{ matrix.secret }} / type=${{ matrix.proxy_type }}
-    runs-on:
-      [
-        self-hosted,
-        "workflow-${{ github.run_id }}-attestor-cli",
-        "proxy-${{ matrix.proxy }}",
-        "secret-${{ matrix.secret }}",
-        "type-${{ matrix.proxy_type }}",
-      ]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 
@@ -1438,34 +1401,6 @@ jobs:
           path: |
             /tmp/attestor-*.std*
             /tmp/creditcoin3-node-*.std*
-
-  rm-gh-runner-attestor-cli:
-    needs:
-      - attestor-cli-testing
-    if: ${{ always() }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - proxy: "no"
-
-          - proxy: "yes"
-            secret: no-funds
-
-          - proxy: "yes"
-            secret: not-a-proxy
-
-          - proxy: "yes"
-            secret: valid-proxy
-            proxy_type: All
-
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}-attestor-cli"
-      proxy: ${{ matrix.proxy }}
-      secret: ${{ matrix.secret }}
-      proxy_type: ${{ matrix.proxy_type }}
-    secrets: inherit
 
   regenerate-metadata:
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,7 @@ jobs:
 
       - name: Start Ethereum simulation with Anvil - 2 chains
         run: |
-          # first install it
+          export FOUNDRY_DIR="$HOME/.foundry"
           curl -L https://foundry.paradigm.xyz | bash
           ~/.foundry/bin/foundryup
 
@@ -787,7 +787,6 @@ jobs:
       - name: Start Ethereum simulation with Anvil
         run: |
           export FOUNDRY_DIR="$HOME/.foundry"
-          # first install it
           curl -L https://foundry.paradigm.xyz | bash
           ~/.foundry/bin/foundryup
 
@@ -997,11 +996,8 @@ jobs:
           .github/wait-for-creditcoin.sh 'http://127.0.0.1:9944'
 
       - name: Deploy contract via forge create
-        env:
-          # otherwise foundry ends up in ~/.config/.foundry/
-          XDG_CONFIG_HOME: ${{ env.HOME }}
         run: |
-          # first install it
+          export FOUNDRY_DIR="$HOME/.foundry"
           curl -L https://foundry.paradigm.xyz | bash
           ~/.foundry/bin/foundryup
 
@@ -1152,7 +1148,6 @@ jobs:
       - name: Start Ethereum simulation with Anvil - several chains
         run: |
           export FOUNDRY_DIR="$HOME/.foundry"
-          # first install it
           curl -L https://foundry.paradigm.xyz | bash
           ~/.foundry/bin/foundryup
 
@@ -1442,7 +1437,7 @@ jobs:
 
       - name: Start Ethereum simulation with Anvil
         run: |
-          # first install it
+          export FOUNDRY_DIR="$HOME/.foundry"
           curl -L https://foundry.paradigm.xyz | bash
           ~/.foundry/bin/foundryup
 
@@ -1796,7 +1791,6 @@ jobs:
       - name: Start Ethereum simulation with Anvil
         run: |
           export FOUNDRY_DIR="$HOME/.foundry"
-          # first install it
           curl -L https://foundry.paradigm.xyz | bash
           ~/.foundry/bin/foundryup
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,45 +175,6 @@ jobs:
             # metadata-cmp-with-mainnet.txt
             metadata-cmp-with-testnet.txt
 
-  rm-gh-runner-integration-test-cli:
-    needs:
-      - integration-test-cli
-    if: ${{ always() }}
-
-    # WARNING: same matrix as integration-test-cli job
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # runners for integration-test-cli-jobs
-          - proxy: "no"
-
-          - proxy: "yes"
-            secret: no-funds
-
-          - proxy: "yes"
-            secret: not-a-proxy
-
-          - proxy: "yes"
-            secret: valid-proxy
-            proxy_type: Staking
-
-          - proxy: "yes"
-            secret: valid-proxy
-            proxy_type: NonTransfer
-
-          - proxy: "yes"
-            secret: valid-proxy
-            proxy_type: All
-
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy: ${{ matrix.proxy }}
-      secret: ${{ matrix.secret }}
-      proxy_type: ${{ matrix.proxy_type }}
-    secrets: inherit
-
   rm-gh-runner-attestator-network:
     needs:
       - integration-test-attestator-network
@@ -535,43 +496,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-  deploy-runner-integration-test-cli:
-    needs:
-      - trigger-integration-test-cli
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - proxy: "no"
-
-          - proxy: "yes"
-            secret: no-funds
-
-          - proxy: "yes"
-            secret: not-a-proxy
-
-          - proxy: "yes"
-            secret: valid-proxy
-            proxy_type: Staking
-
-          - proxy: "yes"
-            secret: valid-proxy
-            proxy_type: NonTransfer
-
-          - proxy: "yes"
-            secret: valid-proxy
-            proxy_type: All
-
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-6"
-      proxy: ${{ matrix.proxy }}
-      secret: ${{ matrix.secret }}
-      proxy_type: ${{ matrix.proxy_type }}
-    secrets: inherit
-
   integration-test-cli:
     strategy:
       fail-fast: false
@@ -600,15 +524,8 @@ jobs:
     name: integration-test-cli / proxy=${{ matrix.proxy }} / ${{ matrix.secret }} / type=${{ matrix.proxy_type }}
     needs:
       - build-creditcoin-node-for-testing-ci
-      - deploy-runner-integration-test-cli
-    runs-on:
-      [
-        self-hosted,
-        "workflow-${{ github.run_id }}",
-        "proxy-${{ matrix.proxy }}",
-        "secret-${{ matrix.secret }}",
-        "type-${{ matrix.proxy_type }}",
-      ]
+      - trigger-integration-test-cli
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1530,7 +1447,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # runners for integration-test-cli-jobs
           - proxy: "no"
 
           - proxy: "yes"

--- a/.github/workflows/proof-gen-api-server.yml
+++ b/.github/workflows/proof-gen-api-server.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install Anvil
         run: |
-          # first install it
+          export FOUNDRY_DIR="$HOME/.foundry"
           curl -L https://foundry.paradigm.xyz | bash
           ~/.foundry/bin/foundryup
 
@@ -180,7 +180,7 @@ jobs:
 
       - name: Start Ethereum simulation with Anvil
         run: |
-          # first install it
+          export FOUNDRY_DIR="$HOME/.foundry"
           curl -L https://foundry.paradigm.xyz | bash
           ~/.foundry/bin/foundryup
 
@@ -415,7 +415,6 @@ jobs:
       - name: Start Ethereum simulation with Anvil
         run: |
           export FOUNDRY_DIR="$HOME/.foundry"
-          # first install it
           curl -L https://foundry.paradigm.xyz | bash
           ~/.foundry/bin/foundryup
 


### PR DESCRIPTION
# Description of proposed changes

CI jobs running on GitHub hosted:
https://github.com/gluwa/creditcoin3/actions/runs/24666584104

same CI jobs running on self-hosted:
https://github.com/gluwa/creditcoin3/actions/runs/24665626997?pr=779

execution duration is nearly identical
