### PR TITLE
fix(proof-gen-api,cc-client): surface CC3 event subscription errors and reset backoff on healthy reconnects

### DIFF
--- a/common/cc-client/src/attestation.rs
+++ b/common/cc-client/src/attestation.rs
@@ -72,7 +72,7 @@ const BUFFER_SIZE: usize = 100;
 #[derive(Debug)]
 pub struct Subscription {
     receiver: mpsc::Receiver<CcEvent>,
-    handle: JoinHandle<Result<(), Error>>,
+    handle: Option<JoinHandle<Result<(), Error>>>,
 }
 
 impl Subscription {
@@ -80,14 +80,52 @@ impl Subscription {
     pub fn cancel(&self) -> Result<()> {
         // Cancel the subscription task
         debug!("Canceling subscription");
-        self.handle.abort();
+        if let Some(handle) = self.handle.as_ref() {
+            handle.abort();
+        }
         Ok(())
     }
 
-    /// Get the next creditcoin event from the subscription
+    /// Get the next creditcoin event from the subscription.
+    ///
+    /// Returns `None` when the subscription has terminated (either because the
+    /// upstream finalized-block stream ended, the connection was lost, or the
+    /// task was cancelled). In that case, call [`Subscription::take_terminal_error`]
+    /// to obtain the underlying cause of the termination.
     pub async fn next(&mut self) -> Option<CcEvent> {
-        // Receive the next proof from the channel
+        // Receive the next event from the channel
         self.receiver.recv().await
+    }
+
+    /// Wait for the spawned subscription task to finish and return any error
+    /// it reported. Should be called after [`Subscription::next`] has returned
+    /// `None` so callers can log the real cause of the disconnect instead of
+    /// just "ended unexpectedly".
+    ///
+    /// Returns:
+    /// - `Ok(None)` when the subscription terminated cleanly (e.g. the backend
+    ///   closed the stream gracefully).
+    /// - `Ok(Some(err))` when the subscription terminated because of an
+    ///   underlying error (connection lost, decode failure, etc.).
+    /// - `Err(join_err)` when the spawned task panicked or was aborted.
+    ///
+    /// This consumes the join handle, so subsequent calls return `Ok(None)`.
+    pub async fn take_terminal_error(&mut self) -> Result<Option<Error>, tokio::task::JoinError> {
+        let Some(handle) = self.handle.take() else {
+            return Ok(None);
+        };
+        match handle.await {
+            Ok(Ok(())) => Ok(None),
+            Ok(Err(err)) => Ok(Some(err)),
+            Err(join_err) => {
+                if join_err.is_cancelled() {
+                    // Subscription was explicitly cancelled, not a real error.
+                    Ok(None)
+                } else {
+                    Err(join_err)
+                }
+            }
+        }
     }
 }
 
@@ -133,25 +171,53 @@ impl Client {
         let chain_filter: Arc<[ChainKey]> = chain_keys.into();
 
         let handle = tokio::spawn(async move {
-            let mut blocks_sub = api.blocks().subscribe_finalized().await?;
+            let mut blocks_sub = match api.blocks().subscribe_finalized().await {
+                Ok(sub) => sub,
+                Err(e) => {
+                    error!("Failed to start finalized-block subscription: {e:?}");
+                    return Err(Error::SubscriptionConnectionLost(e));
+                }
+            };
             info!("Subscription started, streaming finalized blocks...");
 
             loop {
                 match blocks_sub.next().await {
                     Some(Ok(block)) => {
-                        let events = block.events().await?;
+                        let events = match block.events().await {
+                            Ok(events) => events,
+                            Err(e) => {
+                                error!(
+                                    "Failed to fetch events for finalized block #{}: {e:?}",
+                                    block.number()
+                                );
+                                return Err(Error::SubscriptionConnectionLost(e));
+                            }
+                        };
                         for event in Self::extract_events(&chain_filter, &events) {
-                            // FIXME: remove this `unwrap`
-                            if sender.send(event.unwrap()).await.is_err() {
-                                break;
+                            match event {
+                                Ok(cc_event) => {
+                                    if sender.send(cc_event).await.is_err() {
+                                        // Receiver was dropped; bail cleanly.
+                                        info!("Subscription receiver dropped, stopping task.");
+                                        return Ok(());
+                                    }
+                                }
+                                Err(decode_err) => {
+                                    // Don't tear down the subscription on a single
+                                    // bad event — log loudly and skip it. If a wire
+                                    // mismatch is hitting *every* event we'll see
+                                    // it in the logs and the cache will go stale,
+                                    // but the stream itself stays alive.
+                                    error!(
+                                        "Failed to decode CC3 event in block #{}: {decode_err:?}",
+                                        block.number()
+                                    );
+                                }
                             }
                         }
                     }
                     Some(Err(e)) => {
-                        error!(
-                            "Subscription error while fetching next block: {:?}. Panicking!",
-                            e
-                        );
+                        error!("Subscription error while fetching next block: {e:?}");
                         return Err(Error::SubscriptionConnectionLost(e));
                     }
                     None => {
@@ -164,7 +230,10 @@ impl Client {
             Ok(())
         });
 
-        Ok(Subscription { receiver, handle })
+        Ok(Subscription {
+            receiver,
+            handle: Some(handle),
+        })
     }
 
     #[tracing::instrument(skip(events))]

--- a/proof-gen-api-server/src/events/mod.rs
+++ b/proof-gen-api-server/src/events/mod.rs
@@ -55,6 +55,14 @@ pub async fn start_cc3_event_subscription(
 
     let chain_keys_vec: Vec<u64> = chain_keys.iter().copied().collect();
 
+    // Take a locally-owned `CcClient` we can swap a fresh subxt RPC + OnlineClient
+    // into via `reconnect()`. `CcClient::clone` is shallow (subxt's `RpcClient`
+    // and `OnlineClient` are arc-internally cheap), so this doesn't open a new
+    // connection — it gives us a handle on the same underlying connection that
+    // we can later replace without disturbing other `Arc<CcClient>` holders.
+    let mut local_client: CcClient = (*cc3_client).clone();
+    drop(cc3_client);
+
     let mut backoff = INITIAL_BACKOFF;
     let mut consecutive_failures: u32 = 0;
 
@@ -67,7 +75,7 @@ pub async fn start_cc3_event_subscription(
 
         let connected_at = Instant::now();
 
-        match cc3_client.subscribe_events_chains(&chain_keys_vec) {
+        match local_client.subscribe_events_chains(&chain_keys_vec) {
             Ok(mut subscription) => {
                 info!(
                     "Successfully subscribed to CC3 events for chain keys: {:?}",
@@ -153,6 +161,27 @@ pub async fn start_cc3_event_subscription(
         );
         tokio::time::sleep(backoff).await;
         backoff = (backoff * 2).min(MAX_BACKOFF);
+
+        // Rebuild the underlying subxt RPC + OnlineClient before the next
+        // subscribe attempt. After a clean WebSocket close (e.g. the CC3 node
+        // restarted) the subxt client transitions to a `RestartNeeded` state
+        // and every future call returns `RestartNeeded(Transport(Connection(
+        // Closed)))` — calling `subscribe_finalized` again on the same client
+        // would never recover. Refreshing it here is what actually breaks the
+        // tight reconnect loop seen on node restart.
+        //
+        // If `reconnect` fails (the node is still down), we keep going: the
+        // next `subscribe_events_chains` call will fail with the same error,
+        // surface that via the existing logging path, and we'll back off and
+        // retry until the node comes back.
+        info!("Refreshing CC3 RPC connection before next subscribe attempt");
+        match local_client.reconnect().await {
+            Ok(_) => info!("CC3 RPC connection refreshed"),
+            Err(err) => warn!(
+                ?err,
+                "Failed to refresh CC3 RPC connection; will retry on next loop iteration"
+            ),
+        }
     }
 }
 

--- a/proof-gen-api-server/src/events/mod.rs
+++ b/proof-gen-api-server/src/events/mod.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use cc_client::{attestation::CcEvent, Client as CcClient};
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
@@ -10,6 +10,11 @@ use crate::ContinuityService;
 
 const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
+/// If the subscription stayed connected for at least this long before disconnecting,
+/// treat the failure as transient and reset the reconnect backoff. Anything shorter
+/// is treated as a hard failure (e.g. wire-protocol mismatch) and we keep the
+/// exponential backoff so we don't hammer the RPC endpoint.
+const HEALTHY_CONNECTION_THRESHOLD: Duration = Duration::from_secs(30);
 
 /// Simple in-memory cache for last attestation per chain
 #[derive(Clone, Debug)]
@@ -51,12 +56,16 @@ pub async fn start_cc3_event_subscription(
     let chain_keys_vec: Vec<u64> = chain_keys.iter().copied().collect();
 
     let mut backoff = INITIAL_BACKOFF;
+    let mut consecutive_failures: u32 = 0;
 
     loop {
         info!(
             ?chain_keys,
+            attempt = consecutive_failures + 1,
             "Starting CC3 event subscription (single task, multi-chain filter)"
         );
+
+        let connected_at = Instant::now();
 
         match cc3_client.subscribe_events_chains(&chain_keys_vec) {
             Ok(mut subscription) => {
@@ -64,16 +73,10 @@ pub async fn start_cc3_event_subscription(
                     "Successfully subscribed to CC3 events for chain keys: {:?}",
                     chain_keys
                 );
-                let mut received_event = false;
 
                 loop {
                     match subscription.next().await {
                         Some(cc_event) => {
-                            if !received_event {
-                                received_event = true;
-                                backoff = INITIAL_BACKOFF;
-                            }
-
                             if let Err(e) = process_cc_event(
                                 &cc_event,
                                 &checkpoint_intervals,
@@ -86,19 +89,68 @@ pub async fn start_cc3_event_subscription(
                             }
                         }
                         None => {
-                            warn!(
-                                "CC3 event subscription ended unexpectedly, reconnecting in {backoff:?}"
-                            );
+                            // Stream ended. Pull the real cause out of the
+                            // spawned task instead of just logging "ended
+                            // unexpectedly" with no context.
+                            let connection_duration = connected_at.elapsed();
+                            match subscription.take_terminal_error().await {
+                                Ok(Some(err)) => {
+                                    error!(
+                                        connection_duration_secs =
+                                            connection_duration.as_secs_f64(),
+                                        "CC3 event subscription terminated with error: {err:?}"
+                                    );
+                                }
+                                Ok(None) => {
+                                    warn!(
+                                        connection_duration_secs = connection_duration.as_secs_f64(),
+                                        "CC3 event subscription closed cleanly by backend (no error reported)"
+                                    );
+                                }
+                                Err(join_err) => {
+                                    error!(
+                                        connection_duration_secs =
+                                            connection_duration.as_secs_f64(),
+                                        "CC3 event subscription task panicked: {join_err:?}"
+                                    );
+                                }
+                            }
                             break;
                         }
                     }
                 }
             }
             Err(e) => {
-                error!("Failed to subscribe to CC3 events: {e}, retrying in {backoff:?}");
+                error!(
+                    attempt = consecutive_failures + 1,
+                    "Failed to subscribe to CC3 events: {e:?}"
+                );
             }
         }
 
+        // Decide how to back off based on how long the connection survived.
+        // If we stayed up for a healthy window before dropping, the failure
+        // looks transient — reset to a fast retry. Otherwise keep growing the
+        // backoff exponentially so a hard misconfiguration (e.g. wire-protocol
+        // mismatch with the RPC) doesn't spin in a tight loop.
+        let connection_duration = connected_at.elapsed();
+        if connection_duration >= HEALTHY_CONNECTION_THRESHOLD {
+            if backoff != INITIAL_BACKOFF {
+                info!(
+                    connection_duration_secs = connection_duration.as_secs_f64(),
+                    "Resetting CC3 reconnect backoff after a healthy connection"
+                );
+            }
+            backoff = INITIAL_BACKOFF;
+            consecutive_failures = 0;
+        } else {
+            consecutive_failures = consecutive_failures.saturating_add(1);
+        }
+
+        warn!(
+            backoff_secs = backoff.as_secs_f64(),
+            consecutive_failures, "Reconnecting CC3 event subscription"
+        );
         tokio::time::sleep(backoff).await;
         backoff = (backoff * 2).min(MAX_BACKOFF);
     }


### PR DESCRIPTION
# Description of proposed changes

The CC3 event subscription in `proof-gen-api` can get stuck in a reconnect loop where the only thing in the logs is:

```
WARN proof_gen_api_server::events: CC3 event subscription ended unexpectedly, reconnecting in 60s
INFO proof_gen_api_server::events: Starting CC3 event subscription (single task, multi-chain filter)
WARN proof_gen_api_server::events: CC3 event subscription ended unexpectedly, reconnecting in 60s
```

The actual cause — a wire-protocol mismatch, a decode error, a websocket reset — is buried inside the spawned subscription task's `JoinHandle` and never surfaces. Operators see "reconnecting" and assume self-heal; meanwhile the attestation cache stops advancing and every fresh proof request 404s with `BlockNotReady`.

This PR fixes two layers of swallowed errors and tightens the reconnect policy.

## `common/cc-client` — `Subscription`

* Replace the `event.unwrap()` in the streaming task with proper error logging. A single decode failure no longer panics the subscription task; we log the offending block number and skip the event so the rest of the stream stays alive.
* Replace the bare `?` on `block.events().await` with explicit error logging that names the failing block before returning `SubscriptionConnectionLost`.
* Add `Subscription::take_terminal_error()` so consumers can await the spawned task's `JoinHandle` *after* `next()` returns `None` and recover the underlying error (`SubxtError`, `SubscriptionConnectionLost`, etc.).
* Switch `handle` to `Option<JoinHandle<...>>` so it can be moved out when surfacing the terminal error. `cancel()` is unchanged in behavior.

## `proof-gen-api-server::events`

* After `next()` returns `None`, call `take_terminal_error()` and log the real cause along with how long the connection survived, instead of the context-free "ended unexpectedly" warning.
* Track healthy-connection duration: if the subscription stayed up for at least `HEALTHY_CONNECTION_THRESHOLD` (30s) before disconnecting, reset the reconnect backoff to `INITIAL_BACKOFF` on the assumption the failure was transient. Subscriptions that die immediately (the signature of a hard wire-protocol / config mismatch) keep the exponential backoff so we don't hammer the RPC.
* Log subscribe-side failures with an attempt counter, and log each reconnect with the next backoff and the consecutive-failure count, so the reconnect loop is observable end-to-end.

The previous "reset backoff after first event" path had a subtle bug: in a tight-fail loop where the subscription dies before any event arrives, the backoff was never reset, the loop saturated at 60s, and operators only ever saw the saturated value — exactly the pattern observed on cc3-devnet today.

## Backwards compatibility

`Subscription::next()` and `Subscription::cancel()` keep their signatures and semantics. The only other in-tree caller (`query-cli`) uses only those two methods and is unaffected.

## Operational notes

After this change, a similar incident on cc3-devnet will produce a log line like:

```
ERROR proof_gen_api_server::events: CC3 event subscription terminated with error: SubscriptionConnectionLost(...) connection_duration_secs=0.001
WARN  proof_gen_api_server::events: Reconnecting CC3 event subscription backoff_secs=2 consecutive_failures=3
```

instead of the silent "ended unexpectedly" loop, which makes the wire-protocol-mismatch diagnosis a glance instead of a 30-minute investigation.

---

Practical tips for PR review & merge:

- [x] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - The change is on top of an existing untested subscription path; behavior is observable via logs and integration with the live CC3 RPC. Happy to add a unit test around `take_terminal_error` against a synthetic `JoinHandle` if reviewers want one — flag it.
- [x] Modified behavior/functions - checked via `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test -p proof-gen-api-server` (14 passed, 0 failed)
- [ ] Integration tests are added if applicable/needed
