### PR TITLE
Add socket timeout error handling to Traffic Simulator

### DIFF
--- a/scripts/traffic-simulator/deno.json
+++ b/scripts/traffic-simulator/deno.json
@@ -26,5 +26,8 @@
     "rules": {
       "tags": ["recommended"]
     }
+  },
+  "exports": {
+    "main": "src/main.ts"
   }
 }

--- a/scripts/traffic-simulator/src/main.ts
+++ b/scripts/traffic-simulator/src/main.ts
@@ -18,6 +18,26 @@ console.warn = (...args: unknown[]) => {
   originalWarn.apply(console, args);
 };
 
+// Swallow late timeouts from abandoned ethers HTTP requests.
+//
+// When our `withTimeout` wrapper wins the race against a `JsonRpcProvider`
+// call, the inner ethers Promise is still pending — and its underlying
+// `http.ClientRequest` keeps living until the socket idle timer fires.
+// Ethers v6 then rejects internal Promise chains we don't own, which
+// surfaces as `Uncaught (in promise) Error: request timeout` and crashes
+// the simulator. Swallow these specifically.
+addEventListener("unhandledrejection", (event) => {
+  const reason = event.reason;
+  const msg = reason instanceof Error ? reason.message : String(reason ?? "");
+  if (
+    msg.includes("request timeout") &&
+    msg.toLowerCase().includes("code=timeout")
+  ) {
+    event.preventDefault();
+    console.warn(`⚠️  Swallowed late ethers timeout: ${msg}`);
+  }
+});
+
 import { loadConfig, logConfig } from "./config.ts";
 import { BlockWatcher } from "./watchers/blockWatcher.ts";
 import { AttestationWatcher } from "./watchers/attestationWatcher.ts";

--- a/scripts/traffic-simulator/src/submission/signer.ts
+++ b/scripts/traffic-simulator/src/submission/signer.ts
@@ -31,7 +31,19 @@ export function resetSigner(
   cc3HttpUrl: string,
   privateKey: string,
 ): SignerEntry {
-  signerCache.delete(`${cc3HttpUrl}:${privateKey}`);
+  const key = `${cc3HttpUrl}:${privateKey}`;
+  const old = signerCache.get(key);
+  signerCache.delete(key);
+  // Best-effort cleanup of the abandoned provider. `destroy()` clears
+  // internal subscribers and pollers; it does NOT abort in-flight HTTP
+  // requests (ethers v6 doesn't expose a way to cancel them), so any
+  // late `request timeout` rejection still has to be swallowed by
+  // withTimeout's `.catch` and the global handler in main.ts.
+  if (old) {
+    try {
+      old.provider.destroy();
+    } catch { /* ignore */ }
+  }
   return getSigner(cc3HttpUrl, privateKey);
 }
 

--- a/scripts/traffic-simulator/src/utils/errors.ts
+++ b/scripts/traffic-simulator/src/utils/errors.ts
@@ -52,6 +52,13 @@ export function isTransientNetworkError(error: unknown): boolean {
     msg.includes("connection refused") ||
     msg.includes("connection error") ||
     msg.includes("socket disconnected") ||
+    // Our own withTimeout marker — when our outer timeout wins the race
+    // against an ethers RPC, treat it as transient so the retry path
+    // resets the signer (which destroys the abandoned provider).
+    msg.includes("timed out after") ||
+    // Ethers v6 raw timeout: "request timeout (code=TIMEOUT, version=...)"
+    msg.includes("request timeout") ||
+    msg.includes("code=timeout") ||
     (msg.includes("request to") && msg.includes("failed"))
   );
 }


### PR DESCRIPTION
Based on this error trace:

```sh
Batch Proof API request {
  url: "https://proof-gen-api.usc-testnet2.creditcoin.network/api/v1/proof-batch/1",
  queries: 3
}
    📦 Batch txs: 0x808a76f7..., 0xa8e7a401..., 0xc0858102..., 0x8b7a8e6c..., 0x0de571db...
Submitting batch { chainKey: 1, batchSize: 5 }
📦 Block 10755813 queued (143 txs, queue: 11)
❌ Failed to submit proof for 0x062060aa...: Single submit simulation failed: Single submit simulation timed out after 30000ms
📤 Submitting single proof for tx 0x73287df0... (block 10755780, index 64)
Fetching proof { chainKey: 1, block: 10755780, txIndex: 64 }
Proof API request {
  url: "https://proof-gen-api.usc-testnet2.creditcoin.network/api/v1/proof/1/10755780/64"
}
Submitting single proof { chainKey: 1, blockHeight: 10755780, txBytesLen: 3072 }
📦 Block 10755814 queued (139 txs, queue: 12)
    ❌ Batch failed (blocks 10755790-10755792): Batch submit simulation failed: request timeout (code=TIMEOUT, version=6.16.0)
📤 Submitting single proof for tx 0x808a76f7... (block 10755790, index 20)
Fetching proof { chainKey: 1, block: 10755790, txIndex: 20 }
Proof API request {
  url: "https://proof-gen-api.usc-testnet2.creditcoin.network/api/v1/proof/1/10755790/20"
}
error: Uncaught (in promise) Error: request timeout (code=TIMEOUT, version=6.16.0)
            error = new Error(message);
                    ^
    at makeError (file:///deno-dir/npm/registry.npmjs.org/ethers/6.16.0/src.ts/utils/errors.ts:698:21)
    at ClientRequest.<anonymous> (file:///deno-dir/npm/registry.npmjs.org/ethers/6.16.0/src.ts/utils/geturl.ts:66:24)
    at ClientRequest.emit (ext:deno_node/_events.mjs:439:20)
    at TLSSocket.emitRequestTimeout (node:_http_client:743:9)
    at Object.onceWrapper (ext:deno_node/_events.mjs:562:14)
    at TLSSocket.emit (ext:deno_node/_events.mjs:451:22)
    at TLSSocket._onTimeout (node:net:1024:8)
    at Object.cb [as _onTimeout] (ext:deno_node/internal/timers.mjs:149:16)
    at listOnTimeout (ext:core/02_timers.js:307:17)
    at Object.processTimers (ext:core/02_timers.js:250:7)
```

Improves error handling to avoid panicking on uncaught timeout errors from abandoned promises