### PR TITLE
fix(cli): restore env-or-prompt secret flow for attestor write commands

### DIFF
--- a/cli/src/commands/attestor/chill.ts
+++ b/cli/src/commands/attestor/chill.ts
@@ -8,7 +8,7 @@ import {
     ATTESTOR_STATUS_ACTIVE,
     ATTESTOR_STATUS_LEAVING,
 } from '../../lib/attestor/precompile';
-import { getStringFromEnvVar } from '../../lib/account/keyring';
+import { getSecretFromEnvOrPrompt } from '../../lib/account/keyring';
 import { encodeAddress } from '@polkadot/util-crypto';
 import { ethers } from 'ethers';
 
@@ -55,7 +55,7 @@ async function chillAction(options: OptionValues) {
     const attestorSs58 = options.attestor as string;
     const attestorId32 = substrateAddressToBytes32(attestorSs58);
 
-    const secret = getStringFromEnvVar(process.env.CC_SECRET);
+    const secret = await getSecretFromEnvOrPrompt('CC_SECRET', 'caller', options);
     const { contract, stashAddress } = getAttestorContractWithSigner(secret, options);
 
     // Pre-call validation via view function

--- a/cli/src/commands/attestor/registerAttestor.ts
+++ b/cli/src/commands/attestor/registerAttestor.ts
@@ -5,7 +5,7 @@ import {
     substrateAddressToBytes32,
     extractEvmError,
 } from '../../lib/attestor/precompile';
-import { getStringFromEnvVar } from '../../lib/account/keyring';
+import { getSecretFromEnvOrPrompt } from '../../lib/account/keyring';
 
 export function makeRegisterAttestorCommand() {
     const cmd = new Command('register');
@@ -21,7 +21,7 @@ async function registerAttestorAction(options: OptionValues) {
     const attestorSs58 = options.attestor as string;
     const attestorId32 = substrateAddressToBytes32(attestorSs58);
 
-    const secret = getStringFromEnvVar(process.env.CC_SECRET);
+    const secret = await getSecretFromEnvOrPrompt('CC_SECRET', 'caller', options);
     const { contract } = getAttestorContractWithSigner(secret, options);
 
     try {

--- a/cli/src/commands/attestor/unregisterAttestor.ts
+++ b/cli/src/commands/attestor/unregisterAttestor.ts
@@ -7,7 +7,7 @@ import {
     ATTESTOR_STATUS_ACTIVE,
     ATTESTOR_STATUS_LEAVING,
 } from '../../lib/attestor/precompile';
-import { getStringFromEnvVar } from '../../lib/account/keyring';
+import { getSecretFromEnvOrPrompt } from '../../lib/account/keyring';
 
 export function makeUnregisterAttestorCommand() {
     const cmd = new Command('unregister');
@@ -23,7 +23,7 @@ async function unregisterAttestorAction(options: OptionValues) {
     const attestorSs58 = options.attestor as string;
     const attestorId32 = substrateAddressToBytes32(attestorSs58);
 
-    const secret = getStringFromEnvVar(process.env.CC_SECRET);
+    const secret = await getSecretFromEnvOrPrompt('CC_SECRET', 'caller', options);
     const { contract } = getAttestorContractWithSigner(secret, options);
 
     // Pre-call validation via view function

--- a/cli/src/commands/attestor/withdrawUnbonded.ts
+++ b/cli/src/commands/attestor/withdrawUnbonded.ts
@@ -5,7 +5,7 @@ import {
     deriveEvmKeyFromSecret,
     extractEvmError,
 } from '../../lib/attestor/precompile';
-import { getStringFromEnvVar } from '../../lib/account/keyring';
+import { getSecretFromEnvOrPrompt } from '../../lib/account/keyring';
 
 export function makeAttestorWithdrawUnbondedCommand() {
     const cmd = new Command('withdraw-unbonded');
@@ -17,7 +17,7 @@ export function makeAttestorWithdrawUnbondedCommand() {
 }
 
 async function withdrawUnbondedAction(options: OptionValues) {
-    const secret = getStringFromEnvVar(process.env.CC_SECRET);
+    const secret = await getSecretFromEnvOrPrompt('CC_SECRET', 'caller', options);
     const { stashAddress } = deriveEvmKeyFromSecret(secret);
     const stashBytes32 = substrateAddressToBytes32(stashAddress);
 

--- a/cli/src/lib/account/keyring.ts
+++ b/cli/src/lib/account/keyring.ts
@@ -77,6 +77,55 @@ export function getStringFromEnvVar(envVar: string | undefined): string {
     return envVar;
 }
 
+/**
+ * Read a raw secret (BIP39 mnemonic) from the given env var, or prompt the user
+ * for one when stdin is a TTY and `--input` was not disabled. Mirrors
+ * {@link initKeyringFromEnvOrPrompt} but returns the secret string itself,
+ * which is what EVM/precompile-based commands need (they derive the EVM key
+ * via `HDNodeWallet.fromPhrase`, not a Substrate `KeyringPair`).
+ *
+ * Used by attestor commands that go through the attestor-stash precompile
+ * (`register`, `unregister`, `chill`, `withdraw-unbonded`) so they keep the
+ * same env-or-prompt UX as every other write-path CLI command.
+ */
+export async function getSecretFromEnvOrPrompt(
+    envVar: string,
+    accountRole: string,
+    options: OptionValues,
+): Promise<string> {
+    const interactive = setInteractivity(options);
+    const inputName = 'seed phrase';
+
+    if (typeof process.env[envVar] === 'string') {
+        const input = getStringFromEnvVar(process.env[envVar]);
+        if (!mnemonicValidate(input)) {
+            throw new Error(`Error: Seed phrase provided in environment variable ${envVar} is invalid.`);
+        }
+        return input;
+    }
+
+    if (!interactive) {
+        throw new Error(
+            `Error: Must specify a ${inputName} for the ${accountRole} account in the environment variable ${envVar} or use an interactive shell.`,
+        );
+    }
+
+    const promptResult = await prompts([
+        {
+            type: 'password',
+            name: 'seed',
+            message: `Specify a ${inputName} for the ${accountRole} account`,
+            validate: (input) => mnemonicValidate(input as string),
+        },
+    ]);
+
+    // If SIGTERM is issued while prompting, prompts() resolves with no value.
+    if (typeof promptResult.seed !== 'string' || promptResult.seed.length === 0) {
+        throw new Error(`Error: Could not retrieve ${inputName}`);
+    }
+    return promptResult.seed;
+}
+
 export type ProxyKeyring = {
     type: 'proxy';
     pair: KeyringPair;


### PR DESCRIPTION
## Problem

`creditcoin attestor register|unregister|chill|withdraw-unbonded` now hard-fail when `CC_SECRET` is unset, instead of prompting for a seed phrase like every other write-path CLI command:

```
$ creditcoin attestor register --url wss://rpc.cc3-testnet.creditcoin.network/ws \
    --attestor 5HpXCQkKPKFPxm1nb2huueunYjHb1nuixQEUaPjEDNTsq81E --chain 1
Error: Unexpected type; could not retrieve seed phrase or PK from environment variable.
    at getStringFromEnvVar (cli/dist/lib/account/keyring.js:77:15)
    at registerAttestorAction (cli/dist/commands/attestor/registerAttestor.js:20:54)
```

## Root cause

Reported by @DylanVerstraete: regression introduced by #851. When the four attestor write commands were ported to the attestor-stash precompile (which derives an EVM key via `HDNodeWallet.fromPhrase`, so it needs the *raw* mnemonic — not a Substrate `KeyringPair`), `initKeyring(options)` was replaced with `getStringFromEnvVar(process.env.CC_SECRET)`. That short-circuits both the env-var validation and the interactive prompt fallback that `initKeyringFromEnvOrPrompt` provides for the rest of the CLI.

Net effect: `CC_SECRET` became strictly mandatory and silently changed the UX contract for these commands.

## Fix

Add a sibling helper next to `initKeyringFromEnvOrPrompt` that returns the raw mnemonic instead of a `KeyringPair`, with the same env-or-prompt logic:

* `cli/src/lib/account/keyring.ts` — new `getSecretFromEnvOrPrompt(envVar, accountRole, options)`:
  * If `process.env[envVar]` is set, validate via `mnemonicValidate` and return it. Invalid phrases throw immediately (no prompt fallback — keeps the explicit-config UX intact).
  * Otherwise, if `setInteractivity(options)` is truthy (TTY + `--input`), prompt for a password-masked seed phrase, validate via `mnemonicValidate`.
  * Otherwise, throw the same "Must specify ... in environment variable ${envVar} or use an interactive shell" error that `initKeyringFromEnvOrPrompt` throws.

* `cli/src/commands/attestor/{registerAttestor,unregisterAttestor,chill,withdrawUnbonded}.ts` — replace `getStringFromEnvVar(process.env.CC_SECRET)` with `await getSecretFromEnvOrPrompt('CC_SECRET', 'caller', options)`.

This preserves the precompile flow (the helper still returns a `string`, which is fed straight into `getAttestorContractWithSigner` → `HDNodeWallet.fromPhrase`) while restoring CLI parity. Read-only attestor commands (`balance`, `show-status`, `show-attestors-for`) are unchanged — they don't need a secret.

## Behaviour matrix

| `CC_SECRET` | TTY + `--input` | Result |
|---|---|---|
| set, valid mnemonic | any | use it |
| set, invalid mnemonic | any | hard error (no prompt fallback) |
| unset | yes | password-masked prompt |
| unset | no / `--no-input` | hard error pointing at `CC_SECRET` |

## Test / lint status

* `yarn build` (tsc) — clean.
* `yarn lint` (eslint, `--max-warnings 0`) — clean.
* Manual smoke tests against `creditcoin attestor register`:
  * `CC_SECRET` unset + `--no-input` → friendly error.
  * `CC_SECRET="<valid 12-word mnemonic>"` → proceeds past secret retrieval (then fails on the chain call as expected when pointed at an unreachable URL).
  * `CC_SECRET="not a real mnemonic"` → "Seed phrase provided in environment variable CC_SECRET is invalid."

## Compatibility

No new env vars, no flag changes. Users currently relying on `CC_SECRET=…` are unaffected. Users running interactively get the prompt back.

## Context

Reported in Slack by @DylanVerstraete. Regression originated in #851. Affects all four attestor write commands; only `registerAttestor` was named in the report but the same edit applies identically to the other three.

cc @gluwa/protocol