### PR TITLE
CSUB-2023: Remove self-hosted runners for rust.yml workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,9 +89,7 @@ jobs:
           taplo format --check
 
   cargo-check:
-    needs:
-      - deploy-runner-check
-    runs-on: [self-hosted, "workflow-${{ github.run_id }}", "proxy-check"]
+    runs-on: ubuntu-24.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -263,15 +261,6 @@ jobs:
           name: coverage-report
           path: target/llvm-cov/html/
 
-  deploy-runner-check:
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-4"
-      proxy: "check"
-    secrets: inherit
-
   deploy-runner-unit-test-creditcoin:
     uses: ./.github/workflows/deploy-runner.yml
     with:
@@ -279,16 +268,6 @@ jobs:
       LINODE_REGION: "nl-ams"
       LINODE_VM_SIZE: "g6-standard-4"
       proxy: "unit-test-creditcoin"
-    secrets: inherit
-
-  rm-gh-runner-check:
-    needs:
-      - cargo-check
-    if: ${{ always() }}
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy: "check"
     secrets: inherit
 
   rm-gh-runner-unit-test-creditcoin:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -186,14 +186,7 @@ jobs:
         uses: bnjbvr/cargo-machete@main
 
   cargo-test:
-    needs:
-      - deploy-runner-unit-test-creditcoin
-    runs-on:
-      [
-        self-hosted,
-        "workflow-${{ github.run_id }}",
-        "proxy-unit-test-creditcoin",
-      ]
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -260,22 +253,3 @@ jobs:
         with:
           name: coverage-report
           path: target/llvm-cov/html/
-
-  deploy-runner-unit-test-creditcoin:
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-4"
-      proxy: "unit-test-creditcoin"
-    secrets: inherit
-
-  rm-gh-runner-unit-test-creditcoin:
-    needs:
-      - cargo-test
-    if: ${{ always() }}
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy: "unit-test-creditcoin"
-    secrets: inherit

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -133,9 +133,7 @@ jobs:
           SKIP_WASM_BUILD=1 cargo check --features=runtime-benchmarks --release
 
   cargo-clippy:
-    needs:
-      - deploy-runner-clippy
-    runs-on: [self-hosted, "workflow-${{ github.run_id }}", "proxy-clippy"]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 
@@ -265,15 +263,6 @@ jobs:
           name: coverage-report
           path: target/llvm-cov/html/
 
-  deploy-runner-clippy:
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-4"
-      proxy: "clippy"
-    secrets: inherit
-
   deploy-runner-check:
     uses: ./.github/workflows/deploy-runner.yml
     with:
@@ -290,16 +279,6 @@ jobs:
       LINODE_REGION: "nl-ams"
       LINODE_VM_SIZE: "g6-standard-4"
       proxy: "unit-test-creditcoin"
-    secrets: inherit
-
-  rm-gh-runner-clippy:
-    needs:
-      - cargo-clippy
-    if: ${{ always() }}
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy: "clippy"
     secrets: inherit
 
   rm-gh-runner-check:


### PR DESCRIPTION
clippy self-hosted, 35 min:
https://github.com/gluwa/creditcoin3/actions/runs/24783953960/job/72523750782

clippy GH hosted, ~ 37 min:
https://github.com/gluwa/creditcoin3/actions/runs/24784825201/job/72525734960

cargo-check, self-hosted: 16-176 min:
https://github.com/gluwa/creditcoin3/actions/runs/24783953960/job/72524049303

cargo-check, GH hosted, 17-18 min:
https://github.com/gluwa/creditcoin3/actions/runs/24784825201/job/72525735052


cargo-test self-hosted, 41-42 min:
https://github.com/gluwa/creditcoin3/actions/runs/24783953960/job/72523622462

cargo-test, GH hosted, 45 min:
https://github.com/gluwa/creditcoin3/actions/runs/24784825201/job/72525735082

Looks like a small tradeoff. 