### PR TITLE
fix(traffic-simulator): cap uniqueErrors map at 500 to bound memory g…

### DIFF
--- a/scripts/traffic-simulator/src/main.ts
+++ b/scripts/traffic-simulator/src/main.ts
@@ -70,6 +70,11 @@ const metrics = {
 
 let lastError: string | null = null;
 const uniqueErrors: Map<string, number> = new Map();
+// Bound the unique-error map so a long-running process with high error
+// diversity (e.g. RPC dropout storms producing many distinct messages even
+// after `normalizeError`) cannot grow it without limit. Oldest entry is
+// evicted when the cap is reached.
+const MAX_UNIQUE_ERRORS = 500;
 
 /**
  * Normalize an error message by stripping variable parts (URLs, block/tx numbers)
@@ -104,6 +109,13 @@ function recordError(error: string): void {
   lastError = error;
   const key = normalizeError(error);
   if (!key) return;
+  // If the key already exists, just bump the count. If we're at capacity and
+  // adding a new key, evict the oldest insertion (Map preserves insertion
+  // order, so .keys().next() gives the oldest).
+  if (!uniqueErrors.has(key) && uniqueErrors.size >= MAX_UNIQUE_ERRORS) {
+    const oldestKey = uniqueErrors.keys().next().value;
+    if (oldestKey !== undefined) uniqueErrors.delete(oldestKey);
+  }
   uniqueErrors.set(key, (uniqueErrors.get(key) ?? 0) + 1);
 }
 


### PR DESCRIPTION
The uniqueErrors map in main.ts grows unbounded over the process lifetime
  — it was only cleared via the /reset-errors HTTP endpoint, which the
  reporter cron hits but devnet's was last cleared 11h ago. During RPC
  dropout storms (e.g. the 108s source-chain disconnect we saw on
  usc-devnet on Apr 30) the map accumulates hundreds of distinct keys
  even after normalizeError(), since stack traces and timing parts of
  messages survive normalization.

  Combined with the 256Mi container limit, this contributes to the
  OOMKilled cycles observed on usc-devnet (2 restarts / 9h, exit 137)
  that prior unhandled-rejection fixes (#2cd19f76, #d26e5530) do not
  address.

  Cap the map at 500 entries with FIFO eviction (Map preserves insertion
  order, so .keys().next() yields the oldest). Existing keys still bump
  their count freely; only adding a new key past the cap evicts.

  Container memory limit should still be raised separately — this fix
  removes the unbounded-growth contributor, not the underlying capacity
  shortfall during reconnect bursts.