### PR TITLE
CSUB-2023: Remove self-hosted for check-snapshot CI jobs

### DIFF
--- a/.github/workflows/check-devnet-snapshot.yml
+++ b/.github/workflows/check-devnet-snapshot.yml
@@ -10,19 +10,7 @@ name: Check CC3 Devnet Snapshot
 permissions: read-all
 
 jobs:
-  deploy-runner:
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "us-ord"
-      # Shared CPU, Linode 32 GB, 8 vCPU, disk: 640 GB, 0.288 $/hr
-      LINODE_VM_SIZE: "g6-standard-8"
-      proxy_type: "devnet"
-    secrets: inherit
-
   check-snapshot:
-    needs:
-      - deploy-runner
     # b/c of azure/login
     permissions:
       id-token: write
@@ -30,16 +18,5 @@ jobs:
     uses: ./.github/workflows/check-snapshot.yml
     with:
       target-chain: "devnet"
-      runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'type-devnet']"
-    secrets: inherit
-
-  remove-runner:
-    needs:
-      - deploy-runner
-      - check-snapshot
-    if: ${{ always() }}
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy_type: "devnet"
+      runs-on: "['ubuntu-24.04']"
     secrets: inherit

--- a/.github/workflows/check-testnet-snapshot.yml
+++ b/.github/workflows/check-testnet-snapshot.yml
@@ -10,19 +10,7 @@ name: Check Testnet Snapshot
 permissions: read-all
 
 jobs:
-  deploy-runner:
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "us-ord"
-      # Shared CPU, Linode 32 GB, 8 vCPU, disk: 640 GB, 0.288 $/hr
-      LINODE_VM_SIZE: "g6-standard-8"
-      proxy_type: "testnet"
-    secrets: inherit
-
   check-snapshot:
-    needs:
-      - deploy-runner
     # b/c of azure/login
     permissions:
       id-token: write
@@ -30,16 +18,5 @@ jobs:
     uses: ./.github/workflows/check-snapshot.yml
     with:
       target-chain: "testnet"
-      runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'type-testnet']"
-    secrets: inherit
-
-  remove-runner:
-    needs:
-      - deploy-runner
-      - check-snapshot
-    if: ${{ always() }}
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy_type: "testnet"
+      runs-on: "['ubuntu-24.04']"
     secrets: inherit


### PR DESCRIPTION
# Description of proposed changes

Not removing self-hosted here otherwise we run out of disk space:

```
[8](https://github.com/gluwa/creditcoin3/actions/runs/24777306818/job/72498798706#step:10:22999)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
OSError: [Errno 28] No space left on device
```

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
