### PR TITLE
CSUB-2023: Remove self-hosted runners for build jobs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,34 +20,13 @@ permissions: read-all
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  deploy-runner-build-creditcoin-for-testing-benchmarks:
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-6"
-      proxy: "build-creditcoin-node-for-testing-benchmarks"
-    secrets: inherit
-
   build-creditcoin-node-for-testing-benchmarks:
-    needs:
-      - deploy-runner-build-creditcoin-for-testing-benchmarks
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release --features=runtime-benchmarks"
       version-string: testing-benchmarks
       cache-key-name: build-creditcoin-node
-      runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-build-creditcoin-node-for-testing-benchmarks']"
-    secrets: inherit
-
-  rm-gh-runner-build-creditcoin-node-for-testing-benchmarks:
-    needs:
-      - build-creditcoin-node-for-testing-benchmarks
-    if: ${{ always() }}
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy: "build-creditcoin-node-for-testing-benchmarks"
+      runs-on: "['ubuntu-24.04']"
     secrets: inherit
 
   deploy-runner-benchmark:

--- a/.github/workflows/chainspec.yml
+++ b/.github/workflows/chainspec.yml
@@ -20,58 +20,22 @@ permissions: read-all
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  deploy-runner-build-creditcoin-for:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - proxy: build-creditcoin-node-for-devnet
-          - proxy: build-creditcoin-node-for-testnet
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-6"
-      proxy: ${{ matrix.proxy }}
-    secrets: inherit
-
   build-creditcoin-node-for-devnet:
-    needs:
-      - deploy-runner-build-creditcoin-for
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release --features=devnet"
       version-string: devnet
       cache-key-name: build-creditcoin-node
-      runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-build-creditcoin-node-for-devnet']"
+      runs-on: "['ubuntu-24.04']"
     secrets: inherit
 
   build-creditcoin-node-for-testnet:
-    needs:
-      - deploy-runner-build-creditcoin-for
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release"
       version-string: testnet
       cache-key-name: build-creditcoin-node
-      runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-build-creditcoin-node-for-testnet']"
-    secrets: inherit
-
-  rm-gh-runner-build-creditcoin-node:
-    needs:
-      - build-creditcoin-node-for-devnet
-      - build-creditcoin-node-for-testnet
-    if: ${{ always() }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - proxy: build-creditcoin-node-for-devnet
-          - proxy: build-creditcoin-node-for-testnet
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy: ${{ matrix.proxy }}
+      runs-on: "['ubuntu-24.04']"
     secrets: inherit
 
   integration-test-chainspec:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,27 +101,10 @@ jobs:
               - "**Cargo**"
               - ".github/workflows/ci.yml"
 
-  deploy-runner-build-creditcoin-for-testing:
-    needs:
-      - should-run
-    if: toJSON(needs.should-run.outputs.changes) != '[]'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - proxy: build-creditcoin-node-for-testing-ci
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-6"
-      proxy: ${{ matrix.proxy }}
-    secrets: inherit
-
   build-creditcoin-node-for-testing-ci:
     needs:
       - should-run
-      - deploy-runner-build-creditcoin-for-testing
+    if: toJSON(needs.should-run.outputs.changes) != '[]'
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release --features=fast-runtime"
@@ -129,7 +112,7 @@ jobs:
       build-subxt: ${{ needs.should-run.outputs.regenerate_metadata == 'true' }}
       version-string: testing-ci
       cache-key-name: build-creditcoin-node
-      runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-build-creditcoin-node-for-testing-ci']"
+      runs-on: "['ubuntu-24.04']"
     secrets: inherit
 
   integration-test-check-extrinsics:
@@ -174,21 +157,6 @@ jobs:
             # disabled until we have mainnet
             # metadata-cmp-with-mainnet.txt
             metadata-cmp-with-testnet.txt
-
-  rm-gh-runner-build-creditcoin-node-for-testing:
-    needs:
-      - build-creditcoin-node-for-testing-ci
-    if: ${{ always() }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - proxy: build-creditcoin-node-for-testing-ci
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy: ${{ matrix.proxy }}
-    secrets: inherit
 
   integration-test-attestator-network:
     # b/c of azure/login
@@ -1438,40 +1406,19 @@ jobs:
           name: new-metadata.diff
           path: /var/tmp/new-metadata.diff
 
-  deploy-runner-rebuild-new-metadata:
-    needs:
-      - regenerate-metadata
-    if: ${{ needs.regenerate-metadata.outputs.git_diff == 'true' }}
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-6"
-      proxy: "rebuild-new-metadata"
-    secrets: inherit
-
   rebuild-new-metadata:
     # checkov:skip=CKV2_GHA_1:We need this for typedefs auto-commit
     permissions: write-all
     needs:
-      - deploy-runner-rebuild-new-metadata
+      - regenerate-metadata
+    if: ${{ needs.regenerate-metadata.outputs.git_diff == 'true' }}
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release"
       version-string: new-metadata
       cache-key-name: build-creditcoin-node
       use-new-metadata: true
-      runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-rebuild-new-metadata']"
-    secrets: inherit
-
-  rm-runner-rebuild-new-metadata:
-    needs:
-      - rebuild-new-metadata
-    if: ${{ always() }}
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy: "rebuild-new-metadata"
+      runs-on: "['ubuntu-24.04']"
     secrets: inherit
 
   hello-bridge:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,13 +24,11 @@ permissions: read-all
 
 jobs:
   docker-build:
-    needs:
-      - deploy-runner-docker-build
     uses: ./.github/workflows/build-docker.yml
     with:
       build-options: "BUILD_ARGS="
       version-string: "latest"
-      runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-docker-build']"
+      runs-on: "['ubuntu-24.04']"
 
   docker-test:
     needs:
@@ -130,22 +128,3 @@ jobs:
         with:
           name: docker-logs
           path: docker-*.log
-
-  deploy-runner-docker-build:
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-6"
-      proxy: "docker-build"
-    secrets: inherit
-
-  rm-gh-runner-docker-build:
-    needs:
-      - docker-build
-    if: ${{ always() }}
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy: "docker-build"
-    secrets: inherit

--- a/.github/workflows/proof-gen-api-server.yml
+++ b/.github/workflows/proof-gen-api-server.yml
@@ -77,33 +77,12 @@ jobs:
           name: coverage-report
           path: target/llvm-cov/html/
 
-  deploy-runner-build-proof-gen:
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-6"
-      proxy: "build-proof-gen"
-    secrets: inherit
-
-  rm-gh-runner-build-proof-gen:
-    needs:
-      - build-everything
-    if: ${{ always() }}
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy: "build-proof-gen"
-    secrets: inherit
-
   build-everything:
-    needs:
-      - deploy-runner-build-proof-gen
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release --features=fast-runtime"
       version-string: testing-proof-gen
-      runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-build-proof-gen']"
+      runs-on: "['ubuntu-24.04']"
     secrets: inherit
 
   exercise-scripts:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,35 +130,15 @@ jobs:
       previous-release: "${{ needs.setup.outputs.previous_release }}"
     secrets: inherit
 
-  deploy-github-runner:
-    needs:
-      - sanity-check
-      - setup
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # runners for other jobs (repurpose existing labels)
-          - build: docker
-          - build: native
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-6"
-      proxy_type: ${{ matrix.build }}
-    secrets: inherit
-
   build-native-runtime:
     needs:
       - sanity-check
       - setup
-      - deploy-github-runner
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release ${{ needs.setup.outputs.build_options}}"
       version-string: "${{ needs.sanity-check.outputs.TAG_NAME }}-x86_64-unknown-linux-gnu"
-      runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'type-native']"
+      runs-on: "['ubuntu-24.04']"
     secrets: inherit
 
   build-wasm-runtime:
@@ -175,12 +155,11 @@ jobs:
     needs:
       - sanity-check
       - setup
-      - deploy-github-runner
     uses: ./.github/workflows/build-docker.yml
     with:
       build-options: "BUILD_ARGS=${{ needs.setup.outputs.build_options }}"
       version-string: ${{ needs.sanity-check.outputs.TAG_NAME }}
-      runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'type-docker']"
+      runs-on: "['ubuntu-24.04']"
     secrets: inherit
 
   create-release:
