### PR TITLE
feat(traffic-simulator): dynamic gasLimit via estimateGas + balance preflight

### DIFF
--- a/scripts/traffic-simulator/src/constants.ts
+++ b/scripts/traffic-simulator/src/constants.ts
@@ -47,8 +47,37 @@ export const MAX_TRANSIENT_RETRIES = 3;
 export const TRANSIENT_RETRY_BASE_DELAY_MS = 2_000;
 
 // Gas limits
+//
+// These are now treated as **ceilings** rather than unconditional values.
+// Submission code calls `eth_estimateGas` and pads the result; the
+// constants below cap that estimate so a misbehaving node can't hand us
+// an absurd value, and act as a fallback if estimation itself fails.
 export const SINGLE_PROOF_GAS_LIMIT = 5_000_000n;
 export const BATCH_PROOF_GAS_LIMIT = 10_000_000n;
+
+// Floor on the dynamically-computed gasLimit. Anything below this is
+// almost certainly a bad estimate (e.g. Frontier returning 21000 for a
+// precompile call) and we want to reject it rather than ship a tx that
+// will out-of-gas mid-call.
+export const MIN_DYNAMIC_GAS_LIMIT = 200_000n;
+
+// Buffer (`GAS_BUFFER_PERCENT`) applied on top of `eth_estimateGas`.
+// Default 20%. Bigger proofs and Frontier RPC sometimes underestimate by
+// more than EVM does, so we pad before capping.
+const _gasBuffer = Number(Deno.env.get("GAS_BUFFER_PERCENT"));
+export const GAS_BUFFER_PERCENT = Number.isFinite(_gasBuffer) && _gasBuffer >= 0
+  ? BigInt(Math.floor(_gasBuffer))
+  : 20n;
+
+// Per-continuity-block extra gas (`GAS_PER_CONTINUITY_BLOCK`). Continuity
+// verification cost scales with the number of roots in the continuity
+// proof, and `estimateGas` doesn't always capture that growth precisely
+// for large batches. Default 50k per block.
+const _gasPerBlock = Number(Deno.env.get("GAS_PER_CONTINUITY_BLOCK"));
+export const GAS_PER_CONTINUITY_BLOCK =
+  Number.isFinite(_gasPerBlock) && _gasPerBlock >= 0
+    ? BigInt(Math.floor(_gasPerBlock))
+    : 50_000n;
 
 // Fee settings
 export const MIN_PRIORITY_FEE_GWEI = 1n;

