### PR TITLE
ci: exclude target/ and node_modules/ from taplo formatting check

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,4 +1,13 @@
 include = ["Cargo.toml", "**/*.toml"]
+# Skip auto-generated and vendored TOMLs that we don't own. Without this,
+# any populated `target/` (Swatinem/rust-cache, local builds, llvm-cov) drags in
+# files like `target/.../wasm-opt-sys/.../Cargo.toml` and fails `taplo format --check`.
+exclude = [
+    "target/**",
+    "**/target/**",
+    "node_modules/**",
+    "**/node_modules/**",
+]
 
 [formatting]
 # Align consecutive entries vertically.

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -2,12 +2,7 @@ include = ["Cargo.toml", "**/*.toml"]
 # Skip auto-generated and vendored TOMLs that we don't own. Without this,
 # any populated `target/` (Swatinem/rust-cache, local builds, llvm-cov) drags in
 # files like `target/.../wasm-opt-sys/.../Cargo.toml` and fails `taplo format --check`.
-exclude = [
-    "target/**",
-    "**/target/**",
-    "node_modules/**",
-    "**/node_modules/**",
-]
+exclude = ["target/**", "**/target/**", "node_modules/**", "**/node_modules/**"]
 
 [formatting]
 # Align consecutive entries vertically.


### PR DESCRIPTION
## What

Add an `exclude` block to `.taplo.toml` so `target/**` and `node_modules/**` aren't lint-checked.

## The failing job

Job: <https://github.com/gluwa/creditcoin3/actions/runs/25049694166/job/73373958229|cargo-fmt on PR #881>

```
ERROR taplo:format_files: the file is not properly formatted
  path=".../target/llvm-cov-target/release/build/wasm-opt-cxx-sys-.../out/cxxbridge/crate/wasm-opt-cxx-sys/Cargo.toml"
ERROR taplo:format_files: the file is not properly formatted
  path=".../target/llvm-cov-target/release/build/wasm-opt-sys-.../out/cxxbridge/crate/wasm-opt-sys/Cargo.toml"
ERROR operation failed error=some files were not properly formatted
```

## Why it's failing

- `.taplo.toml` had only `include = ["Cargo.toml", "**/*.toml"]` and no `exclude`. Taplo recursed into the entire workdir.
- The `cargo-fmt` job in `.github/workflows/rust.yml` restores `Swatinem/rust-cache@v2` with `shared-key: build-creditcoin-node` *before* the format check. That repopulates `target/` from a previous build.
- The cached `target/` includes auto-generated `Cargo.toml` files emitted by the `wasm-opt-sys` / `wasm-opt-cxx-sys` build scripts (cxxbridge crates). Those are not formatted to our taste — and they shouldn't be, we don't own them.
- Result: format check fails on artifacts that are recreated from scratch on every clean build.

This isn't PR #881's fault — any PR that lands on a runner with a primed `target/` cache would hit this. It just happens that the cache was warm for that run.

## Fix

Add an explicit `exclude` to `.taplo.toml`:

```toml
exclude = [
    "target/**",
    "**/target/**",
    "node_modules/**",
    "**/node_modules/**",
]
```

Per Taplo's <https://taplo.tamasfe.dev/configuration/file.html#exclude|docs>, `exclude` takes precedence over `include`, so this is the canonical way to say "lint everything in the repo except generated/vendored junk."

I also added `node_modules/**` proactively — there's `cli/node_modules/@gluwa/usc-sdk/rust/Cargo.toml` shipping in the SDK package that we likewise don't own.

## Verification

Reproduced locally with a fully-populated `target/` (debug, release, llvm-cov-target, cxxbridge crates):

```
$ taplo format --check
 INFO taplo:format_files:collect_files: found files total=54 excluded=13 cwd="/home/claw/creditcoin3"
exit=0
```

Without the change taplo errored on the two cxxbridge Cargo.tomls (matching the CI failure exactly).

No workflow changes needed — config-only fix.