### PR TITLE
fix(traffic-simulator): add global unhandled-rejection backstop and wrap remaining ethers calls

### DIFF
--- a/scripts/traffic-simulator/src/main.ts
+++ b/scripts/traffic-simulator/src/main.ts
@@ -7,6 +7,19 @@
  * 3. Submitting proofs for random transactions once blocks are attested
  */
 
+// Global backstop: prevent Deno from killing the simulator on a stray
+// unhandled promise rejection (typically a late ethers `request timeout`
+// from an HTTP call whose original awaiter already gave up via withTimeout).
+// Installed as early as possible — before any imports that might spawn
+// network promises during module evaluation.
+globalThis.addEventListener("unhandledrejection", (event) => {
+  event.preventDefault();
+  console.error(
+    "⚠️  Swallowed unhandled rejection:",
+    (event as PromiseRejectionEvent).reason,
+  );
+});
+
 // Suppress Deno Node.js compatibility warnings
 const originalWarn = console.warn;
 console.warn = (...args: unknown[]) => {

--- a/scripts/traffic-simulator/src/submission/precompile.ts
+++ b/scripts/traffic-simulator/src/submission/precompile.ts
@@ -46,7 +46,11 @@ async function sendTransaction(
   label: string,
 ): Promise<ethers.TransactionResponse> {
   try {
-    return await signer.sendTransaction(request);
+    return await withTimeout(
+      signer.sendTransaction(request),
+      RPC_TIMEOUT_MS,
+      `${label} broadcast`,
+    );
   } catch (error) {
     if (!isReplacementUnderpricedError(error)) throw error;
 
@@ -57,11 +61,15 @@ async function sendTransaction(
       `${label} nonce`,
     );
     console.debug("Retrying underpriced tx", { label, nonce });
-    return await signer.sendTransaction({
-      ...request,
-      nonce,
-      ...bumpFees(request),
-    });
+    return await withTimeout(
+      signer.sendTransaction({
+        ...request,
+        nonce,
+        ...bumpFees(request),
+      }),
+      RPC_TIMEOUT_MS,
+      `${label} broadcast retry`,
+    );
   }
 }
 
@@ -87,9 +95,11 @@ async function waitForReceipt(
     }
 
     // Try direct lookup as fallback
-    const receipt = await provider.getTransactionReceipt(tx.hash).catch(() =>
-      null
-    );
+    const receipt = await withTimeout(
+      provider.getTransactionReceipt(tx.hash),
+      RPC_TIMEOUT_MS,
+      `${label} receipt fallback`,
+    ).catch(() => null);
     if (receipt) return receipt;
 
     throw error;


### PR DESCRIPTION
## Symptom

Despite #d26e5530 (`withTimeout` swallows late rejections) and #ce15d7a2 (skip pre-flight simulation for large calldata), the traffic simulator is still crashing in a restart loop with:

```
error: Uncaught (in promise) Error: request timeout
    at .../ethers/6.16.0/.../geturl.ts:66
```

…immediately followed by a process restart.

## Why the prior fix wasn't enough

`d26e5530` attaches a no-op `.catch` only to promises that are routed through `withTimeout`. Several ethers HTTP-bound calls in `submission/precompile.ts` were invoked directly without going through `withTimeout`, so when their underlying socket eventually rejected (typically the ~30s ethers-internal `request timeout` from `geturl.ts`), there was no listener attached and Deno surfaced an unhandled promise rejection — killing the process.

## Fix (two-pronged, defense-in-depth)

**1. Global backstop in `src/main.ts`**

A top-level `unhandledrejection` listener installed before any other module evaluation calls `preventDefault()` and logs the reason. Even if a future code path leaks a late rejection, Deno will not kill the simulator over it.

```ts
globalThis.addEventListener("unhandledrejection", (event) => {
  event.preventDefault();
  console.error("⚠️  Swallowed unhandled rejection:", (event as PromiseRejectionEvent).reason);
});
```

**2. Wrap the remaining ethers HTTP calls in `src/submission/precompile.ts`**

All HTTP-bound calls now flow through `withTimeout` (which absorbs late rejections per `utils/retry.ts`):

- `signer.sendTransaction(request)` → labelled `${label} broadcast`
- `signer.sendTransaction({ ...request, nonce, ...bumpFees(request) })` → labelled `${label} broadcast retry`
- `provider.getTransactionReceipt(tx.hash)` fallback in `waitForReceipt` → labelled `${label} receipt fallback` (existing `.catch(() => null)` preserved)

Each uses `RPC_TIMEOUT_MS`. Local-only calls like `signer.getAddress()` are unchanged.

I also grepped the rest of `scripts/traffic-simulator/src/` for unwrapped ethers HTTP calls (`provider.*`, `signer.*`, `wallet.*`, `contract.*`, `tx.wait()`, `JsonRpcProvider` instantiations). The remaining call sites (`fees.ts:13` `getFeeData`, `precompile.ts:53` `getTransactionCount`, `precompile.ts:72` `tx.wait()`, `precompile.ts:136` `provider.call`, `blockWatcher.ts:130` `getBlock`) are already wrapped. The watcher providers are WebSocket-based and don't go through `geturl.ts`.

## Verification

- `deno task lint` — ✅ clean (22 files)
- `deno task fmt-check` — ✅ clean (25 files)
- `deno task check` — ✅ clean (typechecks `src/main.ts`)
- `deno task test` — no test modules in this package

## Out of scope

This PR does **not** address the `continuity upper-boundary digest mismatch` errors from the proof-gen-api server that Beqa also reported. That is a separate server-side issue and should be investigated independently by the `proof-gen-api-server/` owners.
