### PR TITLE
test(block-prover): fix Frontier calldata threshold test timeout

### DIFF
--- a/cli/src/test/blockchain-tests/precompiles/block-prover.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/block-prover.test.ts
@@ -204,14 +204,27 @@ describe('Precompile: block-prover', (): void => {
 
                 expect(calldataSizeBytes).toBeGreaterThan(FRONTIER_CALLDATA_THRESHOLD);
 
+                // gasLimit reserves PoV via GasLimitPovSizeRatio (=14). 1M gas (~71 KiB PoV)
+                // avoids "Total block weight is exceeded" drops at block-build time.
+                // Fee must clear current basefee: cached gasPrice races with basefee changes
+                // from earlier tests, so use EIP-1559 with a fresh basefee fetch and 10x ceiling.
+                const POV_SAFE_GAS_LIMIT = 1_000_000n;
+                const latestBlock = await provider.getBlock('latest');
+                const baseFeePerGas = latestBlock?.baseFeePerGas ?? 1_000_000_000n;
+                const feeData = await provider.getFeeData();
+                const maxPriorityFeePerGas = feeData.maxPriorityFeePerGas ?? 1_000_000_000n;
+                const maxFeePerGas = baseFeePerGas * 10n + maxPriorityFeePerGas;
+
                 const tx = await alith.sendTransaction({
                     to: blockProverAddress,
                     data,
-                    gasLimit: 500_000,
-                    gasPrice,
+                    gasLimit: POV_SAFE_GAS_LIMIT,
+                    maxFeePerGas,
+                    maxPriorityFeePerGas,
                 });
 
-                const receipt = await tx.wait();
+                // Bound wait so a stuck tx surfaces as an error instead of consuming the Jest timeout.
+                const receipt = await tx.wait(1, 120_000);
                 expect(receipt).toBeDefined();
                 expect(receipt!.status).toBe(1);
 


### PR DESCRIPTION
## Why

CI fails on `Precompile: block-prover › Frontier calldata threshold (verifyAndEmit with calldata > 2893 bytes) › should succeed when calldata exceeds 2893-byte Frontier threshold`. Two failure modes have been seen on CI:

1. `Exceeded timeout of 360000 ms for a test.` (initial mode)
2. `wait for transaction timeout (code=TIMEOUT)` (after first patch added bounded wait)
3. `gas price less than block base fee` (intermittent, seen on `usc-dev` runs prior to PR #851)

Latest failing job (PR #851 / #878 base): https://github.com/gluwa/creditcoin3/actions/runs/25002899668/job/73195900215

## Root cause

Two issues compound to make this test unreliable:

### 1. `gasLimit` reserves too little PoV

On Frontier, `gas_limit` maps to PoV via `GasLimitPovSizeRatio = BLOCK_GAS_LIMIT / MAX_POV_SIZE = 14`. The runtime reserves `gas_limit / 14` bytes of PoV up front when it considers including the tx in a block.

- Original hardcoded `gasLimit: 500_000` reserves ~36 KiB of PoV - enough for this calldata.
- My first attempt replaced that with `provider.estimateGas() * 1.5` (~89k gas, ~6 KiB PoV) - **not enough**. The actual PoV consumed by a `verifyAndEmit` with 3851-byte calldata + state proofs exceeds 6 KiB, so block-build fails with `Total block weight is exceeded` and the pool drops the tx (`InvalidTransaction::Custom(2)`).

Confirmed in node logs from the failing run:

```
runtime::system: Total block weight is exceeded.
txpool: Reported as invalid. Will skip sub-chains while iterating.
txpool: Revalidation: invalid InvalidTransaction::Custom(2)
```

Fix: use `gasLimit: 1_000_000` (~71 KiB PoV) for headroom over the historically-working 500k.

### 2. Stale `gasPrice` racing with dynamic basefee

The test caches `gasPrice` in `beforeEach` from `provider.getFeeData()`. Frontier's `pallet_base_fee` adjusts basefee per block based on block fullness. By the time this test runs, the cached value can be below the current basefee, and the pool rejects with `gas price less than block base fee` (this is what failed PR #870's run on Apr 24 with the original code).

Fix: switch to EIP-1559 fees fetched fresh right before submission, with `maxFeePerGas = 10 * baseFee + maxPriorityFee` so basefee fluctuations are absorbed.

### 3. Bare `tx.wait()` masked the failures

`tx.wait()` polls forever, so any stuck-tx scenario consumed the full 360s Jest timeout silently. Bounded `tx.wait(1, 120_000)` now surfaces `wait for transaction timeout` as a real error, making future regressions debuggable.

## Verification

- `prettier --write` ✅
- `eslint --max-warnings 0` ✅
- `tsc --noEmit` ✅

CI will confirm the actual fix.

## Investigation notes

- Apr 24 PR #868 (commit `59510089`): test ✓ at 12356ms with hardcoded 500k.
- Apr 24 PR #870 (commit `02b02a95`): test ✕ with `gas price less than block base fee` — same code, different timing → flake.
- Apr 27 PR #851 / #878 (commit `8b8d9c7f` / `d90b6f82`): test ✕ with timeout → first patch's reduced gasLimit hit the PoV reservation issue.