### PR TITLE
ci: pin foundry-toolchain to v1.5.1 (fix --load-state on anvil 1.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,11 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          # Pinned: v1.6.x changed the anvil --dump-state JSON format,
+          # which breaks --load-state on the existing anvil10k_blocks.json
+          # snapshot. Bump deliberately when we regenerate that snapshot.
+          version: v1.5.1
 
       - name: Start Ethereum simulation with Anvil - 2 chains
         run: |
@@ -650,6 +655,11 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          # Pinned: v1.6.x changed the anvil --dump-state JSON format,
+          # which breaks --load-state on the existing anvil10k_blocks.json
+          # snapshot. Bump deliberately when we regenerate that snapshot.
+          version: v1.5.1
 
       - name: Start Ethereum simulation with Anvil
         run: |
@@ -862,6 +872,11 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          # Pinned: v1.6.x changed the anvil --dump-state JSON format,
+          # which breaks --load-state on the existing anvil10k_blocks.json
+          # snapshot. Bump deliberately when we regenerate that snapshot.
+          version: v1.5.1
 
       - name: Deploy contract via forge create
         run: |
@@ -999,6 +1014,11 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          # Pinned: v1.6.x changed the anvil --dump-state JSON format,
+          # which breaks --load-state on the existing anvil10k_blocks.json
+          # snapshot. Bump deliberately when we regenerate that snapshot.
+          version: v1.5.1
 
       - name: Start Ethereum simulation with Anvil - several chains
         run: |
@@ -1222,6 +1242,11 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          # Pinned: v1.6.x changed the anvil --dump-state JSON format,
+          # which breaks --load-state on the existing anvil10k_blocks.json
+          # snapshot. Bump deliberately when we regenerate that snapshot.
+          version: v1.5.1
 
       - name: Start Ethereum simulation with Anvil
         run: |
@@ -1523,6 +1548,11 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          # Pinned: v1.6.x changed the anvil --dump-state JSON format,
+          # which breaks --load-state on the existing anvil10k_blocks.json
+          # snapshot. Bump deliberately when we regenerate that snapshot.
+          version: v1.5.1
 
       - name: Start Ethereum simulation with Anvil
         run: |

--- a/.github/workflows/proof-gen-api-server.yml
+++ b/.github/workflows/proof-gen-api-server.yml
@@ -24,6 +24,11 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          # Pinned: v1.6.x changed the anvil --dump-state JSON format,
+          # which breaks --load-state on the existing anvil10k_blocks.json
+          # snapshot. Bump deliberately when we regenerate that snapshot.
+          version: v1.5.1
 
       - name: Install Anvil
         run: |
@@ -133,6 +138,11 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          # Pinned: v1.6.x changed the anvil --dump-state JSON format,
+          # which breaks --load-state on the existing anvil10k_blocks.json
+          # snapshot. Bump deliberately when we regenerate that snapshot.
+          version: v1.5.1
 
       - name: Start Ethereum simulation with Anvil
         run: |
@@ -365,7 +375,11 @@ jobs:
     steps:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-
+        with:
+          # Pinned: v1.6.x changed the anvil --dump-state JSON format,
+          # which breaks --load-state on the existing anvil10k_blocks.json
+          # snapshot. Bump deliberately when we regenerate that snapshot.
+          version: v1.5.1
       # start this early so it has time to produce more blocks to be used by stress-test
       - name: Start Ethereum simulation with Anvil
         run: |


### PR DESCRIPTION
## What

Pin `foundry-rs/foundry-toolchain@v1` to **anvil v1.5.1** in every CI job that installs Foundry.

## Why

`integration-test-attestator-network` started failing on `usc-dev` with:

```
error: invalid value './anvil10k_blocks.json' for '--load-state <PATH>':
failed to parse json file: "./anvil10k_blocks.json":
data did not match any variant of untagged enum SerializableTransactionType
at line 1 column 8128
```

Root cause:

- `anvil10k_blocks.json` (the cached 4.8 GiB chain snapshot in Azure blob storage) was generated with anvil 1.5.x. Its on-disk JSON format is tied to anvil's `SerializableTransactionType` enum.
- anvil 1.6.x introduced a new transaction variant, so 1.6 can't deserialize a snapshot produced by 1.5 — the `--dump-state` / `--load-state` formats are not back-compat across this minor.
- Until <https://github.com/gluwa/creditcoin3/commit/86482a71|86482a71> ("Install Foundry via action", Apr 24) the workflow installed Foundry via `curl … | bash` + `foundryup`, which happened to land on **1.5.1**. After the switch to `foundry-rs/foundry-toolchain@v1` (default `version: stable`) we got rolled forward to **1.6.0-rc1** the moment Foundry promoted it, and `--load-state` started rejecting the snapshot.

Confirmed against logs:

- ✅ Last-good run (`fix/pool` @ 2026-04-28 09:37 UTC) → `anvil Version: 1.5.1-stable`.
- ❌ Failing run (`feat_attestor_chill` @ 2026-04-28 12:42 UTC) → `anvil Version: 1.6.0-v1.6.0-rc1`.

## Fix

Pin **every** foundry-toolchain step (not just the one job that uses `--load-state`) so the entire CI matrix runs on the same anvil:

```yaml
- name: Install Foundry
  uses: foundry-rs/foundry-toolchain@v1
  with:
    # Pinned: v1.6.x changed the anvil --dump-state JSON format,
    # which breaks --load-state on the existing anvil10k_blocks.json
    # snapshot. Bump deliberately when we regenerate that snapshot.
    version: v1.5.1
```

Touched 9 spots across:

- `.github/workflows/ci.yml` (6 steps)
- `.github/workflows/proof-gen-api-server.yml` (3 steps)

Pinning everywhere — not just the `--load-state` call site — keeps the rest of the matrix deterministic and avoids drift between jobs that compile against `anvil` JSON-RPC, deploy contracts, etc. The other jobs were going to start randomly breaking on the 1.6 release notes too.

## When to bump

Lift the pin **together** with regenerating `anvil10k_blocks.json` against the new anvil. Mechanical recipe:

1. `anvil --block-time 6 --chain-id 31337 --port 8141 --dump-state ./anvil10k_blocks.json &` on the new version.
2. Drive it to ~10k blocks (existing helper / forge script).
3. Re-upload to the `usc-testing-data` Azure container as `anvil10k_blocks.json.xz`.
4. Bump the `version: v1.5.1` pins to the new tag in this same PR.

## Verification

- Both workflows still parse as valid YAML (`yaml.safe_load`).
- 9 / 9 `foundry-rs/foundry-toolchain@v1` calls now have a `version: v1.5.1` block.
- No other behavioral changes — purely a version pin + comments.