### PR TITLE
Update USC SDK + added delay usage in tests

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -34,7 +34,7 @@
         "test:archiver": "jest --config src/test/archiver-tests.config.ts --silent --verbose --runInBand --forceExit src/test/archiver-tests"
     },
     "devDependencies": {
-        "@gluwa/usc-sdk": "0.9.0",
+        "@gluwa/usc-sdk": "0.11.0",
         "@polkadot/typegen": "16.5.2",
         "@types/graphqurl": "^1.0.3",
         "@types/jest": "29.5.14",

--- a/cli/src/test/blockchain-tests/precompiles/block-prover.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/block-prover.test.ts
@@ -99,6 +99,7 @@ describe('Precompile: block-prover', (): void => {
                     sourceTxn!.blockNumber!,
                     5_000, // 5 sec poll interval
                     300_000, // 5 min wait Timeout
+                    15_000, // 15 sec finality lag buffer
                 );
                 // we're now sure that there are enough attestations on the execution chain
 

--- a/cli/src/test/cc3-indexer-tests/handleTransactionVerified.test.ts
+++ b/cli/src/test/cc3-indexer-tests/handleTransactionVerified.test.ts
@@ -43,7 +43,16 @@ describe('handleTransactionVerified()', () => {
         expect(sourceTxn!.blockNumber).toBeDefined();
 
         const chainInfoProvider = new chainInfo.PrecompileChainInfoProvider(provider);
-        await chainInfoProvider.waitUntilHeightAttested(chain_Anvil1_Key, sourceTxn!.blockNumber!);
+        const pollIntervalMs = 5_000; // 5 sec poll interval
+        const timeoutMs = 60_000; // 1 min wait Timeout
+        const extraDelayMs = 15_000; // add 15 sec buffer to be sure that the block is finalized on the execution chain
+        await chainInfoProvider.waitUntilHeightAttested(
+            chain_Anvil1_Key,
+            sourceTxn!.blockNumber!,
+            pollIntervalMs,
+            timeoutMs,
+            extraDelayMs,
+        );
         // we're now sure that there are enough attestations on the execution chain
 
         const blockProvider = new proof.raw.blockProvider.SimpleBlockProvider(anvil1Provider);

--- a/cli/src/test/cc3-indexer-tests/handleTransactionVerified.test.ts
+++ b/cli/src/test/cc3-indexer-tests/handleTransactionVerified.test.ts
@@ -44,7 +44,7 @@ describe('handleTransactionVerified()', () => {
 
         const chainInfoProvider = new chainInfo.PrecompileChainInfoProvider(provider);
         const pollIntervalMs = 5_000; // 5 sec poll interval
-        const timeoutMs = 60_000; // 1 min wait Timeout
+        const timeoutMs = 120_000; // 2 min wait Timeout
         const extraDelayMs = 15_000; // add 15 sec buffer to be sure that the block is finalized on the execution chain
         await chainInfoProvider.waitUntilHeightAttested(
             chain_Anvil1_Key,

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -692,10 +692,10 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@gluwa/usc-sdk@0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@gluwa/usc-sdk/-/usc-sdk-0.9.0.tgz#ad8cbf16e4ac7953aead9d9ed86ebb6647c6fcb7"
-  integrity sha512-O1ziQTi5cLoP1ruaVxgbXzPBGlkil6jqo9VyWdjbYrtm9X0DtDz7OxZ9wVR7m0bkGKutF0pRbaAvKGI0E6R3LA==
+"@gluwa/usc-sdk@0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@gluwa/usc-sdk/-/usc-sdk-0.11.0.tgz#487acb6e627ece6c6b11d8d7c301f880aee66f0b"
+  integrity sha512-TygYUJjE3/VBARtAET+Rb5D4eCYkkmcR9H9RMt6DJVgMoB+knb5LKqPkeS3qG0Js1keZelGW8fafDvgaOX+Aqw==
   dependencies:
     axios "^1.13.2"
     dotenv "^17.2.3"


### PR DESCRIPTION
Updates usc-sdk to version 0.11.0 and makes use of the new `extraDelayMs` parameter in `waitUntilHeightAttested`