### PR TITLE
fix(traffic-simulator): prevent unhandled rejection crashing Deno on RPC timeout

### DIFF
--- a/scripts/traffic-simulator/src/utils/retry.ts
+++ b/scripts/traffic-simulator/src/utils/retry.ts
@@ -11,16 +11,36 @@ import { sleep } from "./sleep.ts";
 
 /**
  * Wrap a promise with a timeout. Rejects with an error if the timeout is reached.
+ *
+ * Implementation notes:
+ * - When the timeout wins the race, the inner `promise` is still pending. If it
+ *   later rejects (e.g. ethers' own request timeout firing on the abandoned
+ *   call), that rejection has no listener and surfaces as an unhandled
+ *   promise rejection, which crashes Deno. Attaching a no-op `.catch` on the
+ *   inner promise turns that late rejection into a silent drop.
+ * - Clear the timeout when the inner promise settles first so we don't keep
+ *   dangling timers alive on the event loop.
  */
 export function withTimeout<T>(
   promise: Promise<T>,
   ms: number,
   label: string,
 ): Promise<T> {
-  const timeout = new Promise<never>((_, reject) =>
-    setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
-  );
-  return Promise.race([promise, timeout]);
+  let timer: number | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms,
+    );
+  });
+  // Swallow any late rejection from the abandoned inner promise after the
+  // timeout has already won the race. Without this, ethers' own internal
+  // request timeout firing ~30s later produces an unhandled rejection and
+  // takes down the whole process.
+  promise.catch(() => {});
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
 }
 
 /**


### PR DESCRIPTION
## Problem

The traffic simulator panics and restarts with an unhandled promise rejection like:

```
error: Uncaught (in promise) Error: request timeout (code=TIMEOUT, version=6.16.0)
  at makeError (ethers/utils/errors.ts:698:21)
  at ClientRequest.<anonymous> (ethers/utils/geturl.ts:66:24)
  at TLSSocket.emitRequestTimeout (node:_http_client:743:9)
  at TLSSocket._onTimeout (node:net:1024:8)
```

This happens shortly after a `Single submit simulation timed out after 30000ms` log line. The two errors are linked.

## Root cause

`withTimeout` in `src/utils/retry.ts` races the inner promise against a `setTimeout`-based timeout:

```ts
return Promise.race([promise, timeout]);
```

When the timeout wins, the inner promise (typically an ethers `provider.call(...)`) is still pending. Nobody has a `.catch` on it anymore. When ethers' internal HTTP request timeout fires later on that abandoned promise, the rejection is unhandled, Deno surfaces it as a process-level error, and the simulator crashes.

The stack trace confirms it: `node net timeout → http_client → ethers makeError`.

## Fix

- Attach a no-op `.catch(() => {})` to the inner promise so any late rejection is silently dropped after the timeout has already won the race.
- Clear the racing `setTimeout` when the inner promise settles first, so we don't leave dead timers on the event loop.

This only addresses the *crash*. The underlying simulation timeouts (`provider.call` taking >30s for large `verifyAndEmit` calldata) are a separate problem and will be tackled in a follow-up PR.

## Testing

- `deno fmt --check` ✅
- `deno lint` ✅
- `deno check src/main.ts` ✅