### PR TITLE
fix(traffic-simulator): skip pre-flight simulation for large calldata

### DIFF
--- a/scripts/traffic-simulator/src/constants.ts
+++ b/scripts/traffic-simulator/src/constants.ts
@@ -26,6 +26,22 @@ export const RECEIPT_TIMEOUT_MS = _receiptTimeout > 0
   ? _receiptTimeout
   : 120_000;
 
+// Simulation timeout — `eth_call` against `verifyAndEmit` with non-trivial
+// calldata can take significantly longer than a normal RPC round-trip because
+// the node has to run the full precompile (Merkle + continuity verification)
+// inside the single-threaded RPC handler. Give it more headroom than the
+// generic RPC timeout, but still bound it.
+const _simTimeout = Number(Deno.env.get("SIMULATION_TIMEOUT_MS"));
+export const SIMULATION_TIMEOUT_MS = _simTimeout > 0 ? _simTimeout : 90_000;
+
+// Skip pre-flight `eth_call` simulation when the calldata exceeds this size,
+// in bytes. Large `verifyAndEmit` payloads (batches, big tx witnesses) can
+// take longer than any reasonable RPC timeout to simulate, even though the
+// actual on-chain submission goes through fine. For those, skip simulation
+// and rely on receipt-side error handling instead.
+const _simSkip = Number(Deno.env.get("SIMULATION_SKIP_BYTES"));
+export const SIMULATION_SKIP_BYTES = _simSkip > 0 ? _simSkip : 16_384;
+
 // Transient network error retry settings (for socket hang up, ECONNRESET, etc.)
 export const MAX_TRANSIENT_RETRIES = 3;
 export const TRANSIENT_RETRY_BASE_DELAY_MS = 2_000;

--- a/scripts/traffic-simulator/src/submission/precompile.ts
+++ b/scripts/traffic-simulator/src/submission/precompile.ts
@@ -11,6 +11,8 @@ import {
   PRECOMPILE_ADDRESS,
   RECEIPT_TIMEOUT_MS,
   RPC_TIMEOUT_MS,
+  SIMULATION_SKIP_BYTES,
+  SIMULATION_TIMEOUT_MS,
   SINGLE_PROOF_GAS_LIMIT,
   SINGLE_VERIFY_SIG,
   TRANSIENT_RETRY_BASE_DELAY_MS,
@@ -112,6 +114,15 @@ async function executePrecompileCall(
 ): Promise<{ txHash: string; gasUsed: bigint }> {
   const { cc3HttpUrl, privateKey, data, gasLimit, label } = params;
 
+  // Calldata size in bytes (the hex string is `0x` + 2 hex chars per byte).
+  const calldataBytes = Math.max(0, (data.length - 2) >> 1);
+  // For very large payloads the node-side simulation reliably exceeds any
+  // sensible RPC timeout even though the on-chain submission would succeed,
+  // so skip the pre-flight `eth_call` and rely on receipt-side error
+  // handling instead. Smaller payloads still get simulated for early revert
+  // detection.
+  const skipSimulation = calldataBytes > SIMULATION_SKIP_BYTES;
+
   /**
    * Simulate the transaction with retry for transient network errors.
    * This is safe to retry because no nonce is used during simulation.
@@ -129,14 +140,22 @@ async function executePrecompileCall(
       const { signer, provider } = entry;
 
       try {
-        const from = await signer.getAddress();
+        if (skipSimulation) {
+          console.debug(
+            `${label} skipping simulation (calldata ${calldataBytes}B > ${SIMULATION_SKIP_BYTES}B threshold)`,
+          );
+        } else {
+          const from = await signer.getAddress();
 
-        // Simulate the transaction
-        await withTimeout(
-          provider.call({ to: PRECOMPILE_ADDRESS, data, from }),
-          RPC_TIMEOUT_MS,
-          `${label} simulation`,
-        );
+          // Simulate the transaction. Use the simulation-specific timeout
+          // because `eth_call` against `verifyAndEmit` with non-trivial
+          // calldata is materially slower than a normal RPC round-trip.
+          await withTimeout(
+            provider.call({ to: PRECOMPILE_ADDRESS, data, from }),
+            SIMULATION_TIMEOUT_MS,
+            `${label} simulation`,
+          );
+        }
 
         // Get fee data
         const feeOverrides = await getFeeOverrides(provider);


### PR DESCRIPTION
## Problem

The simulator logs intermittent failures like:

```
❌ Batch failed (blocks 10747976-10747979): Batch submit simulation failed: Batch submit simulation timed out after 30000ms
❌ Failed to submit proof for 0x6d213f87...: Single submit simulation failed: request timeout (code=TIMEOUT, version=6.16.0)
```

The failing single-proof submissions consistently have very large calldata, e.g. `txBytesLen: 120992`.

## Root cause

Before submitting a transaction, `executePrecompileCall` runs a pre-flight `eth_call` to catch reverts early:

```ts
await withTimeout(
  provider.call({ to: PRECOMPILE_ADDRESS, data, from }),
  RPC_TIMEOUT_MS, // 30_000
  `${label} simulation`,
);
```

That `eth_call` re-runs the full block-prover precompile (Merkle + continuity verification) inside the node's single-threaded RPC handler. For large `verifyAndEmit` payloads (~120 KB calldata) the work simply does not finish within `RPC_TIMEOUT_MS` (30s), even though the on-chain submission itself would succeed if we just sent it.

The upshot: the simulator never even submits the tx, and reports a "simulation timed out" failure for what is effectively a healthy submission path.

## Fix

- Skip the pre-flight `eth_call` simulation when calldata is larger than `SIMULATION_SKIP_BYTES` (default 16 KiB). For those, rely on receipt-side error handling — actual reverts still surface as `receipt.status !== 1`.
- For payloads that *do* still get simulated, use a separate `SIMULATION_TIMEOUT_MS` (default 90s) so they have more headroom than the generic 30s `RPC_TIMEOUT_MS` without relaxing it for unrelated calls (nonce fetch, fee data, etc.).
- Both thresholds are env-overridable (`SIMULATION_SKIP_BYTES`, `SIMULATION_TIMEOUT_MS`) to tune per environment.

The transient-error retry loop and signer-reset logic still apply around the (now-narrower) network calls.

## Trade-off

We lose pre-flight revert detection for large payloads. In practice those are exactly the submissions where simulation was already useless (it never completed). On-chain `verifyAndEmit` failures still surface via the receipt path with the proper revert reason captured from the receipt logs.

## Testing

- `deno fmt --check` ✅
- `deno lint` ✅
- `deno check src/main.ts` ✅

## Related

Depends conceptually on #883 (which prevents the unhandled rejection that *also* fired when these simulations timed out). Both should land.