### PR TITLE
feat(proof-gen-api): return 422 for BlockNotReady

### DIFF
--- a/proof-gen-api-server/README.md
+++ b/proof-gen-api-server/README.md
@@ -139,7 +139,9 @@ Error Response Shape:
 will predict the next attestation using the attestation interval and generate an "eager" proof.
 This proof will become verifiable once the predicted attestation is created on-chain.
 
-In rare cases where no attestations exist at all, a `BlockNotReady` error is returned:
+In rare cases where no attestations exist at all, a `BlockNotReady` error is returned
+with HTTP status `422 Unprocessable Entity` (the request is well-formed but the block
+is not yet attested):
 
 ```jsonc
 {

--- a/proof-gen-api-server/src/networking/routes/continuity.rs
+++ b/proof-gen-api-server/src/networking/routes/continuity.rs
@@ -30,6 +30,7 @@ type TxHashes = Vec<String>;
         (status = 200, description = "Continuity and merkle proof", body = SingleContinuityResponse),
         (status = 400, description = "Invalid parameters", body = ErrorResponse),
         (status = 404, description = "Block or transaction not found", body = ErrorResponse),
+        (status = 422, description = "Block exists but is not yet attested (BlockNotReady)", body = ErrorResponse),
         (status = 503, description = "RPC unavailable", body = ErrorResponse)
     )
 )]
@@ -71,6 +72,7 @@ pub async fn get_proof_with_tx(
         (status = 200, description = "Continuity and merkle proof", body = SingleContinuityResponse),
         (status = 400, description = "Invalid parameters", body = ErrorResponse),
         (status = 404, description = "Transaction not found", body = ErrorResponse),
+        (status = 422, description = "Block exists but is not yet attested (BlockNotReady)", body = ErrorResponse),
         (status = 501, description = "Tx hash lookup not implemented", body = ErrorResponse)
     )
 )]
@@ -103,6 +105,7 @@ pub async fn get_proof_by_tx_hash(
         (status = 200, description = "Continuity and merkle proof entries", body = BatchedContinuityResponse),
         (status = 400, description = "Invalid parameters", body = ErrorResponse),
         (status = 404, description = "Transaction not found", body = ErrorResponse),
+        (status = 422, description = "Block exists but is not yet attested (BlockNotReady)", body = ErrorResponse),
         (status = 501, description = "Tx hash lookup not implemented", body = ErrorResponse)
     )
 )]
@@ -185,6 +188,7 @@ pub async fn get_proof_batch(
         (status = 200, description = "Continuity and merkle proof entries", body = BatchedContinuityResponse),
         (status = 400, description = "Invalid parameters", body = ErrorResponse),
         (status = 404, description = "Transaction not found", body = ErrorResponse),
+        (status = 422, description = "Block exists but is not yet attested (BlockNotReady)", body = ErrorResponse),
         (status = 501, description = "Tx hash lookup not implemented", body = ErrorResponse)
     )
 )]

--- a/proof-gen-api-server/src/services/errors.rs
+++ b/proof-gen-api-server/src/services/errors.rs
@@ -160,9 +160,14 @@ impl ServiceError {
             | Self::BatchSpanTooLarge { .. } => StatusCode::BAD_REQUEST,
             Self::RpcUnavailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
             Self::TxHashLookupUnavailable { .. } => StatusCode::NOT_IMPLEMENTED,
-            Self::TxHashNotFound { .. }
-            | Self::BlockNotReady { .. }
-            | Self::BlockNotOnSourceChain { .. } => StatusCode::NOT_FOUND,
+            Self::TxHashNotFound { .. } | Self::BlockNotOnSourceChain { .. } => {
+                StatusCode::NOT_FOUND
+            }
+            // Block exists but is not yet attested. The request is well-formed but
+            // cannot be processed in the current state, so 422 Unprocessable Entity
+            // is more accurate than 404 Not Found and lets clients distinguish
+            // "keep waiting / retry" from "this will never exist".
+            Self::BlockNotReady { .. } => StatusCode::UNPROCESSABLE_ENTITY,
             Self::MerkleError { .. } | Self::Internal { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/proof-gen-api-server/tests/route_tests.rs
+++ b/proof-gen-api-server/tests/route_tests.rs
@@ -214,7 +214,9 @@ async fn test_swagger_json_route_should_return_valid_json() {
     let response = app.oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    let bytes = axum::body::to_bytes(response.into_body(), 10240)
+    // 32 KiB is plenty of headroom as we add new endpoints / response variants;
+    // the previous 10 KiB cap was tight enough to break on the next addition.
+    let bytes = axum::body::to_bytes(response.into_body(), 32 * 1024)
         .await
         .unwrap();
     // note: if we can deserialize without error it must be valid json, no?


### PR DESCRIPTION
## What

Map `BlockNotReady` from the proof-gen API to **HTTP 422 Unprocessable Entity** instead of 404.

Requested by Dave: when a client waits until a block is attested but asks for a proof before the attestation is finalized, the server returned an opaque error. On the client side this surfaced as a generic 500 (because the SDK retry/wrap path didn't preserve the underlying status), which covers too many failure modes. 422 makes it cleanly distinguishable from "the tx/block will never exist" (404) and "transient infra failure" (5xx).

## Why 422?

- The request is **well-formed** (valid chain, valid block number that exists on the source chain).
- It **cannot be processed in the current state** — the block exists but isn't attested yet.
- That's the canonical 422 use case. 404 was wrong because the resource will exist; the client should keep polling. `retriable: true` in the body still tells clients to wait.

## Changes

- `proof-gen-api-server/src/services/errors.rs`
  - `ServiceError::BlockNotReady` → `StatusCode::UNPROCESSABLE_ENTITY`
  - `TxHashNotFound` and `BlockNotOnSourceChain` stay on `404` (they're genuinely "not found").
- `proof-gen-api-server/src/networking/routes/continuity.rs`
  - Added `(status = 422, …)` to the utoipa `responses(...)` on all four proof endpoints so the generated OpenAPI/Swagger spec advertises it.
- `proof-gen-api-server/README.md`
  - Documented the 422 alongside the example `BlockNotReady` body.
- `proof-gen-api-server/tests/route_tests.rs`
  - Bumped the swagger-json `to_bytes` cap from 10 KiB to 32 KiB. The four extra response variants pushed the doc past the old limit and broke `test_swagger_json_route_should_return_valid_json` with a `LengthLimitError`. 32 KiB gives headroom for future endpoints.

## Client impact

The traffic simulator and the SDK already retry on `retriable || status >= 500`, and `BlockNotReady` is `retriable: true`, so existing waiters keep retrying as before. The only behavioral change is callers that key off the HTTP status now get a stable, accurate code instead of a 500/404 grab-bag.

## Verification

- `cargo fmt -p proof-gen-api-server` ✅
- `cargo clippy -p proof-gen-api-server --all-targets -- -D warnings` ✅
- `cargo test -p proof-gen-api-server` ✅ (27 + 14 tests, all green)