### PR TITLE
CSUB-2030: Don't build auxiliary binaries for every CI execution - publish & download them as release artifacts

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -13,6 +13,9 @@ name: Reusable workflow to build WASM runtime
       runs-on:
         required: true
         type: string
+      build-subwasm:
+        required: false
+        type: boolean
 
 permissions: read-all
 
@@ -62,3 +65,17 @@ jobs:
           name: binary-for-wasm
           path: "*.wasm"
           if-no-files-found: error
+
+      - name: Install subwasm
+        if: ${{ inputs.build-subwasm }}
+        uses: gluwa/cargo@dev
+        with:
+          command: install
+          args: --locked --git https://github.com/chevdor/subwasm --tag v0.21.3
+
+      - name: Upload subwasm binary
+        if: ${{ inputs.build-subwasm }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: subwasm
+          path: ~/.cargo/bin/subwasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       integration_test_blockchain: ${{ steps.filter.outputs.integration_test_blockchain }}
       integration_test_cli: ${{ steps.filter.outputs.integration_test_cli }}
       regenerate_metadata: ${{ steps.filter.outputs.regenerate_metadata }}
+      devnet_release_tag: ${{ steps.devnet-env.outputs.release_tag }}
     steps:
       - uses: actions/checkout@v6
 
@@ -101,6 +102,16 @@ jobs:
               - "**Cargo**"
               - ".github/workflows/ci.yml"
 
+      - name: Devnet ENV
+        id: devnet-env
+        run: |
+          # shellcheck disable=SC2129
+          RELEASE_TAG=$(.github/extract-release-tag.sh "devnet")
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+
   deploy-runner-build-creditcoin-for-testing:
     needs:
       - should-run
@@ -126,7 +137,6 @@ jobs:
     with:
       build-options: "--release --features=fast-runtime"
       build-subkey: ${{ needs.should-run.outputs.attestor_cli_testing == 'true' }}
-      build-subxt: ${{ needs.should-run.outputs.regenerate_metadata == 'true' }}
       git-lfs-checkout: false
       version-string: testing-ci
       cache-key-name: build-creditcoin-node
@@ -1335,12 +1345,6 @@ jobs:
           name: binary-for-testing-ci
           path: target/release
 
-      - name: Download subxt binary
-        uses: actions/download-artifact@v8
-        with:
-          name: subxt
-          path: ~/.cargo/bin
-
       - name: Start creditcoin3-node in order to update typedefs
         run: |
           chmod a+x ./target/release/creditcoin3-node
@@ -1369,15 +1373,24 @@ jobs:
         run: |
           yarn install
 
+      - name: Download subxt from release ${{ needs.should-run.outputs.devnet_release_tag }}
+        uses: i3h/download-release-asset@v1
+        with:
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          tag: ${{ needs.should-run.outputs.devnet_release_tag }}
+          file: subxt
+          path: /usr/local/bin
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+
       - name: Auto-update typedefs
         id: update_typedefs
         working-directory: ./cli
         run: |
           ./get-metadata.sh
 
-          chmod a+x ~/.cargo/bin/subxt
-          sudo cp ~/.cargo/bin/subxt /usr/local/bin
-          subxt --help
+          sudo chmod a+x /usr/local/bin/subxt
+          subxt version
 
           subxt metadata -f bytes > ../common/cc-client/artifacts/metadata.scale
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,6 @@ jobs:
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release --features=fast-runtime"
-      build-subkey: ${{ needs.should-run.outputs.attestor_cli_testing == 'true' }}
       git-lfs-checkout: false
       version-string: testing-ci
       cache-key-name: build-creditcoin-node
@@ -1209,18 +1208,21 @@ jobs:
           name: binary-for-testing-ci
           path: target/release
 
-      - name: Download subkey binary
-        uses: actions/download-artifact@v8
+      - name: Download subkey from release ${{ needs.should-run.outputs.devnet_release_tag }}
+        uses: i3h/download-release-asset@v1
         with:
-          name: subkey
-          path: ~/.cargo/bin
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          tag: ${{ needs.should-run.outputs.devnet_release_tag }}
+          file: subkey
+          path: /usr/local/bin
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
       - name: Start creditcoin3-node
         run: |
           chmod a+x ./target/release/attestor
 
-          chmod a+x ~/.cargo/bin/subkey
-          sudo cp ~/.cargo/bin/subkey /usr/local/bin
+          sudo chmod a+x /usr/local/bin/subkey
           subkey --version
 
           chmod a+x ./target/release/creditcoin3-node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,8 @@ jobs:
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release ${{ needs.setup.outputs.build_options}}"
+      build-subkey: true
+      build-subxt: true
       git-lfs-checkout: true
       version-string: "${{ needs.sanity-check.outputs.TAG_NAME }}-x86_64-unknown-linux-gnu"
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'type-native']"
@@ -169,6 +171,7 @@ jobs:
     uses: ./.github/workflows/build-wasm.yml
     with:
       build-options: "${{ needs.setup.outputs.build_options }}"
