### PR TITLE
CSUB-2023: Remove self-hosted runners for proof-gen-api-server workflow

### DIFF
--- a/.github/workflows/proof-gen-api-server.yml
+++ b/.github/workflows/proof-gen-api-server.yml
@@ -106,32 +106,10 @@ jobs:
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-build-proof-gen']"
     secrets: inherit
 
-  deploy-runner-submit-proof:
-    needs:
-      - build-everything
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-4"
-      proxy: "submit-proof"
-    secrets: inherit
-
-  rm-gh-runner-submit-proof:
-    needs:
-      - exercise-scripts
-    if: ${{ always() }}
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy: "submit-proof"
-    secrets: inherit
-
   exercise-scripts:
     needs:
-      - deploy-runner-submit-proof
-    runs-on:
-      [self-hosted, "workflow-${{ github.run_id }}", "proxy-submit-proof"]
+      - build-everything
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/proof-gen-api-server.yml
+++ b/.github/workflows/proof-gen-api-server.yml
@@ -18,14 +18,7 @@ permissions: read-all
 
 jobs:
   integration-tests:
-    needs:
-      - deploy-runner-proof-gen-api-server-integration-tests
-    runs-on:
-      [
-        self-hosted,
-        "workflow-${{ github.run_id }}",
-        "proxy-proof-gen-api-server-integration-tests",
-      ]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 
@@ -83,25 +76,6 @@ jobs:
         with:
           name: coverage-report
           path: target/llvm-cov/html/
-
-  deploy-runner-proof-gen-api-server-integration-tests:
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-4"
-      proxy: "proof-gen-api-server-integration-tests"
-    secrets: inherit
-
-  rm-gh-runner-proof-gen-api-server-integration-tests:
-    needs:
-      - integration-tests
-    if: ${{ always() }}
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy: "proof-gen-api-server-integration-tests"
-    secrets: inherit
 
   deploy-runner-build-proof-gen:
     uses: ./.github/workflows/deploy-runner.yml


### PR DESCRIPTION
self-hosted integration tests, ~ 8 min:
https://github.com/gluwa/creditcoin3/actions/runs/24768703049/job/72470047580

GH hosted integration tests, 9min:
https://github.com/gluwa/creditcoin3/actions/runs/24779685384/job/72507113391


self-hosted exercise-scripts, 21 min:
https://github.com/gluwa/creditcoin3/actions/runs/24768703049/job/72474782590

GH hosted exercise-scripts, 21 min:
https://github.com/gluwa/creditcoin3/actions/runs/24779685384/job/72512919631