### PR TITLE
feat(traffic-simulator): fee headroom + configurable tip + log-on-submit at info level

### DIFF
--- a/scripts/traffic-simulator/src/constants.ts
+++ b/scripts/traffic-simulator/src/constants.ts
@@ -51,7 +51,39 @@ export const SINGLE_PROOF_GAS_LIMIT = 5_000_000n;
 export const BATCH_PROOF_GAS_LIMIT = 10_000_000n;
 
 // Fee settings
-export const MIN_PRIORITY_FEE_GWEI = 1n;
+//
+// Tip floor (`MIN_PRIORITY_FEE_GWEI`): the minimum priority fee we'll attach
+// to a tx. Override via env for chains where 1 gwei is not enough to outbid
+// the mempool floor under contention.
+const _minPriority = Number(Deno.env.get("MIN_PRIORITY_FEE_GWEI"));
+export const MIN_PRIORITY_FEE_GWEI =
+  Number.isFinite(_minPriority) && _minPriority > 0
+    ? BigInt(Math.floor(_minPriority))
+    : 1n;
+
+// Tip ceiling (`MAX_PRIORITY_FEE_GWEI`): hard cap on the tip after the
+// headroom multiplier. Keeps a misconfigured headroom from producing
+// absurdly high tips. `0` disables the cap.
+const _maxPriority = Number(Deno.env.get("MAX_PRIORITY_FEE_GWEI"));
+export const MAX_PRIORITY_FEE_GWEI =
+  Number.isFinite(_maxPriority) && _maxPriority > 0
+    ? BigInt(Math.floor(_maxPriority))
+    : 0n;
+
+// Fee headroom (`FEE_HEADROOM_PERCENT`): extra percent applied on top of
+// the node's suggested `maxFeePerGas` / `maxPriorityFeePerGas` (and on the
+// legacy `gasPrice` path) before we broadcast. Default 100% → 2×.
+//
+// Why: `eth_feeHistory`-derived suggestions track the *current* base fee;
+// if the next block's base fee jumps, a tx whose `maxFeePerGas` was equal
+// to the current base fee + small tip will sit in the mempool until base
+// fee falls back. Adding headroom is the standard fix used by production
+// submitters and matches what wallets do under the hood.
+const _feeHeadroom = Number(Deno.env.get("FEE_HEADROOM_PERCENT"));
+export const FEE_HEADROOM_PERCENT =
+  Number.isFinite(_feeHeadroom) && _feeHeadroom >= 0
+    ? BigInt(Math.floor(_feeHeadroom))
+    : 100n;
 
 // Precompile address
 export const PRECOMPILE_ADDRESS = "0x0000000000000000000000000000000000000FD2";

--- a/scripts/traffic-simulator/src/submission/fees.ts
+++ b/scripts/traffic-simulator/src/submission/fees.ts
@@ -3,8 +3,38 @@
  */
 
 import { ethers, JsonRpcProvider } from "ethers";
-import { MIN_PRIORITY_FEE_GWEI, RPC_TIMEOUT_MS } from "../constants.ts";
+import {
+  FEE_HEADROOM_PERCENT,
+  MAX_PRIORITY_FEE_GWEI,
+  MIN_PRIORITY_FEE_GWEI,
+  RPC_TIMEOUT_MS,
+} from "../constants.ts";
 import { withTimeout } from "../utils/retry.ts";