+      build-subwasm: true
       version-string: ${{ needs.sanity-check.outputs.TAG_NAME }}
       runs-on: "['ubuntu-24.04']"
 
@@ -210,6 +213,27 @@ jobs:
         with:
           path: artifact
           pattern: binary-for-*
+          merge-multiple: true
+
+      - name: Download subkey
+        uses: actions/download-artifact@v8
+        with:
+          path: artifact
+          name: subkey
+          merge-multiple: true
+
+      - name: Download subwasm
+        uses: actions/download-artifact@v8
+        with:
+          path: artifact
+          name: subwasm
+          merge-multiple: true
+
+      - name: Download subxt
+        uses: actions/download-artifact@v8
+        with:
+          path: artifact
+          name: subxt
           merge-multiple: true
 
       - name: Download changelog
@@ -258,6 +282,9 @@ jobs:
             artifact/attestor-binaries-${{ needs.sanity-check.outputs.TAG_NAME }}*
             artifact/creditcoin-${{ needs.sanity-check.outputs.TAG_NAME }}*
             artifact/proof-gen-api-server-${{ needs.sanity-check.outputs.TAG_NAME }}*
+            artifact/subkey
+            artifact/subwasm
+            artifact/subxt
             precompiles/metadata/abi/*.json
           fail_on_unmatched_files: true
           name: ${{ needs.sanity-check.outputs.TAG_NAME  }}

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -25,6 +25,7 @@ jobs:
       rpc_url: ${{ steps.testnet-env.outputs.rpc_url || steps.mainnet-env.outputs.rpc_url }}
       https_rpc_url: ${{ steps.testnet-env.outputs.https_rpc_url || steps.mainnet-env.outputs.https_rpc_url }}
       release_tag: ${{ steps.testnet-env.outputs.release_tag || steps.mainnet-env.outputs.release_tag }}
+      devnet_release_tag: ${{ steps.devnet-env.outputs.release_tag }}
       snapshot_container: ${{ steps.testnet-env.outputs.snapshot_container || steps.mainnet-env.outputs.snapshot_container }}
       artifact_name: ${{ steps.testnet-env.outputs.artifact_name || steps.mainnet-env.outputs.artifact_name }}
       last_block_hash: ${{ steps.last-block-info.outputs.last_block_hash }}
@@ -37,6 +38,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt install -y jq
+
+      - name: Devnet ENV
+        id: devnet-env
+        run: |
+          # shellcheck disable=SC2129
+          RELEASE_TAG=$(.github/extract-release-tag.sh "devnet")
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Testnet ENV
         id: testnet-env
@@ -392,22 +403,15 @@ jobs:
           yarn install
           yarn build
 
-      - name: Configure rustc version
-        run: |
-          RUSTC_VERSION=$(grep channel rust-toolchain.toml | tail -n1 | tr -d " " | cut -f2 -d'"')
-          echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
-          sudo apt install -y gcc
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Download subwasm from release ${{ needs.setup.outputs.devnet_release_tag }}
+        uses: i3h/download-release-asset@v1
         with:
-          toolchain: ${{ env.RUSTC_VERSION }}
-
-      - name: Install Subwasm
-        uses: gluwa/cargo@dev
-        with:
-          command: install
-          args: --locked --git https://github.com/chevdor/subwasm --tag v0.21.3
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          tag: ${{ needs.setup.outputs.devnet_release_tag }}
+          file: subwasm
+          path: /usr/local/bin
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
       - name: Download WASM runtime from current PR
         id: download-wasm
@@ -418,6 +422,9 @@ jobs:
       - name: Upgrade WASM
         working-directory: cli
         run: |
+          sudo chmod a+x /usr/local/bin/subwasm
+          subwasm --version
+
           node dist/scripts/runtimeUpgrade.js ws://127.0.0.1:9944  ../creditcoin3_runtime.compact.compressed.wasm //Alice 0
         env:
           # WARNING: always quote otherwise we get "2E+24" which can't parse

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -22,28 +22,6 @@ jobs:
     uses: ./.github/workflows/build-wasm.yml
     with:
       build-options: "--features devnet"
+      build-subwasm: true
       version-string: ${{ github.sha }}
       runs-on: "['ubuntu-24.04']"
-
-  # try installing subwasm b/c we use this version in multiple places
-  # and need to know whether it builds with current rustc
-  dry-run-install-subwasm:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Configure rustc version
-        run: |
-          RUSTC_VERSION=$(grep channel rust-toolchain.toml | tail -n1 | tr -d " " | cut -f2 -d'"')
-          echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUSTC_VERSION }}
-
-      - name: Install Subwasm
-        uses: gluwa/cargo@dev
-        with:
-          command: install
-          args: --locked --git https://github.com/chevdor/subwasm --tag v0.21.3


### PR DESCRIPTION
# Description of proposed changes

NOTE:
an instumented release workflow execution can be seen at https://github.com/gluwa/creditcoin3/actions/runs/24999160051/job/73209579448

Just before we make the actual release & upload the artifacts we can see that subkey, subxt and subwasm files are present in the artifacts/ directory from which the release is created (expand step before the one which failed)!

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