@@ -270,21 +249,3 @@ jobs:
           status: ${{ job.status }}
           channel: "#protocol-internal"
           message: "Release pipeline finished! cc <@U028EMRHS3S>"
-
-  rm-gh-runner-docker:
-    needs:
-      - docker-build
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy_type: "docker"
-    secrets: inherit
-
-  rm-gh-runner-native:
-    needs:
-      - build-native-runtime
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy_type: "native"
-    secrets: inherit

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -108,35 +108,13 @@ jobs:
           path: "last-block*"
           if-no-files-found: error
 
-  deploy-runner-build-sut:
-    uses: ./.github/workflows/deploy-runner.yml
-    with:
-      EPHEMERAL: false
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      LINODE_REGION: "nl-ams"
-      LINODE_VM_SIZE: "g6-standard-6"
-      proxy_type: "native"
-    secrets: inherit
-
   build-sut:
-    needs:
-      - deploy-runner-build-sut
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release"
       version-string: PR
       cache-key-name: build-creditcoin-node
-      runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'type-native']"
-    secrets: inherit
-
-  remove-runner-build-sut:
-    needs:
-      - build-sut
-    if: ${{ always() }}
-    uses: ./.github/workflows/remove-runner.yml
-    with:
-      RUNNER_VM_NAME: "${{ github.event.repository.name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
-      proxy_type: "native"
+      runs-on: "['ubuntu-24.04']"
     secrets: inherit
 
   setup-self-hosted:


### PR DESCRIPTION
Some stats between the latest build jobs using self-hosted vs GH hosted: 

* benchmarks: 27 min -> 40 min 
* chainspec: 27+27 min -> 37 + 37 min (runs in parallel)
* ci: 30 min -> 51 min
  * build with new metadata not triggered but expect 37- 40 mins in the worst case
* docker: 31 min -> 41 min

Clearly there is a tradeoff to be made here. 

Risk areas: release.yml vs. ci.yml+docker.yml - ideally these 3 will be using the same runner (either self-hosted or GH hosted) to minimize the risk of failures during release just because the platform is different! It's a small risk and most likely if something were to fail it would be related to 3rd party (difference in ENV, path changed silently, etc). 