### PR TITLE
CSUB-2030: Parametrize git-lfs checkout for native builds

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release --features=runtime-benchmarks"
+      git-lfs-checkout: false
       version-string: testing-benchmarks
       cache-key-name: build-creditcoin-node
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-build-creditcoin-node-for-testing-benchmarks']"

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -11,6 +11,9 @@ name: Reusable workflow to build a native client
       version-string:
         required: true
         type: string
+      git-lfs-checkout:
+        required: true
+        type: boolean
       cache-key-name:
         required: false
         type: string
@@ -35,13 +38,13 @@ jobs:
         if: ${{ ! inputs.use-new-metadata }}
         uses: actions/checkout@v6
         with:
-          lfs: true
+          lfs: ${{ inputs.git-lfs-checkout }}
 
       - name: Checkout code for typedefs update
         if: ${{ inputs.use-new-metadata }}
         uses: actions/checkout@v6
         with:
-          lfs: true
+          lfs: ${{ inputs.git-lfs-checkout }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/chainspec.yml
+++ b/.github/workflows/chainspec.yml
@@ -41,6 +41,7 @@ jobs:
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release --features=devnet"
+      git-lfs-checkout: true
       version-string: devnet
       cache-key-name: build-creditcoin-node
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-build-creditcoin-node-for-devnet']"
@@ -52,6 +53,7 @@ jobs:
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release"
+      git-lfs-checkout: true
       version-string: testnet
       cache-key-name: build-creditcoin-node
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-build-creditcoin-node-for-testnet']"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
       build-options: "--release --features=fast-runtime"
       build-subkey: ${{ needs.should-run.outputs.attestor_cli_testing == 'true' }}
       build-subxt: ${{ needs.should-run.outputs.regenerate_metadata == 'true' }}
+      git-lfs-checkout: false
       version-string: testing-ci
       cache-key-name: build-creditcoin-node
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-build-creditcoin-node-for-testing-ci']"
@@ -1455,6 +1456,7 @@ jobs:
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release"
+      git-lfs-checkout: false
       version-string: new-metadata
       cache-key-name: build-creditcoin-node
       use-new-metadata: true

--- a/.github/workflows/proof-gen-api-server.yml
+++ b/.github/workflows/proof-gen-api-server.yml
@@ -103,6 +103,7 @@ jobs:
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release --features=fast-runtime"
+      git-lfs-checkout: false
       version-string: testing-proof-gen
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-build-proof-gen']"
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,7 @@ jobs:
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release ${{ needs.setup.outputs.build_options}}"
+      git-lfs-checkout: true
       version-string: "${{ needs.sanity-check.outputs.TAG_NAME }}-x86_64-unknown-linux-gnu"
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'type-native']"
     secrets: inherit

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -124,6 +124,7 @@ jobs:
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release"
+      git-lfs-checkout: true
       version-string: PR
       cache-key-name: build-creditcoin-node
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'type-native']"


### PR DESCRIPTION
when running the majority of test jobs we don't really need chainspecs so don't checkout/build them in.