+
+const GWEI = 1_000_000_000n;
+
+/**
+ * Apply `FEE_HEADROOM_PERCENT` extra on top of `value`.
+ * `headroom = 0` is a no-op; default 100 means 2×.
+ */
+function applyHeadroom(value: bigint): bigint {
+  if (FEE_HEADROOM_PERCENT === 0n) return value;
+  return value + (value * FEE_HEADROOM_PERCENT) / 100n;
+}
+
+/**
+ * Clamp the priority fee to `[MIN_PRIORITY_FEE_GWEI, MAX_PRIORITY_FEE_GWEI]`.
+ * `MAX_PRIORITY_FEE_GWEI = 0` disables the upper bound.
+ */
+function clampPriority(priority: bigint): bigint {
+  const minPriority = MIN_PRIORITY_FEE_GWEI * GWEI;
+  let p = priority < minPriority ? minPriority : priority;
+  if (MAX_PRIORITY_FEE_GWEI > 0n) {
+    const maxPriority = MAX_PRIORITY_FEE_GWEI * GWEI;
+    if (p > maxPriority) p = maxPriority;
+  }
+  return p;
+}
 
 export async function getFeeOverrides(
   provider: JsonRpcProvider,
@@ -14,17 +44,26 @@ export async function getFeeOverrides(
     RPC_TIMEOUT_MS,
     "Fee data",
   );
-  const minPriority = MIN_PRIORITY_FEE_GWEI * 1_000_000_000n;
 
   if (feeData.maxFeePerGas !== null) {
-    const priority = feeData.maxPriorityFeePerGas ?? minPriority;
+    // EIP-1559 path: bump both the cap *and* the tip with headroom so a
+    // single base-fee jump doesn't strand the tx, then enforce the
+    // configurable tip floor and (optional) ceiling. `maxFeePerGas` must
+    // remain >= tip after bumping or ethers will reject the tx.
+    const suggestedTip = feeData.maxPriorityFeePerGas ??
+      MIN_PRIORITY_FEE_GWEI * GWEI;
+    const priority = clampPriority(applyHeadroom(suggestedTip));
+    let maxFee = applyHeadroom(feeData.maxFeePerGas);
+    if (maxFee < priority) maxFee = priority;
     return {
-      maxFeePerGas: feeData.maxFeePerGas,
-      maxPriorityFeePerGas: priority < minPriority ? minPriority : priority,
+      maxFeePerGas: maxFee,
+      maxPriorityFeePerGas: priority,
     };
   }
 
-  return { gasPrice: feeData.gasPrice ?? minPriority };
+  // Legacy path: no EIP-1559 fee data, just bump the suggested gasPrice.
+  const suggested = feeData.gasPrice ?? MIN_PRIORITY_FEE_GWEI * GWEI;
+  return { gasPrice: applyHeadroom(suggested) };
 }
 
 export function bumpFees(

--- a/scripts/traffic-simulator/src/submission/precompile.ts
+++ b/scripts/traffic-simulator/src/submission/precompile.ts
@@ -39,6 +39,30 @@ import PRECOMPILE_ABI from "../abi/block_prover.json" with { type: "json" };
 // Transaction Submission (private)
 // ============================================================================
 
+/**
+ * Format fee overrides as gwei strings for human-readable logging.
+ * Wei values are unwieldy in logs; gwei is what operators actually reason
+ * about when diagnosing fee-related issues.
+ */
+function formatFees(
+  overrides: ethers.TransactionRequest,
+): Record<string, string> {
+  const toGwei = (v: bigint | null | undefined): string | undefined =>
+    v === null || v === undefined
+      ? undefined
+      : `${ethers.formatUnits(v as bigint, "gwei")} gwei`;
+  const out: Record<string, string> = {};
+  const maxFee = toGwei(overrides.maxFeePerGas as bigint | null | undefined);
+  const tip = toGwei(
+    overrides.maxPriorityFeePerGas as bigint | null | undefined,
+  );
+  const gasPrice = toGwei(overrides.gasPrice as bigint | null | undefined);
+  if (maxFee !== undefined) out.maxFeePerGas = maxFee;
+  if (tip !== undefined) out.maxPriorityFeePerGas = tip;
+  if (gasPrice !== undefined) out.gasPrice = gasPrice;
+  return out;
+}
+
 async function sendTransaction(
   signer: ethers.NonceManager,
   provider: JsonRpcProvider,
@@ -169,7 +193,10 @@ async function executePrecompileCall(
 
         // Get fee data
         const feeOverrides = await getFeeOverrides(provider);
-        console.debug(`${label} fees`, { ...feeOverrides });
+        // Logged at info level so the fees we actually broadcast with show
+        // up at production log levels — critical for diagnosing stuck-tx
+        // / receipt-timeout errors after the fact.
+        console.info(`${label} fees`, formatFees(feeOverrides));
 
         return { entry, feeOverrides };
       } catch (error) {
@@ -230,7 +257,14 @@ async function executePrecompileCall(
       { to: PRECOMPILE_ADDRESS, data, gasLimit, ...feeOverrides },
       label,
     );
-    console.debug(`${label} sent`, { txHash: tx.hash, nonce: tx.nonce });
+    // Logged at info level (not debug) so receipt-timeout reports can be
+    // cross-referenced against the txHash/nonce/fees we actually broadcast.
+    console.info(`${label} sent`, {
+      txHash: tx.hash,
+      nonce: tx.nonce,
+      from: tx.from,
+      ...formatFees(feeOverrides),
+    });
 
     return { tx, provider };
   };


### PR DESCRIPTION
## What

Three related changes that together make the simulator more resilient to mempool contention and far easier to diagnose when txs get stuck.

### 1. Fee headroom (`FEE_HEADROOM_PERCENT`, default `100` → 2×)

`getFeeData()` returns a `maxFeePerGas` that tracks the **current** base fee. When the next block's base fee jumps, a tx broadcast at that level sits in the mempool until base fee falls back — manifesting as `confirmation timed out` from `tx.wait()`.

Applying a headroom multiplier on top of the node's suggestion is the standard fix and matches what production wallets do under the hood. Applied on:

- the EIP-1559 path (bumps **both** `maxFeePerGas` and `maxPriorityFeePerGas`)
- the legacy `gasPrice` path

`maxFeePerGas` is kept `>= tip` so ethers won't reject the tx. Set `FEE_HEADROOM_PERCENT=0` to opt out entirely.

### 2. Configurable tip floor + ceiling

- `MIN_PRIORITY_FEE_GWEI` is now env-driven (default `1`, same as before).
- New `MAX_PRIORITY_FEE_GWEI` caps the tip after the headroom multiplier — purely a safety net against misconfiguration; default `0` disables the cap to preserve current behavior.

### 3. Log fees at info level on broadcast

The `${label} fees` and `${label} sent` lines were `console.debug` — invisible at production log levels, which made stuck-tx diagnosis hard because we couldn't tell what fees we'd actually paid for the timed-out tx.

Both lines are now `console.info`, with fees rendered as gwei strings (not raw wei) and the `sent` log carrying `txHash`, `nonce`, `from`, **and the fees** together. Receipt timeouts can now be cross-referenced against the actual broadcast parameters without enabling debug logs.

## Why

Follow-up to #902. Working theory (raised by @beqaabu in <https://gluwa.slack.com|#C0AGC5PC6VC>) is that the `Single submit confirmation timed out` errors are caused by underpriced txs sitting in the mempool, not actual chain stalls. This PR makes the fee strategy resilient to base-fee jumps and makes the diagnostic data visible at prod log levels so we can confirm or rule that out from logs alone.

## Sample log output

Before (debug-only, raw wei):
```
[debug] Single submit fees { maxFeePerGas: 1500000000n, maxPriorityFeePerGas: 1000000000n }
[debug] Single submit sent { txHash: '0xa62432f5...', nonce: 4271 }
```
After (info, gwei, full context):
```
[info] Single submit fees { maxFeePerGas: '3.0 gwei', maxPriorityFeePerGas: '2.0 gwei' }
[info] Single submit sent { txHash: '0xa62432f5...', nonce: 4271, from: '0xabc...', maxFeePerGas: '3.0 gwei', maxPriorityFeePerGas: '2.0 gwei' }
```

## Breaking-ish change

The default 2× headroom raises the gas cost of submissions on the happy path. Operators on cheap chains who want the old behavior can set `FEE_HEADROOM_PERCENT=0`. Worth flagging because some cost dashboards may notice.

## Checks

- `deno fmt --check` ✅
- `deno lint` ✅
- `deno check src/main.ts` ✅

## Out of scope (deliberately separate)

- Stuck-tx rebroadcast loop (re-send same nonce with bumped fees after a watchdog instead of waiting for `RECEIPT_TIMEOUT_MS`). Real new logic, deserves its own review.