### PR TITLE
fix(pool): quorum panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,6 +1542,7 @@ dependencies = [
  "common",
  "futures 0.3.31",
  "parking_lot 0.12.3",
+ "pretty_assertions",
  "rstest 0.26.1",
  "sp-core",
  "stream",
@@ -3277,7 +3278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3457,6 +3458,12 @@ dependencies = [
  "syn 2.0.111",
  "unicode-xid",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "difflib"
@@ -10305,6 +10312,16 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -17859,6 +17876,12 @@ dependencies = [
  "static_assertions",
  "web-time",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ version = "3.111.0"
 [workspace.dependencies]
 assert_matches = "1.5.0"
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
+pretty_assertions = { version = "1.4.1" }
 proptest = "1.10.0"
 rstest = "0.26.1"
 sync_wrapper = "1.0.2"

--- a/attestor/pool/Cargo.toml
+++ b/attestor/pool/Cargo.toml
@@ -33,5 +33,6 @@ parking_lot = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+pretty_assertions = { workspace = true }
 rstest = { workspace = true }
 tokio-test = { workspace = true }

--- a/attestor/pool/src/lib.rs
+++ b/attestor/pool/src/lib.rs
@@ -1158,6 +1158,7 @@ impl AttestationPoolForks {
         }
 
         self.validate_quorum.target_quorum = quorum_new;
+        self.forks_best = self.find_best();
     }
 
     fn note_attestation_chain_reversion(&mut self, info: stream::util::AttestationInfo) {
@@ -2825,6 +2826,8 @@ mod test {
                 size: 1,
                 digest: attestation_2.compound_digest()
             }));
+
+            assert_eq!(forks.forks_best, Some(attestation_0.clone()));
         }
 
         sx.note_target_sample_size_change(1);
@@ -2843,6 +2846,8 @@ mod test {
                 size: 1,
                 digest: attestation_2.compound_digest()
             }));
+
+            assert_eq!(forks.forks_best, Some(attestation_0.clone()));
         }
     }
 
@@ -2885,6 +2890,8 @@ mod test {
                 size: 1,
                 digest: attestation_2.compound_digest()
             }));
+
+            assert_eq!(forks.forks_best, Some(attestation_2.clone()));
         }
 
         sx.note_target_sample_size_change(2);
@@ -2903,6 +2910,8 @@ mod test {
                 size: 1,
                 digest: attestation_2.compound_digest()
             }));
+
+            assert_eq!(forks.forks_best, Some(attestation_0));
         }
     }
 

--- a/attestor/pool/src/lib.rs
+++ b/attestor/pool/src/lib.rs
@@ -1124,6 +1124,42 @@ impl AttestationPoolForks {
             .note_attestation_interval_change(interval_new);
     }
 
