### PR TITLE
Improve proof-gen-api health endpoint to account for archiver issues

### DIFF
--- a/common/continuity/src/archiver.rs
+++ b/common/continuity/src/archiver.rs
@@ -169,6 +169,20 @@ impl EthRpcProvider for ArchiverEthProvider {
     async fn get_chain_id(&self) -> Result<u64> {
         self.eth_fallback.get_chain_id().await
     }
+
+    async fn is_healthy(&self) -> Result<bool> {
+        // Check both the archiver and the fallback RPC for health.
+        let archiver_healthy = self
+            .archiver
+            .get_latest_block()
+            .await
+            .map(|_| true)
+            .unwrap_or(false);
+
+        let eth_healthy = self.eth_fallback.is_healthy().await.unwrap_or(false);
+
+        Ok(archiver_healthy && eth_healthy)
+    }
 }
 
 fn parse_h256(s: &str) -> Result<H256> {

--- a/common/continuity/src/mocks.rs
+++ b/common/continuity/src/mocks.rs
@@ -295,6 +295,11 @@ impl EthRpcProvider for MockEthRpcProvider {
         // Mock returns test chain ID
         Ok(31337)
     }
+
+    async fn is_healthy(&self) -> Result<bool> {
+        // Mock provider is always healthy
+        Ok(true)
+    }
 }
 
 /// Create a pair of mock RPC providers for testing.

--- a/common/continuity/src/rpc.rs
+++ b/common/continuity/src/rpc.rs
@@ -238,6 +238,9 @@ pub trait EthRpcProvider: Send + Sync {
     ///
     /// Useful for validation and health checks.
     async fn get_chain_id(&self) -> Result<u64>;
+
+    /// Check if the source chain RPC is healthy.
+    async fn is_healthy(&self) -> Result<bool>;
 }
 
 #[async_trait]
@@ -396,6 +399,15 @@ impl EthRpcProvider for ReconnectingEthRpcProvider {
                 .map_err(|e| anyhow!("Failed to get chain ID: {e}"))
         })
         .await
+    }
+
+    async fn is_healthy(&self) -> Result<bool> {
+        let _ = self
+            .get_chain_id()
+            .await
+            .map_err(|e| anyhow!("Failed to get chain ID: {e}"))?;
+
+        Ok(true)
     }
 }
 

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -330,6 +330,10 @@ mod tests {
         async fn get_chain_id(&self) -> Result<u64> {
             Ok(31337)
         }
+
+        async fn is_healthy(&self) -> Result<bool> {
+            Ok(true)
+        }
     }
 
     struct ErrorEthProvider;
@@ -362,6 +366,10 @@ mod tests {
         }
         async fn get_chain_id(&self) -> Result<u64> {
             Ok(31337)
+        }
+
+        async fn is_healthy(&self) -> Result<bool> {
+            Err(anyhow::anyhow!("connection refused"))
         }
     }
 

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -392,9 +392,12 @@ impl ContinuityService {
         for (chain_key, chain) in &self.chains {
             chain
                 .builder
-                .get_eth_chain_id()
+                .eth_provider
+                .is_healthy()
                 .await
-                .map_err(|e| anyhow::anyhow!("eth RPC chain {chain_key}: {e}"))?;
+                .map_err(|e| anyhow::anyhow!("eth RPC chain {chain_key}: {e}"))?
+                .then_some(())
+                .ok_or_else(|| anyhow::anyhow!("eth RPC chain {chain_key} is unhealthy"))?;
         }
         Ok(())
     }


### PR DESCRIPTION
Adds a new method `is_healthy` to ethereum rpc interface and adjusts proof-gen server health check to fail if any of the configured archivers is having trouble