--- a/scripts/traffic-simulator/src/submission/gas.ts
+++ b/scripts/traffic-simulator/src/submission/gas.ts
@@ -1,0 +1,177 @@
+/**
+ * Dynamic gas-limit estimation for precompile transactions.
+ *
+ * Why dynamic instead of fixed? Shipping a fixed 5M / 10M `gasLimit` for
+ * every submission has two failure modes:
+ *
+ *   1. Block-builder deprioritization. Validators ordering by effective gas
+ *      price for the slot a tx takes up will deprioritize fat txs in favor
+ *      of skinnier ones at the same fee, even when the fat tx pays more in
+ *      absolute terms. The fat tx sits in the mempool and `tx.wait()`
+ *      eventually times out.
+ *   2. Upfront balance check. Nodes reject txs where
+ *      `gasLimit * maxFeePerGas > sender.balance` even though the actual
+ *      spend would have been a fraction of that. Easy to trip on a
+ *      low-balance signer with `gasLimit = 10_000_000`.
+ *
+ * `eth_estimateGas` + a buffer is what production submitters do. The
+ * existing `*_GAS_LIMIT` constants are kept as ceilings (and as fallback
+ * values when estimation itself fails) rather than unconditional values.
+ */
+
+import { ethers, JsonRpcProvider } from "ethers";
+import {
+  GAS_BUFFER_PERCENT,
+  GAS_PER_CONTINUITY_BLOCK,
+  MIN_DYNAMIC_GAS_LIMIT,
+  PRECOMPILE_ADDRESS,
+  RPC_TIMEOUT_MS,
+} from "../constants.ts";
+import { withTimeout } from "../utils/retry.ts";
+import { getErrorMessage } from "../utils/errors.ts";
+
+interface ComputeGasLimitParams {
+  provider: JsonRpcProvider;
+  from: string;
+  data: string;
+  /**
+   * Number of continuity-proof roots in this submission. `1` for single
+   * proofs; `continuityProof.roots.length` for batches.
+   */
+  continuityBlocks: number;
+  /**
+   * Hard ceiling on the returned `gasLimit`. The dynamically-computed
+   * value is `min(estimate * buffer + perBlockPadding, ceiling)`.
+   */
+  ceiling: bigint;
+  /**
+   * Fallback returned (along with a warning log) when `estimateGas`
+   * itself errors. Typically the same value as `ceiling`.
+   */
+  fallback: bigint;
+  /** Log label for diagnostics. */
+  label: string;
+}
+
+/**
+ * Compute a tight-but-safe `gasLimit` for a precompile submission.
+ *
+ * - Calls `eth_estimateGas` (under `RPC_TIMEOUT_MS`) — Frontier nodes can
+ *   be slow to estimate because it runs the full precompile.
+ * - Pads with `GAS_BUFFER_PERCENT` (default 20%).
+ * - Adds `GAS_PER_CONTINUITY_BLOCK` (default 50k) per continuity root.
+ * - Floors at `MIN_DYNAMIC_GAS_LIMIT` to reject obviously-bad estimates
+ *   (e.g. 21000 from a misbehaving Frontier node).
+ * - Caps at `ceiling` to keep a misbehaving estimator from returning
+ *   absurd values.
+ * - On `estimateGas` failure (revert mid-estimate, RPC timeout, etc.),
+ *   logs a warning and returns `fallback` so submission can proceed
+ *   instead of crashing the caller.
+ *
+ * The returned record includes the inputs we used so the caller can log
+ * estimated vs. final gas at info level for diagnostics.
+ */
+export async function computeGasLimit(
+  params: ComputeGasLimitParams,
+): Promise<
+  {
+    gasLimit: bigint;
+    estimated: bigint | null;
+    paddedEstimate: bigint | null;
+    cappedAtCeiling: boolean;
+    usedFallback: boolean;
+  }
+> {
+  const { provider, from, data, continuityBlocks, ceiling, fallback, label } =
+    params;
+
+  let estimated: bigint;
+  try {
+    estimated = await withTimeout(
+      provider.estimateGas({ from, to: PRECOMPILE_ADDRESS, data }),
+      RPC_TIMEOUT_MS,
+      `${label} estimateGas`,
+    );
+  } catch (error) {
+    console.warn(
+      `⚠️  ${label}: estimateGas failed (${
+        getErrorMessage(error)
+      }), falling back to ceiling=${fallback}`,
+    );
+    return {
+      gasLimit: fallback,
+      estimated: null,
+      paddedEstimate: null,
+      cappedAtCeiling: false,
+      usedFallback: true,
+    };
+  }
+
+  // Apply percent buffer. `GAS_BUFFER_PERCENT = 0` is a no-op.
+  let padded = estimated +
+    (estimated * GAS_BUFFER_PERCENT) / 100n;
+
+  // Per-continuity-block extra padding.
+  if (continuityBlocks > 0 && GAS_PER_CONTINUITY_BLOCK > 0n) {
+    padded += BigInt(continuityBlocks) * GAS_PER_CONTINUITY_BLOCK;
+  }
+
+  // Floor: anything below this is almost certainly a bad estimate.
+  if (padded < MIN_DYNAMIC_GAS_LIMIT) {
+    console.warn(
+      `⚠️  ${label}: padded estimate ${padded} below floor ${MIN_DYNAMIC_GAS_LIMIT} (raw=${estimated}); using floor`,
+    );
+    padded = MIN_DYNAMIC_GAS_LIMIT;
+  }
+
+  // Cap at ceiling.
+  let capped = false;
+  let gasLimit = padded;
+  if (gasLimit > ceiling) {
+    capped = true;
+    gasLimit = ceiling;
+  }
+
+  return {
+    gasLimit,
+    estimated,
+    paddedEstimate: padded,
+    cappedAtCeiling: capped,
+    usedFallback: false,
+  };
+}
+
+/**
+ * Pre-flight balance check. Many nodes reject a tx outright when
+ * `gasLimit * maxFeePerGas > sender.balance` even when the actual spend
+ * would be a small fraction of that — and on some Frontier-derived nodes
+ * the rejection manifests as silent non-propagation rather than a clean
+ * error. Surface a clear log line before broadcast so operators can see
+ * what's happening.
+ *
+ * Returns `null` if everything looks fine, or an explanatory string if
+ * the balance is tight; the caller decides whether to log/throw.
+ */
+export async function checkBalanceForGas(
+  provider: JsonRpcProvider,
+  from: string,
+  gasLimit: bigint,
+  feeOverrides: ethers.TransactionRequest,
+): Promise<string | null> {
+  // Use the higher of maxFeePerGas / gasPrice for the worst-case calc.
+  const feeCap = (feeOverrides.maxFeePerGas as bigint | undefined) ??
+    (feeOverrides.gasPrice as bigint | undefined);
+  if (feeCap === undefined) return null;
+
+  const required = gasLimit * feeCap;
+  const balance = await withTimeout(
+    provider.getBalance(from),
+    RPC_TIMEOUT_MS,
+    "Balance check",
+  );
+
+  if (balance >= required) return null;
+
+  return `signer balance ${balance} < required upfront ${required} ` +
+    `(gasLimit=${gasLimit} * feeCap=${feeCap})`;
+}