+    /// Updating the target sample size is a sparse operation which may invalidate past quorums. As
+    /// a result, we discard all past quorums and recompute the set of quorums under the new target
+    /// sample size.
+    ///
+    /// While this has `O(n)` complexity, in practice this is a rare enough event that the cost of
+    /// recomputing quorums is negligible once amortized.
+    fn note_target_sample_size_change(&mut self, quorum_new: std::num::NonZeroUsize) {
+        self.quorums_by_height.clear();
+
+        let key_start = KeySize {
+            size: quorum_new.into(),
+            height: 0,
+            digest: CompoundDigest::min(),
+        };
+        let index = (
+            std::ops::Bound::Included(key_start),
+            std::ops::Bound::Unbounded,
+        );
+
+        for KeySize {
+            size,
+            height,
+            digest,
+        } in self.forks_by_size.range(index).copied()
+        {
+            let key_height = KeyHeight {
+                height,
+                size,
+                digest,
+            };
+            self.quorums_by_height.insert(key_height);
+        }
+
+        self.validate_quorum.target_quorum = quorum_new;
+    }
+
     fn note_attestation_chain_reversion(&mut self, info: stream::util::AttestationInfo) {
         tracing::debug!("Clearing forks");
 
@@ -1285,8 +1321,8 @@ impl AttestationPoolSender {
         *self.common.pool.lock() = AttestationPool::Closed;
     }
 
-    pub fn note_target_sample_size_change(&self, target_sample_size_new: u32) {
-        let threshold = attestor_primitives::calculate_threshold(target_sample_size_new) as usize;
+    pub fn note_target_sample_size_change(&self, target_sample_size: u32) {
+        let threshold = attestor_primitives::calculate_threshold(target_sample_size) as usize;
         let quorum_new = std::num::NonZeroUsize::new(threshold);
 
         let Some(quorum_new) = quorum_new else {
@@ -1297,7 +1333,7 @@ impl AttestationPoolSender {
             return;
         };
 
-        inner.forks.validate_quorum.target_quorum = quorum_new;
+        inner.forks.note_target_sample_size_change(quorum_new);
 
         if let Some(waker) = inner.wakers.pop_back() {
             tracing::debug!("Target sample size updated, waking receiver...");
@@ -2110,7 +2146,7 @@ mod test {
     #[tokio::test]
     #[rstest::rstest]
     #[timeout(TIMEOUT)]
-    async fn attestation_pool_sanity_mark_invalid(
+    async fn attestation_pool_sanity_mark_invalid_simple(
         _logs: (),
         #[from(attestation)]
         #[with([ATTESTOR_VALID_0])]
@@ -2132,6 +2168,49 @@ mod test {
 
         let (quorum_actual, permit, _digest_local) = rx.next().await.unwrap();
 
+        assert_eq!(quorum_actual, quorum_expected);
+        rx.mark_invalid(permit);
+
+        let mut pool = rx.common.pool.lock();
+        let inner = pool.expect_open();
+
+        assert!(inner.forks.votes_invalid.contains(&KeyDigest {
+            height: attestation_0.attestation.header_number(),
+            digest: attestation_0.compound_digest()
+        }));
+
+        assert!(inner.forks.votes_invalid.contains(&KeyDigest {
+            height: attestation_1.attestation.header_number(),
+            digest: attestation_1.compound_digest()
+        }));
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    #[timeout(TIMEOUT)]
+    async fn attestation_pool_sanity_mark_invalid_no_panic(
+        _logs: (),
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_0])]
+        attestation_0: AttestationVote,
+        #[from(quorum)]
+        #[with([ATTESTOR_VALID_0])]
+        quorum_expected: Quorum,
+        config: Config,
+    ) {
+        use futures::stream::StreamExt as _;
+
+        let (sx, mut rx) = attestation_pool(config);
+
+        assert!(sx.send(attestation_0.attestation.clone()).unwrap().is_ok());
+
+        // A vote which is note yet in `quorums_by_height` reaches quorum
+        sx.note_target_sample_size_change(1);
+
+        let (quorum_actual, permit, _digest_local) = rx.next().await.unwrap();
+
+        // `mark_invalid` removes quorum under new validation rules. `quorums_by_height` must have
+        // been updated by now or this will panic!
         assert_eq!(quorum_actual, quorum_expected);
         rx.mark_invalid(permit);
 
@@ -2211,6 +2290,55 @@ mod test {
     #[tokio::test]
     #[rstest::rstest]
     #[timeout(TIMEOUT)]
+    async fn attestation_pool_sanity_pending(
+        _logs: (),
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_0], 2, DIGEST_1)]
+        attestation_pending: AttestationVote,
+        config: Config,
+    ) {
+        let (mut sx, rx) = attestation_pool(config);
+
+        assert!(sx
+            .send(attestation_pending.attestation.clone())
+            .unwrap()
+            .is_ok());
+
+        {
+            let mut pool = rx.common.pool.lock();
+            let inner = pool.expect_open();
+
+            assert_eq!(inner.forks.pending_by_digest.len(), 1);
+            assert_eq!(inner.forks.pending_by_prev_digest_tail.len(), 1);
+            assert_eq!(inner.forks.pending_by_height.len(), 1);
+            assert!(inner
+                .forks
+                .pending_by_prev_digest_tail
+                .contains(&KeyTailPending {
+                    prev_digest_tail: PrevDigestTail(DIGEST_1.digest),
+                    height: 2,
+                    digest: attestation_pending.compound_digest(),
+                }));
+        }
+
+        sx.note_attestation_finalization(stream::util::AttestationInfo {
+            digest: DIGEST_1.digest,
+            height: 1,
+        })
+        .unwrap();
+
+        {
+            let mut pool = rx.common.pool.lock();
+            let inner = pool.expect_open();
+            let vote = AttestationVote::new(attestation_pending.attestation.clone());
+
+            assert_eq!(inner.forks.forks_best.clone().unwrap(), vote);
+        }
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    #[timeout(TIMEOUT)]
     async fn attestation_pool_sanity_deduplicate_header_hash(
         _logs: (),
         #[from(attestation)]
@@ -2262,54 +2390,6 @@ mod test {
             height: 2,
             digest: attestation_1.compound_digest()
         }));
-    }
-    #[tokio::test]
-    #[rstest::rstest]
-    #[timeout(TIMEOUT)]
-    async fn attestation_pool_sanity_pending(
-        _logs: (),
-        #[from(attestation)]
-        #[with([ATTESTOR_VALID_0], 2, DIGEST_1)]
-        attestation_pending: AttestationVote,
-        config: Config,
-    ) {
-        let (mut sx, rx) = attestation_pool(config);
-
-        assert!(sx
-            .send(attestation_pending.attestation.clone())
-            .unwrap()
-            .is_ok());
-
-        {
-            let mut pool = rx.common.pool.lock();
-            let inner = pool.expect_open();
-
-            assert_eq!(inner.forks.pending_by_digest.len(), 1);
-            assert_eq!(inner.forks.pending_by_prev_digest_tail.len(), 1);
-            assert_eq!(inner.forks.pending_by_height.len(), 1);
-            assert!(inner
-                .forks
-                .pending_by_prev_digest_tail
-                .contains(&KeyTailPending {
-                    prev_digest_tail: PrevDigestTail(DIGEST_1.digest),
-                    height: 2,
-                    digest: attestation_pending.compound_digest(),
-                }));
-        }
-
-        sx.note_attestation_finalization(stream::util::AttestationInfo {
-            digest: DIGEST_1.digest,
-            height: 1,
-        })
-        .unwrap();
-
-        {
-            let mut pool = rx.common.pool.lock();
-            let inner = pool.expect_open();
-            let vote = AttestationVote::new(attestation_pending.attestation.clone());
-
-            assert_eq!(inner.forks.forks_best.clone().unwrap(), vote);
-        }
     }
 
     #[tokio::test]
@@ -2585,8 +2665,252 @@ mod test {
     #[tokio::test]
     #[rstest::rstest]
     #[timeout(TIMEOUT)]
+    async fn attestation_pool_note_attestation_finalization(
+        _logs: (),
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_0], 1)]
+        attestation_0: AttestationVote,
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_0], 2)]
+        attestation_1: AttestationVote,
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_0], 3)]
+        attestation_2: AttestationVote,
+        config: Config,
+    ) {
+        let (mut sx, _rx) = attestation_pool(config);
+
+        assert!(sx.send(attestation_0.attestation.clone()).unwrap().is_ok());
+        assert!(sx.send(attestation_1.attestation.clone()).unwrap().is_ok());
+        assert!(sx.send(attestation_2.attestation.clone()).unwrap().is_ok());
+
+        {
+            let mut inner = sx.common.pool.lock();
+            let forks = &inner.expect_open().forks;
+
+            assert!(forks.forks_by_height.contains(&KeyHeight {
+                height: attestation_0.attestation.header_number(),
+                size: 1,
+                digest: attestation_0.compound_digest()
+            }));
+            assert!(forks.forks_by_height.contains(&KeyHeight {
+                height: attestation_1.attestation.header_number(),
+                size: 1,
+                digest: attestation_1.compound_digest()
+            }));
+            assert!(forks.forks_by_height.contains(&KeyHeight {
+                height: attestation_2.attestation.header_number(),
+                size: 1,
+                digest: attestation_2.compound_digest()
+            }));
+        }
+
+        sx.note_attestation_finalization(stream::util::AttestationInfo {
+            height: 2,
+            ..Default::default()
+        })
+        .unwrap();
+
+        {
+            let mut inner = sx.common.pool.lock();
+            let forks = &inner.expect_open().forks;
+
+            assert!(!forks.forks_by_height.contains(&KeyHeight {
+                height: attestation_0.attestation.header_number(),
+                size: 1,
+                digest: attestation_0.compound_digest()
+            }));
+            assert!(!forks.forks_by_height.contains(&KeyHeight {
+                height: attestation_1.attestation.header_number(),
+                size: 1,
+                digest: attestation_1.compound_digest()
+            }));
+            assert!(forks.forks_by_height.contains(&KeyHeight {
+                height: attestation_2.attestation.header_number(),
+                size: 1,
+                digest: attestation_2.compound_digest()
+            }));
+        }
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    #[timeout(TIMEOUT)]
+    async fn attestation_pool_note_attestation_interval_change(
+        _logs: (),
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_0], 1)]
+        attestation_0: AttestationVote,
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_0], 2)]
+        attestation_1: AttestationVote,
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_0], 3)]
+        attestation_2: AttestationVote,
+        config: Config,
+    ) {
+        let (mut sx, _rx) = attestation_pool(config);
+
+        assert!(sx.send(attestation_0.attestation.clone()).unwrap().is_ok());
+        assert!(sx.send(attestation_1.attestation.clone()).unwrap().is_ok());
+        assert!(sx.send(attestation_2.attestation.clone()).unwrap().is_ok());
+
+        {
+            let mut inner = sx.common.pool.lock();
+            let forks = &inner.expect_open().forks;
+
+            assert!(forks.forks_by_height.contains(&KeyHeight {
+                height: attestation_0.attestation.header_number(),
+                size: 1,
+                digest: attestation_0.compound_digest()
+            }));
+            assert!(forks.forks_by_height.contains(&KeyHeight {
+                height: attestation_1.attestation.header_number(),
+                size: 1,
+                digest: attestation_1.compound_digest()
+            }));
+            assert!(forks.forks_by_height.contains(&KeyHeight {
+                height: attestation_2.attestation.header_number(),
+                size: 1,
+                digest: attestation_2.compound_digest()
+            }));
+        }
+
+        sx.note_attestation_interval_change(std::num::NonZero::new(1).unwrap());
+
+        {
+            let mut inner = sx.common.pool.lock();
+            let forks = &inner.expect_open().forks;
+
+            assert!(forks.forks_by_digest.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    #[timeout(TIMEOUT)]
+    async fn attestation_pool_note_target_sample_size_shrinks(
+        _logs: (),
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_0], 1)]
+        attestation_0: AttestationVote,
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_1], 1)]
+        attestation_1: AttestationVote,
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_0], 2)]
+        attestation_2: AttestationVote,
+        #[from(validate_quorum)]
+        #[with(2)]
+        _quorum_validate: ValidateQuorum,
+        #[with(_quorum_validate.clone())] config: Config,
+    ) {
+        let (sx, _rx) = attestation_pool(config);
+
+        assert!(sx.send(attestation_0.attestation.clone()).unwrap().is_ok());
+        assert!(sx.send(attestation_1.attestation.clone()).unwrap().is_ok());
+        assert!(sx.send(attestation_2.attestation.clone()).unwrap().is_ok());
+
+        {
+            let mut inner = sx.common.pool.lock();
+            let forks = &inner.expect_open().forks;
+
+            assert!(forks.quorums_by_height.contains(&KeyHeight {
+                height: 1,
+                size: 2,
+                digest: attestation_0.compound_digest()
+            }));
+            assert!(!forks.quorums_by_height.contains(&KeyHeight {
+                height: 2,
+                size: 1,
+                digest: attestation_2.compound_digest()
+            }));
+        }
+
+        sx.note_target_sample_size_change(1);
+
+        {
+            let mut inner = sx.common.pool.lock();
+            let forks = &inner.expect_open().forks;
+
+            assert!(forks.quorums_by_height.contains(&KeyHeight {
+                height: 1,
+                size: 2,
+                digest: attestation_0.compound_digest()
+            }));
+            assert!(forks.quorums_by_height.contains(&KeyHeight {
+                height: 2,
+                size: 1,
+                digest: attestation_2.compound_digest()
+            }));
+        }
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    #[timeout(TIMEOUT)]
+    async fn attestation_pool_note_target_sample_size_grows(
+        _logs: (),
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_0], 1)]
+        attestation_0: AttestationVote,
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_1], 1)]
+        attestation_1: AttestationVote,
+        #[from(attestation)]
+        #[with([ATTESTOR_VALID_0], 2)]
+        attestation_2: AttestationVote,
+        #[from(validate_quorum)]
+        #[with(1)]
+        _quorum_validate: ValidateQuorum,
+        #[with(_quorum_validate.clone())] config: Config,
+    ) {
+        let (sx, _rx) = attestation_pool(config);
+
+        assert!(sx.send(attestation_0.attestation.clone()).unwrap().is_ok());
+        assert!(sx.send(attestation_1.attestation.clone()).unwrap().is_ok());
+        assert!(sx.send(attestation_2.attestation.clone()).unwrap().is_ok());
+
+        {
+            let mut inner = sx.common.pool.lock();
+            let forks = &inner.expect_open().forks;
+
+            assert!(forks.quorums_by_height.contains(&KeyHeight {
+                height: 1,
+                size: 2,
+                digest: attestation_0.compound_digest()
+            }));
+            assert!(forks.quorums_by_height.contains(&KeyHeight {
+                height: 2,
+                size: 1,
+                digest: attestation_2.compound_digest()
+            }));
+        }
+
+        sx.note_target_sample_size_change(2);
+
+        {
+            let mut inner = sx.common.pool.lock();
+            let forks = &inner.expect_open().forks;
+
+            assert!(forks.quorums_by_height.contains(&KeyHeight {
+                height: 1,
+                size: 2,
+                digest: attestation_0.compound_digest()
+            }));
+            assert!(!forks.quorums_by_height.contains(&KeyHeight {
+                height: 2,
+                size: 1,
+                digest: attestation_2.compound_digest()
+            }));
+        }
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    #[timeout(TIMEOUT)]
     #[allow(clippy::too_many_arguments)]
-    async fn chain_reversion_resets_validation_pool(
+    async fn attestation_pool_note_chain_reversion(
         _logs: (),
         // Attestations that will be marked valid via mark_for_later
         #[from(attestation)]

--- a/attestor/pool/src/lib.rs
+++ b/attestor/pool/src/lib.rs
@@ -875,13 +875,15 @@ impl AttestationPoolForks {
             "Missing mapping in forks_by_size: {key_size:#?}"
         );
         assert!(
-            self.quorums_by_height.remove(&key_height),
-            "Missing mapping in quorums_by_height: {key_height:#?}"
-        );
-        assert!(
             self.votes_invalid.insert(key_digest),
             "Duplicate mapping in votes_invalid: {key_digest:#?}"
         );
+
+        // WARNING: RACE CONDITION
+        //
+        // The entry for this digest in `quorums_by_height` may have been removed following a
+        // target sample size update since quorum was last observed.
+        let _ = self.quorums_by_height.remove(&key_height);
 
         for attestor in vote.signers {
             let key_vote = KeyVote { height, attestor };

--- a/attestor/pool/src/lib.rs
+++ b/attestor/pool/src/lib.rs
@@ -999,7 +999,7 @@ impl AttestationPoolForks {
 
     fn find_best(&self) -> Option<AttestationVote> {
         self.quorums_by_height
-            .first()
+            .last()
             .map(|KeyHeight { digest, .. }| digest)
             .or_else(|| {
                 self.forks_by_size
@@ -2126,7 +2126,7 @@ mod test {
 
         let (quorum_actual, permit, _digest_local) = rx.next().await.unwrap();
 
-        assert_eq!(quorum_actual, quorum_expected);
+        pretty_assertions::assert_eq!(quorum_actual, quorum_expected);
 
         rx.mark_valid(permit);
 
@@ -2138,7 +2138,7 @@ mod test {
             size: 2,
             digest: DIGEST_0
         }));
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             inner.digest_local,
             Some(cc_client::H256(attestation_1.attestation.digest().0))
         );
@@ -2169,7 +2169,7 @@ mod test {
 
         let (quorum_actual, permit, _digest_local) = rx.next().await.unwrap();
 
-        assert_eq!(quorum_actual, quorum_expected);
+        pretty_assertions::assert_eq!(quorum_actual, quorum_expected);
         rx.mark_invalid(permit);
 
         let mut pool = rx.common.pool.lock();
@@ -2212,7 +2212,7 @@ mod test {
 
         // `mark_invalid` removes quorum under new validation rules. `quorums_by_height` must have
         // been updated by now or this will panic!
-        assert_eq!(quorum_actual, quorum_expected);
+        pretty_assertions::assert_eq!(quorum_actual, quorum_expected);
         rx.mark_invalid(permit);
 
         let mut pool = rx.common.pool.lock();
@@ -2252,7 +2252,7 @@ mod test {
 
         let (quorum_actual, permit, _digest_local) = rx.next().await.unwrap();
 
-        assert_eq!(quorum_actual, quorum_expected);
+        pretty_assertions::assert_eq!(quorum_actual, quorum_expected);
         rx.mark_for_later(
             permit,
             attestation_signed.clone(),
@@ -2270,11 +2270,11 @@ mod test {
         > = attestation_signed.clone().into();
 
         assert_matches::assert_matches!(rx.take_next_validated(), Some((height, digest, attestation, votes)) => {
-            assert_eq!(height, attestation_0.attestation.header_number());
-            assert_eq!(digest, attestation_0.attestation.digest());
+            pretty_assertions::assert_eq!(height, attestation_0.attestation.header_number());
+            pretty_assertions::assert_eq!(digest, attestation_0.attestation.digest());
             // Other types in this don't implement PartialEq and Eq...
-            assert_eq!(attestation.attestors, attestation_expected.attestors);
-            assert_eq!(votes,
+            pretty_assertions::assert_eq!(attestation.attestors, attestation_expected.attestors);
+            pretty_assertions::assert_eq!(votes,
                 vec![
                     attestation_0.attestation,
                     attestation_1.attestation,
@@ -2282,7 +2282,7 @@ mod test {
             );
         });
 
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             sx.common.pool.lock().expect_open().digest_local,
             Some(cc_client::H256(attestation_signed.digest().0))
         );
@@ -2309,9 +2309,9 @@ mod test {
             let mut pool = rx.common.pool.lock();
             let inner = pool.expect_open();
 
-            assert_eq!(inner.forks.pending_by_digest.len(), 1);
-            assert_eq!(inner.forks.pending_by_prev_digest_tail.len(), 1);
-            assert_eq!(inner.forks.pending_by_height.len(), 1);
+            pretty_assertions::assert_eq!(inner.forks.pending_by_digest.len(), 1);
+            pretty_assertions::assert_eq!(inner.forks.pending_by_prev_digest_tail.len(), 1);
+            pretty_assertions::assert_eq!(inner.forks.pending_by_height.len(), 1);
             assert!(inner
                 .forks
                 .pending_by_prev_digest_tail
@@ -2333,7 +2333,7 @@ mod test {
             let inner = pool.expect_open();
             let vote = AttestationVote::new(attestation_pending.attestation.clone());
 
-            assert_eq!(inner.forks.forks_best.clone().unwrap(), vote);
+            pretty_assertions::assert_eq!(inner.forks.forks_best.clone().unwrap(), vote);
         }
     }
 
@@ -2358,11 +2358,11 @@ mod test {
         let mut pool = rx.common.pool.lock();
         let inner = pool.expect_open();
 
-        assert_eq!(inner.forks.votes.len(), 2);
-        assert_eq!(inner.forks.forks_by_digest.len(), 2);
-        assert_eq!(inner.forks.forks_by_size.len(), 2);
+        pretty_assertions::assert_eq!(inner.forks.votes.len(), 2);
+        pretty_assertions::assert_eq!(inner.forks.forks_by_digest.len(), 2);
+        pretty_assertions::assert_eq!(inner.forks.forks_by_size.len(), 2);
 
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             inner
                 .forks
                 .forks_by_digest
@@ -2371,7 +2371,7 @@ mod test {
             &attestation_0
         );
 
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             inner
                 .forks
                 .forks_by_digest
@@ -2428,11 +2428,11 @@ mod test {
         let mut pool = rx.common.pool.lock();
         let inner = pool.expect_open();
 
-        assert_eq!(inner.forks.votes.len(), 2);
-        assert_eq!(inner.forks.forks_by_digest.len(), 2);
-        assert_eq!(inner.forks.forks_by_size.len(), 2);
+        pretty_assertions::assert_eq!(inner.forks.votes.len(), 2);
+        pretty_assertions::assert_eq!(inner.forks.forks_by_digest.len(), 2);
+        pretty_assertions::assert_eq!(inner.forks.forks_by_size.len(), 2);
 
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             inner
                 .forks
                 .forks_by_digest
@@ -2441,7 +2441,7 @@ mod test {
             &attestation_0
         );
 
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             inner
                 .forks
                 .forks_by_digest
@@ -2544,7 +2544,7 @@ mod test {
         let actual = rx.next().await;
         let expected = Some((quorum, permit, None));
 
-        assert_eq!(actual, expected);
+        pretty_assertions::assert_eq!(actual, expected);
     }
 
     #[tokio::test]
@@ -2595,7 +2595,7 @@ mod test {
         let actual = rx.next().await;
         let expected = Some((quorum, permit, None));
 
-        assert_eq!(actual, expected);
+        pretty_assertions::assert_eq!(actual, expected);
     }
 
     #[tokio::test]
@@ -2827,7 +2827,7 @@ mod test {
                 digest: attestation_2.compound_digest()
             }));
 
-            assert_eq!(forks.forks_best, Some(attestation_0.clone()));
+            pretty_assertions::assert_eq!(forks.forks_best, Some(attestation_0.clone()));
         }
 
         sx.note_target_sample_size_change(1);
@@ -2847,7 +2847,7 @@ mod test {
                 digest: attestation_2.compound_digest()
             }));
 
-            assert_eq!(forks.forks_best, Some(attestation_0.clone()));
+            pretty_assertions::assert_eq!(forks.forks_best, Some(attestation_2.clone()));
         }
     }
 
@@ -2891,7 +2891,7 @@ mod test {
                 digest: attestation_2.compound_digest()
             }));
 
-            assert_eq!(forks.forks_best, Some(attestation_2.clone()));
+            pretty_assertions::assert_eq!(forks.forks_best, Some(attestation_2.clone()));
         }
 
         sx.note_target_sample_size_change(2);
@@ -2911,7 +2911,7 @@ mod test {
                 digest: attestation_2.compound_digest()
             }));
 
-            assert_eq!(forks.forks_best, Some(attestation_0));
+            pretty_assertions::assert_eq!(forks.forks_best, Some(attestation_0));
         }
     }
 
@@ -3077,13 +3077,13 @@ mod test {
         let inner = pool.expect_open();
 
         // Digest local reset
-        assert_eq!(inner.digest_local, None);
+        pretty_assertions::assert_eq!(inner.digest_local, None);
 
         // Forks reset
         assert!(inner.forks.forks_by_digest.is_empty());
         assert!(inner.forks.forks_by_height.is_empty());
         assert!(inner.forks.forks_by_size.is_empty());
-        assert_eq!(inner.forks.forks_best, None);
+        pretty_assertions::assert_eq!(inner.forks.forks_best, None);
 
         assert!(inner.forks.pending_by_digest.is_empty());
         assert!(inner.forks.pending_by_prev_digest_tail.is_empty());
@@ -3094,7 +3094,7 @@ mod test {
         assert!(inner.forks.quorums_by_height.is_empty());
 
         // Reversion should set the new finalized digest
-        assert_eq!(inner.forks.last_finalized_digest, Some(DIGEST_1.digest));
+        pretty_assertions::assert_eq!(inner.forks.last_finalized_digest, Some(DIGEST_1.digest));
 
         // Valid queue reset
         assert!(inner.valid.quorums_valid.is_empty());


### PR DESCRIPTION
# Description of proposed changes

<describe what this PR is about and why we want it>

---

## Features

- [Recomputes quorums on target sample size change](https://github.com/gluwa/creditcoin3/pull/881/changes#diff-bb440cdeae707e0007839d405c32851ebafa706a67c9931a98d9c2d65753d8c0R1127-R1162).

## Fixes

- Rare bug in the attestation pool, where [shrinking the target sample size](https://github.com/gluwa/creditcoin3/blob/099a331c9dde023edf634053eab6faea9fd681d4/attestor/pool/src/lib.rs#L1288) then [invalidating a past quorum](https://github.com/gluwa/creditcoin3/blob/099a331c9dde023edf634053eab6faea9fd681d4/attestor/pool/src/lib.rs#L451) would cause a panic on a [missing `quorum_by_height`](https://github.com/gluwa/creditcoin3/blob/099a331c9dde023edf634053eab6faea9fd681d4/attestor/pool/src/lib.rs#L877-L880).

## Tests

- [Added regression tests](https://github.com/gluwa/creditcoin3/pull/881/changes#diff-bb440cdeae707e0007839d405c32851ebafa706a67c9931a98d9c2d65753d8c0R2188-R2224) to guard against this issue happening again in the future.
- [Added coverage for all cc3 attestation pool event handlers](https://github.com/gluwa/creditcoin3/pull/881/changes#diff-bb440cdeae707e0007839d405c32851ebafa706a67c9931a98d9c2d65753d8c0R2665-R2907).
- Added [`pretty_assertions`](https://docs.rs/pretty_assertions/latest/pretty_assertions/index.html) as a test dependency to help spot error diffs in large struct comparisons.
