### PR TITLE
fix(chill): prevent quorum submission when inelligible

### DIFF
--- a/attestor/attestor/src/lib.rs
+++ b/attestor/attestor/src/lib.rs
@@ -372,12 +372,14 @@ impl Attestor {
 
         tracing::info!("⏳ [2/4] Starting attestation validation worker");
 
+        let can_attest = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
         let config = worker::validation::ConfigBuilder::new()
             .with_stream_cc3(stream_cc3_validation)
             .with_cc3(client_cc3.clone())
             .with_signer(signer)
             .with_validation_receiver(receiver_validation)
             .with_validation_sender(sender_validation.clone())
+            .with_can_attest(std::sync::Arc::clone(&can_attest))
             .with_api_calls(cc_client::Client::runtime_api())
             .with_start_height(start_height)
             .with_genesis(genesis)
@@ -449,6 +451,7 @@ impl Attestor {
             .with_sender_validation(sender_validation)
             .with_interval_attestation(interval_attestation)
             .with_attestation_latest_cc3(attestation_latest_cc3)
+            .with_can_attest(std::sync::Arc::clone(&can_attest))
             .with_start_height(start_height)
             .with_account_id(account_id)
             .with_metrics(metrics)

--- a/attestor/attestor/src/worker/production/mod.rs
+++ b/attestor/attestor/src/worker/production/mod.rs
@@ -107,6 +107,7 @@ pub struct Config {
 
     interval_attestation: std::num::NonZero<attestor_primitives::Height>,
     attestation_latest_cc3: stream::util::AttestationInfo,
+    can_attest: std::sync::Arc<std::sync::atomic::AtomicBool>,
 
     start_height: attestor_primitives::Height,
     account_id: cc_client::AccountId32,
@@ -136,7 +137,7 @@ pub(crate) struct WorkerAttestationProduction {
 
     // ATTESTOR DATA
     account_id: cc_client::AccountId32,
-    can_attest: bool,
+    can_attest: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl WorkerAttestationProduction {
@@ -157,7 +158,7 @@ impl WorkerAttestationProduction {
             metrics: config.metrics,
 
             account_id: config.account_id,
-            can_attest: true,
+            can_attest: config.can_attest,
         }
     }
 }
@@ -175,6 +176,8 @@ impl super::Worker for WorkerAttestationProduction {
         use futures::StreamExt as _;
 
         loop {
+            let can_attest = self.can_attest.load(std::sync::atomic::Ordering::Acquire);
+
             tokio::select! {
                 biased;
 
@@ -184,7 +187,7 @@ impl super::Worker for WorkerAttestationProduction {
                 Some(events) = self.stream_cc3.next() => {
                     self.handle_event_cc3(events).await?;
                 }
-                Some(attestation) = self.stream_attestation.next(), if self.can_attest => {
+                Some(attestation) = self.stream_attestation.next(), if can_attest => {
                     self.handle_event_attestation(attestation).await?;
                 }
             }
@@ -405,13 +408,15 @@ impl WorkerAttestationProduction {
                     //
                     // Update local attestation eligibility.
                     if attestors.contains(&self.account_id) {
-                        self.can_attest = true;
+                        self.can_attest
+                            .store(true, std::sync::atomic::Ordering::Release);
                         tracing::info!(
                             attestor_id = %self.account_id,
                             "☀️ Attestor is eligible for production"
                         );
                     } else {
-                        self.can_attest = false;
+                        self.can_attest
+                            .store(false, std::sync::atomic::Ordering::Release);
                         tracing::info!(
                             attestor_id = %self.account_id,
                             "🛏️ Waiting for attestor to be elected"
@@ -445,7 +450,8 @@ impl WorkerAttestationProduction {
                 // CASE 8] ATTESTOR DEACTIVATION
                 cc_client::attestation::CcEvent::AttestorChilled(_chain_key, attestor) => {
                     if attestor == self.account_id {
-                        self.can_attest = false;
+                        self.can_attest
+                            .store(false, std::sync::atomic::Ordering::Release);
                         tracing::info!(
                             attestor_id = %self.account_id,
                             "🪫 Attestor has been deactivated"
@@ -456,7 +462,8 @@ impl WorkerAttestationProduction {
                 // CASE 9] ATTESTOR FORCE-KICK
                 cc_client::attestation::CcEvent::AttestorKicked(attestor) => {
                     if attestor == self.account_id {
-                        self.can_attest = false;
+                        self.can_attest
+                            .store(false, std::sync::atomic::Ordering::Release);
                         tracing::info!(
                             attestor_id = %self.account_id,
                             "💥 Attestor has been kicked"

--- a/attestor/attestor/src/worker/validation/mod.rs
+++ b/attestor/attestor/src/worker/validation/mod.rs
@@ -106,6 +106,7 @@ pub struct Config {
 
     validation_sender: attestation_pool::AttestationPoolSender,
     validation_receiver: attestation_pool::AttestationPoolReceiver,
+    can_attest: std::sync::Arc<std::sync::atomic::AtomicBool>,
 
     api_calls: cc_client::cc3::runtime_apis::RuntimeApi,
     start_height: attestor_primitives::Height,
@@ -126,6 +127,7 @@ pub(crate) struct WorkerAttestationValidation {
     watch_submission: future::OptionFuture<(AttestationSubmission, attestor_primitives::Height)>,
     validation_sender: attestation_pool::AttestationPoolSender,
     validation_receiver: attestation_pool::AttestationPoolReceiver,
+    can_attest: std::sync::Arc<std::sync::atomic::AtomicBool>,
 
     // CHAIN DATA
     api_calls: cc_client::cc3::runtime_apis::RuntimeApi,
@@ -146,6 +148,7 @@ impl WorkerAttestationValidation {
             watch_submission: future::OptionFuture::default(),
             validation_receiver: config.validation_receiver,
             validation_sender: config.validation_sender,
+            can_attest: config.can_attest,
 
             api_calls: config.api_calls,
             start_height: config.start_height,
@@ -167,6 +170,8 @@ impl super::Worker for WorkerAttestationValidation {
         use futures::StreamExt as _;
 
         loop {
+            let can_attest = self.can_attest.load(std::sync::atomic::Ordering::Acquire);
+
             tokio::select! {
                 biased;
 
@@ -176,7 +181,7 @@ impl super::Worker for WorkerAttestationValidation {
                 event = &mut self.watch_submission => {
                     self.handle_event_submission(event).await?;
                 }
-                event = self.validation_receiver.next() => {
+                event = self.validation_receiver.next(), if can_attest => {
                     self.handle_event_quorum(event).await?;
                 },
             }
@@ -984,6 +989,12 @@ impl WorkerAttestationValidation {
         // If the attestation has not finalized in time, then we submit it anyway. This
         // happens on average either if the attestor is first in line for submission or if
         // another attestor went down.
+
+        // Make sure the attestor hasn't been chilled in the time it took to await backoff
+        let can_attest = self.can_attest.load(std::sync::atomic::Ordering::Acquire);
+        if !can_attest {
+            return Ok(());
+        }
 
         let call = cc_client::cc3::tx()
             .attestation()

--- a/attestor/attestor/src/worker/validation/mod.rs
+++ b/attestor/attestor/src/worker/validation/mod.rs
@@ -170,8 +170,6 @@ impl super::Worker for WorkerAttestationValidation {
         use futures::StreamExt as _;
 
         loop {
-            let can_attest = self.can_attest.load(std::sync::atomic::Ordering::Acquire);
-
             tokio::select! {
                 biased;
 
@@ -181,7 +179,7 @@ impl super::Worker for WorkerAttestationValidation {
                 event = &mut self.watch_submission => {
                     self.handle_event_submission(event).await?;
                 }
-                event = self.validation_receiver.next(), if can_attest => {
+                event = self.validation_receiver.next() => {
                     self.handle_event_quorum(event).await?;
                 },
             }
@@ -297,6 +295,11 @@ impl WorkerAttestationValidation {
 
         let (submission, height) = submission;
 
+        // WARNING: PANIC
+        //
+        // Resets `watch_submission` to avoid double polling on future calls!
+        self.watch_submission = future::OptionFuture::default();
+
         match submission {
             // CASE 1] SUBMITTED ATTESTATION
             AttestationSubmission::Eligible { success, votes } => {
@@ -313,11 +316,6 @@ impl WorkerAttestationValidation {
                                 tracing::info!(height, "✅ Attestation submitted on-chain");
                             }
                             _ => {
-                                // WARNING: PANIC
-                                //
-                                // Any early return must reset the `watch_submission` future to
-                                // avoid double polling!
-                                self.watch_submission = future::OptionFuture::default();
                                 return Ok(());
                             }
                         }
@@ -356,20 +354,10 @@ impl WorkerAttestationValidation {
                                     };
                                 }
 
-                                // WARNING: PANIC
-                                //
-                                // Any early return must reset the `watch_submission` future to
-                                // avoid double polling!
-                                self.watch_submission = future::OptionFuture::default();
                                 return Ok(());
                             }
                             err => {
                                 tracing::error!(height, ?err, "⛔ Invalid attestation");
-                                // WARNING: PANIC
-                                //
-                                // Any early return must reset the `watch_submission` future to
-                                // avoid double polling!
-                                self.watch_submission = future::OptionFuture::default();
                                 return Ok(());
                             }
                         }
@@ -377,11 +365,6 @@ impl WorkerAttestationValidation {
                     // CASE 1.C] RUNTIME SUBMISSION FAILURE
                     Err(err) => {
                         tracing::error!(height, ?err, "⛔ Submission failure");
-                        // WARNING: PANIC
-                        //
-                        // Any early return must reset the `watch_submission` future to
-                        // avoid double polling!
-                        self.watch_submission = future::OptionFuture::default();
                         return Ok(());
                     }
                 }
@@ -412,7 +395,6 @@ impl WorkerAttestationValidation {
                             }
                         }
                         _ = tokio::signal::ctrl_c() => {
-                            self.watch_submission = future::OptionFuture::default();
                             return Err(Interrupt::Stop);
                         }
                     }
@@ -454,11 +436,9 @@ impl WorkerAttestationValidation {
                                 height,
                                 "🏃 Attestation finalization timed out, assuming no leader was elected"
                             );
-                            self.watch_submission = future::OptionFuture::default();
                             return Ok(());
                         }
                         _ = tokio::signal::ctrl_c() => {
-                            self.watch_submission = future::OptionFuture::default();
                             return Err(Interrupt::Stop);
                         }
                     }
@@ -474,10 +454,8 @@ impl WorkerAttestationValidation {
         if let Some((height, digest, attestation, votes)) =
             self.validation_receiver.take_next_validated()
         {
-            // CASE 1] AN ATTESTATION IS READY
-            //
-            // Submit that attestation and wait for it to be validated by the runtime as part of the
-            // typical `WorkerAttestationValidation::task` event loop.
+            // At attestation is ready, Submit it and wait for it to be validated by the runtime as
+            // part of the typical `WorkerAttestationValidation::task` event loop.
 
             tracing::info!(
                 ?digest,
@@ -491,12 +469,6 @@ impl WorkerAttestationValidation {
             );
 
             self.submit_attestation(attestation, votes, height).await?;
-        } else {
-            // CASE 2] NO ATTESTATION
-            //
-            // Default to waiting for the next quorum which will be submitted immediately on
-            // local validation.
-            self.watch_submission = future::OptionFuture::default();
         }
 
         Ok(())
@@ -816,6 +788,13 @@ impl WorkerAttestationValidation {
         use futures::FutureExt as _;
         use futures::StreamExt as _;
         use futures::TryStreamExt as _;
+
+        // Don't submit if the attestor is currently chilled
+        let can_attest = self.can_attest.load(std::sync::atomic::Ordering::Acquire);
+        if !can_attest {
+            tracing::info!("⏳ Attestor chilled, skipping submission");
+            return Ok(());
+        }
 
         let (randomness, epoch_index) = loop {
             match self.cc3.fetch_babe_randomness_two_epoch_ago().await {


### PR DESCRIPTION
# Description of proposed changes

<describe what this PR is about and why we want it>

> [!NOTE]
> _Follow-up to_ #879 

##  Features

- Attestors share chill status between the production and validation worker.

##  Fixes

- Attestors no longer try to submit quorums if they are chilled.

## Known limitations

- Submission can still fail with "AttestorNotActive" if a runtime call to `commit_attestation` is made right before an attestor is chilled.

---

# Testing

To test this PR, start a local cc3 chain against anvil **with fast-runtime disabled**. Spawn zombienet and rotate the attestor set. wait for initial attestations to come in. Chill some attestors, update the target sample size accordingly, apply pending updates and force-rotate the attestor set. You will notice quorum is still observed and chilled attestors no longer try to commit attestations.