--- a/scripts/traffic-simulator/src/submission/precompile.ts
+++ b/scripts/traffic-simulator/src/submission/precompile.ts
@@ -17,6 +17,7 @@ import {
   SINGLE_VERIFY_SIG,
   TRANSIENT_RETRY_BASE_DELAY_MS,
 } from "../constants.ts";
+import { checkBalanceForGas, computeGasLimit } from "./gas.ts";
 import {
   decodeRevertMessage,
   getErrorMessage,
@@ -115,14 +116,28 @@ interface PrecompileParams {
   privateKey: string;
   chainKey: number;
   data: string;
-  gasLimit: bigint;
+  /** Hard ceiling on the dynamically-computed gas limit. */
+  gasCeiling: bigint;
+  /**
+   * Number of continuity-proof roots in this submission. `1` for single
+   * proofs; `continuityProof.roots.length` for batches. Used to add
+   * per-block padding on top of `eth_estimateGas`.
+   */
+  continuityBlocks: number;
   label: string;
 }
 
 async function executePrecompileCall(
   params: PrecompileParams,
 ): Promise<{ txHash: string; gasUsed: bigint }> {
-  const { cc3HttpUrl, privateKey, data, gasLimit, label } = params;
+  const {
+    cc3HttpUrl,
+    privateKey,
+    data,
+    gasCeiling,
+    continuityBlocks,
+    label,
+  } = params;
 
   // Calldata size in bytes (the hex string is `0x` + 2 hex chars per byte).
   const calldataBytes = Math.max(0, (data.length - 2) >> 1);
@@ -222,12 +237,51 @@ async function executePrecompileCall(
     const { entry, feeOverrides } = await simulateWithRetry(initialEntry);
     const { signer, provider } = entry;
 
+    // Compute a tight-but-safe gasLimit. `gasCeiling` is used as both the
+    // hard cap and the fallback if `estimateGas` itself errors. Done
+    // *after* fee data so its diagnostic log line sits next to fees.
+    const from = await signer.getAddress();
+    const gasResult = await computeGasLimit({
+      provider,
+      from,
+      data,
+      continuityBlocks,
+      ceiling: gasCeiling,
+      fallback: gasCeiling,
+      label,
+    });
+    console.info(`${label} gas`, {
+      estimated: gasResult.estimated?.toString() ?? "<fallback>",
+      padded: gasResult.paddedEstimate?.toString() ?? "<fallback>",
+      gasLimit: gasResult.gasLimit.toString(),
+      cappedAtCeiling: gasResult.cappedAtCeiling,
+      usedFallback: gasResult.usedFallback,
+    });
+
+    // Pre-flight balance check. Doesn't throw — some nodes will reject
+    // and that's a cleaner error than ours — but logs prominently so it's
+    // not invisible when it bites.
+    const balanceIssue = await checkBalanceForGas(
+      provider,
+      from,
+      gasResult.gasLimit,
+      feeOverrides,
+    ).catch(() => null);
+    if (balanceIssue !== null) {
+      console.warn(`⚠️  ${label}: ${balanceIssue}`);
+    }
+
     // Send transaction phase (no transient retry - nonce is used)
     // If this fails, we rely on nonce error handling, not blind retry
     const tx = await sendTransaction(
       signer,
       provider,
-      { to: PRECOMPILE_ADDRESS, data, gasLimit, ...feeOverrides },
+      {
+        to: PRECOMPILE_ADDRESS,
+        data,
+        gasLimit: gasResult.gasLimit,
+        ...feeOverrides,
+      },
       label,
     );
     console.debug(`${label} sent`, { txHash: tx.hash, nonce: tx.nonce });
@@ -305,7 +359,9 @@ export async function submitSingleToPrecompile(
     privateKey,
     chainKey,
     data,
-    gasLimit: SINGLE_PROOF_GAS_LIMIT,
+    gasCeiling: SINGLE_PROOF_GAS_LIMIT,
+    // Single submissions verify against one continuity-proof position.
+    continuityBlocks: 1,
     label: "Single submit",
   });
 
@@ -340,7 +396,10 @@ export async function submitBatchToPrecompile(
     privateKey,
     chainKey,
     data,
-    gasLimit: BATCH_PROOF_GAS_LIMIT,
+    gasCeiling: BATCH_PROOF_GAS_LIMIT,
+    // Batch verification cost scales with the number of continuity roots,
+    // not the batch size in tx count.
+    continuityBlocks: continuityProof.roots.length,
     label: "Batch submit",
   });
 


### PR DESCRIPTION
## What

Stop shipping a fixed `5_000_000` (single) / `10_000_000` (batch) `gasLimit` on every submission. Both values are now treated as **ceilings** and **fallbacks**; the actual `gasLimit` is derived from `eth_estimateGas` + a configurable buffer + per-continuity-block padding, then floored and capped.

## Why this matters

A fixed-and-large `gasLimit` has two failure modes that match the `confirmation timed out after Nms` symptom we've been chasing in #902 / #903:

1. **Block-builder deprioritization.** Validators ordering by effective gas price *for the slot a tx takes up* will deprioritize fat txs in favor of skinnier ones at the same fee, even when the fat tx pays more in absolute terms. Yours sits in the mempool and `tx.wait()` eventually times out.
2. **Upfront balance check.** Nodes reject txs where `gasLimit * maxFeePerGas > sender.balance` even though the actual spend would be a fraction of that. Easy to trip on a low-balance signer with `gasLimit = 10_000_000`, *especially* after #903 raised `maxFeePerGas` headroom. On some Frontier-derived nodes the rejection manifests as silent non-propagation rather than a clean error.

## What's new

### `submission/gas.ts` (new)
- `computeGasLimit()` — wraps `estimateGas` in `withTimeout(RPC_TIMEOUT_MS, ...)`, adds `GAS_BUFFER_PERCENT` (default 20%), adds `GAS_PER_CONTINUITY_BLOCK` (default `50_000`) per continuity root, floors at `MIN_DYNAMIC_GAS_LIMIT` (`200_000`), caps at the per-call ceiling, and **falls back to the ceiling on `estimateGas` errors** (with a warning) instead of crashing the caller.
- `checkBalanceForGas()` — pre-flight balance check that logs prominently when `balance < gasLimit * feeCap`. Deliberately doesn't throw (letting the node reject is a cleaner error path) but surfaces what would otherwise be invisible silent rejection.

### `constants.ts`
- New env vars:
  - `GAS_BUFFER_PERCENT` (default `20`)
  - `GAS_PER_CONTINUITY_BLOCK` (default `50000`)
  - internal `MIN_DYNAMIC_GAS_LIMIT = 200_000n` (not env-exposed; if you want a different floor, change the constant)
- `SINGLE_PROOF_GAS_LIMIT` / `BATCH_PROOF_GAS_LIMIT` are now documented as **ceilings and fallback values** rather than unconditional values. Same numbers as before, different role.

### `precompile.ts`
- `PrecompileParams`: `gasLimit (bigint)` replaced with `gasCeiling (bigint) + continuityBlocks (number)`.
- `executePrecompileCall()` runs `estimateGas` after fee data, logs estimated/padded/final gas at **info** level (same diagnostic philosophy as #903), runs the balance preflight, then broadcasts.
- `submitSingleToPrecompile` passes `continuityBlocks: 1`.
- `submitBatchToPrecompile` passes `continuityProof.roots.length` — batch verification cost scales with the number of continuity roots, not the batch size in tx count.

## Behavior change

Most submissions will now broadcast with a *smaller* `gasLimit` than before, which is the whole point — getting out of the heaviest gas-tier in the mempool/block-builder. The existing constants still apply as **hard ceilings**, so nothing can ship with a higher `gasLimit` than today. On `estimateGas` failure we fall back to the old constant value with a warning, so the worst-case behavior is the current behavior.

## Sample log output

```
[info] Single submit fees { maxFeePerGas: '3.0 gwei', maxPriorityFeePerGas: '2.0 gwei' }
[info] Single submit gas { estimated: '342118', padded: '460541', gasLimit: '460541', cappedAtCeiling: false, usedFallback: false }
[info] Single submit sent { txHash: '0xa62432f5...', nonce: 4271, ... }
```

When estimation fails:
```
[warn] ⚠️  Single submit: estimateGas failed (execution reverted), falling back to ceiling=5000000
[info] Single submit gas { estimated: '<fallback>', padded: '<fallback>', gasLimit: '5000000', cappedAtCeiling: false, usedFallback: true }
```

When balance is tight:
```
[warn] ⚠️  Single submit: signer balance 1234567890 < required upfront 18421640000000000 (gasLimit=460541 * feeCap=40000000000)
```

## Stacking with #902 and #903

- #902 (receipt timeout bump + enriched logs) — independent, mergeable in any order.
- #903 (fee headroom + log-on-submit) — independent. If this PR succeeds in eliminating the timeouts, the 2× headroom in #903 may be belt-and-braces overkill; we can dial it back via `FEE_HEADROOM_PERCENT` without code changes.
- This PR (#904) — independent. Branched off `usc-dev`, not off the others.

## Checks

- `deno fmt --check` ✅
- `deno lint` ✅
- `deno check src/main.ts` ✅

## Out of scope

- Stuck-tx rebroadcast loop (re-send same nonce with bumped fees after a watchdog) — separate concern, keep tracking it.
- Persisting an EWMA of estimateGas results to skip the RPC call on the hot path — possible follow-up if estimateGas latency becomes a bottleneck.