### PR TITLE
feat(api): key per block range overrides

### DIFF
--- a/common/eth/src/block_cache.rs
+++ b/common/eth/src/block_cache.rs
@@ -216,20 +216,20 @@ impl Client {
         private_key: Option<&str>,
         config: BlockCacheConfig,
     ) -> Result<Self, Error> {
-        Self::new_with_cache_and_overrides(url, &[], private_key, config).await
+        Self::new_with_cache_and_fallbacks(url, &[], private_key, config).await
     }
 
-    /// Like [`Client::new_with_cache`] but also installs per-block-range RPC
-    /// URL overrides. See [`crate::RpcRangeOverride`] for the override
-    /// semantics and validation rules.
-    pub async fn new_with_cache_and_overrides(
+    /// Like [`Client::new_with_cache`] but also installs ordered fallback
+    /// RPC URLs. Each fallback is tried in declared order whenever the
+    /// primary returns `Ok(None)` or a transport error.
+    pub async fn new_with_cache_and_fallbacks(
         url: &str,
-        overrides: &[crate::RpcRangeOverride],
+        fallback_urls: &[String],
         private_key: Option<&str>,
         config: BlockCacheConfig,
     ) -> Result<Self, Error> {
         let (url, rpc_provider, chain_id) = Self::init_rpc(url).await?;
-        let range_providers = Self::init_range_providers(chain_id, overrides)
+        let fallback_providers = Self::init_fallback_providers(chain_id, fallback_urls)
             .await
             .map_err(Error::ClientError)?;
 
@@ -284,7 +284,7 @@ impl Client {
             url,
             private_key: private_key.map(|s| s.to_owned()),
             rpc_provider,
-            range_providers,
+            fallback_providers,
             chain_id,
             cache: Some(cache),
         })

--- a/common/eth/src/block_cache.rs
+++ b/common/eth/src/block_cache.rs
@@ -216,7 +216,22 @@ impl Client {
         private_key: Option<&str>,
         config: BlockCacheConfig,
     ) -> Result<Self, Error> {
+        Self::new_with_cache_and_overrides(url, &[], private_key, config).await
+    }
+
+    /// Like [`Client::new_with_cache`] but also installs per-block-range RPC
+    /// URL overrides. See [`crate::RpcRangeOverride`] for the override
+    /// semantics and validation rules.
+    pub async fn new_with_cache_and_overrides(
+        url: &str,
+        overrides: &[crate::RpcRangeOverride],
+        private_key: Option<&str>,
+        config: BlockCacheConfig,
+    ) -> Result<Self, Error> {
         let (url, rpc_provider, chain_id) = Self::init_rpc(url).await?;
+        let range_providers = Self::init_range_providers(chain_id, overrides)
+            .await
+            .map_err(Error::ClientError)?;
 
         let connection_timeout = Duration::from_secs(REDIS_CONNECTION_TIMEOUT_SECS);
         let response_timeout = Duration::from_secs(REDIS_RESPONSE_TIMEOUT_SECS);
@@ -269,6 +284,7 @@ impl Client {
             url,
             private_key: private_key.map(|s| s.to_owned()),
             rpc_provider,
+            range_providers,
             chain_id,
             cache: Some(cache),
         })

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -292,32 +292,15 @@ pub enum ConnectionTransport {
     Ws(WsConnect),
 }
 
-/// One per-block-range RPC URL override.
+/// One ordered fallback RPC provider attached to a [`Client`].
 ///
-/// Block-keyed RPC requests (block fetch, receipts) whose `block_number`
-/// falls within the inclusive range `[from_block, to_block]` are routed to
-/// `url` instead of the [`Client`]'s default URL. Either bound may be `None`
-/// to mean "open-ended on that side".
-///
-/// All override URLs must point to a node that reports the same `chain_id`
-/// as the default URL — this is verified when the [`Client`] is constructed.
-///
-/// Constraints (enforced at construction time):
-/// * Each override must specify at least one of `from_block` or `to_block`
-///   (otherwise it would silently shadow the default URL).
-/// * If both bounds are set, `from_block <= to_block`.
-/// * Overrides must not overlap each other.
+/// The [`Client`] always tries its primary URL first; on `Ok(None)` or
+/// transport errors it walks `fallback_providers` in declared order and
+/// uses the first non-empty answer. All fallback URLs must point to a
+/// node that reports the same `chain_id` as the primary URL — this is
+/// verified when the [`Client`] is constructed.
 #[derive(Debug, Clone)]
-pub struct RpcRangeOverride {
-    pub from_block: Option<u64>,
-    pub to_block: Option<u64>,
-    pub url: String,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct RangeProvider {
-    pub(crate) from: u64,
-    pub(crate) to: u64,
+pub(crate) struct FallbackProvider {
     pub(crate) url: Url,
     pub(crate) provider: AlloyProvider,
 }
@@ -327,9 +310,10 @@ pub struct Client {
     url: Url,
     private_key: Option<String>,
     rpc_provider: AlloyProvider,
-    /// Block-range RPC overrides, sorted by `from`. Empty = no overrides
-    /// (legacy single-URL behavior). See [`RpcRangeOverride`].
-    range_providers: Vec<RangeProvider>,
+    /// Ordered fallback RPC providers. Empty = no fallbacks (single-URL
+    /// behavior). Each provider is tried in declared order whenever the
+    /// primary returns `Ok(None)` or errors. See [`FallbackProvider`].
+    fallback_providers: Vec<FallbackProvider>,
     // what chain id is implied here? Maybe need to define internal chain ids for different attestation chains
     // and not rely on ethereum chain ids?
     chain_id: u64,
@@ -377,37 +361,38 @@ impl Client {
             url,
             private_key: private_key.map(|s| s.to_owned()),
             rpc_provider,
-            range_providers: Vec::new(),
+            fallback_providers: Vec::new(),
             chain_id,
             #[cfg(feature = "block_cache")]
             cache: None,
         })
     }
 
-    /// Build a [`Client`] with per-block-range RPC URL overrides.
+    /// Build a [`Client`] with ordered fallback RPC URLs.
     ///
-    /// `url` is the default URL used for tip-related calls (subscriptions,
-    /// `eth_blockNumber`, `eth_getTransactionByHash`) and for any block whose
-    /// number is not covered by an entry in `overrides`.
+    /// `url` is the primary URL: tried first for every operation, and the
+    /// only URL used for tip-related calls (subscriptions, `eth_blockNumber`,
+    /// `eth_chainId`).
     ///
-    /// All override URLs are connected to at startup; each must report the
-    /// same `chain_id` as `url` and the override ranges must satisfy the
-    /// validity rules documented on [`RpcRangeOverride`].
+    /// `fallback_urls` are tried in declaration order whenever the primary
+    /// returns `Ok(None)` or a transport error for a block fetch / tx-hash
+    /// lookup. Each fallback URL is connected to at startup and must report
+    /// the same `chain_id` as `url`.
     ///
-    /// When `overrides` is empty this is equivalent to [`Client::new`].
-    pub async fn new_with_overrides(
+    /// When `fallback_urls` is empty this is equivalent to [`Client::new`].
+    pub async fn new_with_fallbacks(
         url: &str,
-        overrides: &[RpcRangeOverride],
+        fallback_urls: &[String],
         private_key: Option<&str>,
     ) -> anyhow::Result<Self> {
         let (url, rpc_provider, chain_id) = Self::init_rpc(url).await?;
-        let range_providers = Self::init_range_providers(chain_id, overrides).await?;
+        let fallback_providers = Self::init_fallback_providers(chain_id, fallback_urls).await?;
 
         anyhow::Ok(Self {
             url,
             private_key: private_key.map(|s| s.to_owned()),
             rpc_provider,
-            range_providers,
+            fallback_providers,
             chain_id,
             #[cfg(feature = "block_cache")]
             cache: None,
@@ -417,91 +402,82 @@ impl Client {
     pub async fn reconnect(&mut self) -> Result<(), Error> {
         let (url, rpc_provider, chain_id) = Self::init_rpc(self.url.as_ref()).await?;
 
-        // Reconnect each range provider against its own URL too, otherwise a
-        // recovered default would silently start serving range-bucket blocks
-        // until each override picked up the network fault on its own.
-        let mut new_ranges = Vec::with_capacity(self.range_providers.len());
-        for rp in &self.range_providers {
-            let (rp_url, rp_provider, rp_chain_id) = Self::init_rpc(rp.url.as_ref()).await?;
-            if rp_chain_id != chain_id {
+        // Reconnect each fallback against its own URL too, otherwise a
+        // recovered primary would silently keep using a stale fallback
+        // socket until that fallback hit a fault on its own.
+        let mut new_fallbacks = Vec::with_capacity(self.fallback_providers.len());
+        for fp in &self.fallback_providers {
+            let (fp_url, fp_provider, fp_chain_id) = Self::init_rpc(fp.url.as_ref()).await?;
+            if fp_chain_id != chain_id {
                 return Err(Error::ClientError(anyhow::anyhow!(
-                    "RPC override URL chain_id ({rp_chain_id}) does not match default URL chain_id ({chain_id}) on reconnect"
+                    "Fallback RPC URL chain_id ({fp_chain_id}) does not match primary URL chain_id ({chain_id}) on reconnect"
                 )));
             }
-            new_ranges.push(RangeProvider {
-                from: rp.from,
-                to: rp.to,
-                url: rp_url,
-                provider: rp_provider,
+            new_fallbacks.push(FallbackProvider {
+                url: fp_url,
+                provider: fp_provider,
             });
         }
 
         self.url = url;
         self.rpc_provider = rpc_provider;
-        self.range_providers = new_ranges;
+        self.fallback_providers = new_fallbacks;
         self.chain_id = chain_id;
 
         Ok(())
     }
 
-    /// Validate the override list (no network I/O), connect to each override
-    /// URL in declaration order, and verify the chain id matches the default.
-    pub(crate) async fn init_range_providers(
-        default_chain_id: u64,
-        overrides: &[RpcRangeOverride],
-    ) -> anyhow::Result<Vec<RangeProvider>> {
-        // Fail fast on invalid bounds before opening any sockets.
-        let normalized = validate_range_overrides(overrides)?;
-
-        let mut providers: Vec<RangeProvider> = Vec::with_capacity(normalized.len());
-        for (from, to, raw_url) in normalized {
+    /// Connect to each fallback URL in declaration order and verify each
+    /// reports the same `chain_id` as the primary.
+    pub(crate) async fn init_fallback_providers(
+        primary_chain_id: u64,
+        fallback_urls: &[String],
+    ) -> anyhow::Result<Vec<FallbackProvider>> {
+        let mut providers: Vec<FallbackProvider> = Vec::with_capacity(fallback_urls.len());
+        for (idx, raw_url) in fallback_urls.iter().enumerate() {
             let (url, provider, chain_id) =
                 Self::init_rpc(raw_url.as_ref()).await.with_context(|| {
-                    format!("Failed to connect to RPC override URL for block range [{from}, {to}]")
+                    format!(
+                        "Failed to connect to fallback RPC URL #{idx} ({})",
+                        redact_url_query(raw_url),
+                    )
                 })?;
 
-            if chain_id != default_chain_id {
+            if chain_id != primary_chain_id {
                 anyhow::bail!(
-                    "RPC override for block range [{from}, {to}] reports chain_id {chain_id}, \
-                     which does not match the default URL's chain_id {default_chain_id}; \
-                     all override URLs must point to the same chain"
+                    "Fallback RPC URL #{idx} ({}) reports chain_id {chain_id}, \
+                     which does not match the primary URL's chain_id {primary_chain_id}; \
+                     all fallback URLs must point to the same chain",
+                    redact_url_query(raw_url),
                 );
             }
 
-            providers.push(RangeProvider {
-                from,
-                to,
-                url,
-                provider,
-            });
+            providers.push(FallbackProvider { url, provider });
         }
 
         Ok(providers)
     }
 
-    /// Pick the RPC provider for a block-keyed call.
-    ///
-    /// Returns the matching range override's provider when one covers
-    /// `block_number`, otherwise the default `rpc_provider`.
-    fn provider_for_block(&self, block_number: u64) -> &AlloyProvider {
-        let bounds: Vec<(u64, u64)> = self
-            .range_providers
-            .iter()
-            .map(|rp| (rp.from, rp.to))
-            .collect();
-        match find_range_index(block_number, &bounds) {
-            Some(i) => &self.range_providers[i].provider,
-            None => &self.rpc_provider,
+    /// Build the ordered `[(label, provider)]` list used by the sequential
+    /// fallback walk. The primary is first; each fallback gets a label like
+    /// `fallback[0]@<redacted-url>` for log output.
+    fn providers_with_labels(&self) -> Vec<(String, &AlloyProvider)> {
+        let mut out: Vec<(String, &AlloyProvider)> =
+            Vec::with_capacity(1 + self.fallback_providers.len());
+        out.push(("primary".to_string(), &self.rpc_provider));
+        for (i, fp) in self.fallback_providers.iter().enumerate() {
+            out.push((
+                format!("fallback[{i}]@{}", redact_url_query(fp.url.as_str())),
+                &fp.provider,
+            ));
         }
+        out
     }
 
-    /// Returns the configured RPC overrides as `(from, to, url)` tuples
-    /// (sorted by `from`). Useful for startup logging.
-    pub fn range_overrides(&self) -> Vec<(u64, u64, &Url)> {
-        self.range_providers
-            .iter()
-            .map(|rp| (rp.from, rp.to, &rp.url))
-            .collect()
+    /// Returns the configured fallback URLs in declaration order. Useful
+    /// for startup logging.
+    pub fn fallback_urls(&self) -> Vec<&Url> {
+        self.fallback_providers.iter().map(|fp| &fp.url).collect()
     }
 
     pub fn chain_id(&self) -> u64 {
@@ -638,28 +614,133 @@ impl Client {
     }
 
     async fn get_receipts(&self, number: u64) -> Result<Vec<TransactionReceipt>, Error> {
-        self.provider_for_block(number)
-            .get_block_receipts(BlockId::Number(BlockNumberOrTag::Number(number)))
-            .await
-            .map_err(|e| {
-                error!("Failed to get receipts: {:?}", e);
-                Error::FailedToGetReceipts(number)
-            })?
-            .ok_or(Error::FailedToGetBlock(number))
+        let providers = self.providers_with_labels();
+        let mut got_definitive_none = false;
+        let mut errors: Vec<(String, Error)> = Vec::new();
+
+        for (label, provider) in providers {
+            match provider
+                .get_block_receipts(BlockId::Number(BlockNumberOrTag::Number(number)))
+                .await
+            {
+                Ok(Some(receipts)) => {
+                    if label != "primary" {
+                        info!(
+                            provider = %label,
+                            block_number = number,
+                            "receipts fetched via fallback provider"
+                        );
+                    }
+                    return Ok(receipts);
+                }
+                Ok(None) => got_definitive_none = true,
+                Err(e) => errors.push((label, Error::from(e))),
+            }
+        }
+
+        // Mirror the legacy behavior: an `Ok(None)` from a single provider
+        // mapped to `FailedToGetBlock(number)`. When at least one provider
+        // says the receipts are not available we honor that and surface the
+        // block-not-found error; transport errors from any other provider
+        // are demoted to warnings.
+        match merge_provider_lookup(got_definitive_none, errors) {
+            LookupOutcome::NotFound { errors_to_warn } => {
+                for (label, err) in errors_to_warn {
+                    tracing::warn!(
+                        provider = %label,
+                        block_number = number,
+                        error = %err,
+                        "receipts fetch: provider errored but another said `not found`; treating as not found"
+                    );
+                }
+                Err(Error::FailedToGetBlock(number))
+            }
+            LookupOutcome::AllErrored {
+                first,
+                additional_to_warn,
+            } => {
+                for (label, err) in additional_to_warn {
+                    tracing::warn!(
+                        provider = %label,
+                        block_number = number,
+                        error = %err,
+                        "receipts fetch: additional provider error"
+                    );
+                }
+                let (first_label, first_err) = first;
+                error!(
+                    provider = %first_label,
+                    block_number = number,
+                    error = %first_err,
+                    "Failed to get receipts: all providers errored",
+                );
+                Err(Error::FailedToGetReceipts(number))
+            }
+        }
     }
 
     pub async fn get_eth_block(&self, number: u64) -> Result<Block, Error> {
-        self.provider_for_block(number)
-            .get_block(
-                BlockId::Number(BlockNumberOrTag::Number(number)),
-                true.into(),
-            )
-            .await
-            .map_err(|e| {
-                error!("Failed to get block: {:?}", e);
-                Error::FailedToGetBlock(number)
-            })?
-            .ok_or(Error::FailedToGetBlock(number))
+        let providers = self.providers_with_labels();
+        let mut got_definitive_none = false;
+        let mut errors: Vec<(String, Error)> = Vec::new();
+
+        for (label, provider) in providers {
+            match provider
+                .get_block(
+                    BlockId::Number(BlockNumberOrTag::Number(number)),
+                    true.into(),
+                )
+                .await
+            {
+                Ok(Some(block)) => {
+                    if label != "primary" {
+                        info!(
+                            provider = %label,
+                            block_number = number,
+                            "block fetched via fallback provider"
+                        );
+                    }
+                    return Ok(block);
+                }
+                Ok(None) => got_definitive_none = true,
+                Err(e) => errors.push((label, Error::from(e))),
+            }
+        }
+
+        match merge_provider_lookup(got_definitive_none, errors) {
+            LookupOutcome::NotFound { errors_to_warn } => {
+                for (label, err) in errors_to_warn {
+                    tracing::warn!(
+                        provider = %label,
+                        block_number = number,
+                        error = %err,
+                        "block fetch: provider errored but another said `not found`; treating as not found"
+                    );
+                }
+                Err(Error::FailedToGetBlock(number))
+            }
+            LookupOutcome::AllErrored {
+                first,
+                additional_to_warn,
+            } => {
+                for (label, err) in additional_to_warn {
+                    tracing::warn!(
+                        provider = %label,
+                        block_number = number,
+                        error = %err,
+                        "block fetch: additional provider error"
+                    );
+                }
+                let (first_label, first_err) = first;
+                error!(
+                    provider = %first_label,
+                    block_number = number,
+                    error = %first_err,
+                    "Failed to get block: all providers errored",
+                );
+                Err(Error::FailedToGetBlock(number))
+            }
+        }
     }
 
     pub async fn get_last_block(&self) -> Result<u64, Error> {
@@ -692,6 +773,26 @@ impl Client {
     ///
     /// Returns `Ok(None)` if the transaction is not found on chain (not mined or doesn't exist).
     /// Returns `Err` only for actual RPC/transport failures.
+    ///
+    /// # Routing
+    ///
+    /// A transaction hash carries no block-number information until it is
+    /// resolved, so the lookup walks the configured providers in
+    /// `[primary, fallback_0, fallback_1, ...]` order: the first provider
+    /// to return `Ok(Some(_))` wins, and the rest are not queried. This
+    /// minimizes calls to the (typically expensive / quota-limited) archive
+    /// fallbacks: a recent tx that the primary can answer never reaches an
+    /// archive endpoint at all.
+    ///
+    /// Result-merging policy:
+    /// * The first provider to return `Ok(Some(_))` wins.
+    /// * If every provider returns `Ok(None)`, the result is `Ok(None)`
+    ///   (the tx truly does not exist on this chain).
+    /// * If some providers return `Ok(None)` and others error, the errors
+    ///   are logged as warnings and `Ok(None)` is returned — at least one
+    ///   provider that did respond said the tx is not present.
+    /// * If every provider errors, the first error is returned and the
+    ///   rest are logged at warn level.
     pub async fn get_tx_position_by_hash(
         &self,
         tx_hash: H256,
@@ -699,24 +800,98 @@ impl Client {
         let tx_hash_alloy = TxHash::from_str(&tx_hash.encode_hex())
             .map_err(|e| Error::ClientError(anyhow::anyhow!("Invalid tx hash: {e}")))?;
 
-        let tx_opt = self
-            .rpc_provider
+        let providers = self.providers_with_labels();
+        let mut got_definitive_none = false;
+        let mut errors: Vec<(String, Error)> = Vec::new();
+
+        for (label, provider) in providers {
+            match Self::resolve_tx_on_provider(provider, tx_hash_alloy, &tx_hash).await {
+                Ok(Some(pos)) => {
+                    // Only log when a fallback served the request; the
+                    // primary case is the boring path and would otherwise
+                    // dominate logs for projects without fallbacks.
+                    //
+                    // INFO level here (vs DEBUG for per-block logs)
+                    // because tx-hash resolution is at most once per
+                    // `/proof-by-tx` request, so log volume is bounded
+                    // and the signal is high — operators want to confirm
+                    // at a glance which provider answered.
+                    if label != "primary" {
+                        info!(
+                            provider = %label,
+                            tx_hash = %tx_hash,
+                            block_number = pos.0,
+                            tx_index = pos.1,
+                            "tx-hash resolved by fallback provider"
+                        );
+                    }
+                    return Ok(Some(pos));
+                }
+                Ok(None) => got_definitive_none = true,
+                Err(e) => errors.push((label, e)),
+            }
+        }
+
+        match merge_provider_lookup(got_definitive_none, errors) {
+            LookupOutcome::NotFound { errors_to_warn } => {
+                for (label, err) in errors_to_warn {
+                    tracing::warn!(
+                        provider = %label,
+                        tx_hash = %tx_hash,
+                        error = %err,
+                        "tx-hash lookup: provider errored but another said `not found`; treating as not found"
+                    );
+                }
+                Ok(None)
+            }
+            LookupOutcome::AllErrored {
+                first,
+                additional_to_warn,
+            } => {
+                for (label, err) in additional_to_warn {
+                    tracing::warn!(
+                        provider = %label,
+                        tx_hash = %tx_hash,
+                        error = %err,
+                        "tx-hash lookup: additional provider error"
+                    );
+                }
+                let (first_label, first_err) = first;
+                tracing::error!(
+                    provider = %first_label,
+                    tx_hash = %tx_hash,
+                    error = %first_err,
+                    "tx-hash lookup: all providers errored"
+                );
+                Err(first_err)
+            }
+        }
+    }
+
+    /// One provider's slice of [`Self::get_tx_position_by_hash`]: looks the tx
+    /// up by hash and converts it to `(block_number, tx_index)`. Pure
+    /// extraction so the sequential walk stays readable.
+    async fn resolve_tx_on_provider(
+        provider: &AlloyProvider,
+        tx_hash_alloy: TxHash,
+        tx_hash_for_err: &H256,
+    ) -> Result<Option<(u64, u64)>, Error> {
+        let Some(tx) = provider
             .get_transaction_by_hash(tx_hash_alloy)
             .await
-            .map_err(Error::from)?;
-
-        let Some(tx) = tx_opt else {
+            .map_err(Error::from)?
+        else {
             return Ok(None);
         };
 
         let block_number = tx.block_number.ok_or_else(|| {
             Error::ClientError(anyhow::anyhow!(
-                "Transaction not in a block (pending): {tx_hash}"
+                "Transaction not in a block (pending): {tx_hash_for_err}"
             ))
         })?;
         let tx_index = tx.transaction_index.ok_or_else(|| {
             Error::ClientError(anyhow::anyhow!(
-                "Missing transactionIndex for tx: {tx_hash}"
+                "Missing transactionIndex for tx: {tx_hash_for_err}"
             ))
         })?;
 
@@ -724,73 +899,73 @@ impl Client {
     }
 }
 
-/// Validate a slice of [`RpcRangeOverride`]s, returning normalized
-/// `(from, to, url)` tuples sorted by `from`.
+/// Decision returned by [`merge_provider_lookup`] once the sequential
+/// fallback walk finishes without any provider returning `Ok(Some(_))`.
 ///
-/// This performs *no* network I/O so it can be exercised cheaply in unit
-/// tests and called as a pre-flight check in [`Client::init_range_providers`].
-///
-/// # Errors
-///
-/// * Either bound is `None` on both sides (would shadow the default URL).
-/// * `from_block > to_block`.
-/// * Any two overrides cover an overlapping block range.
-fn validate_range_overrides(
-    overrides: &[RpcRangeOverride],
-) -> anyhow::Result<Vec<(u64, u64, String)>> {
-    if overrides.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let mut bounds: Vec<(u64, u64, String)> = Vec::with_capacity(overrides.len());
-    for ov in overrides {
-        if ov.from_block.is_none() && ov.to_block.is_none() {
-            anyhow::bail!(
-                "RPC range override must set at least one of `from_block` or `to_block` \
-                 (an unbounded override would silently shadow the default URL)"
-            );
-        }
-        let from = ov.from_block.unwrap_or(0);
-        let to = ov.to_block.unwrap_or(u64::MAX);
-        if from > to {
-            anyhow::bail!(
-                "RPC range override has from_block ({from}) > to_block ({to}); \
-                 swap the bounds in your config"
-            );
-        }
-        bounds.push((from, to, ov.url.clone()));
-    }
-
-    bounds.sort_by_key(|(from, _, _)| *from);
-    for w in bounds.windows(2) {
-        let (a_from, a_to, _) = &w[0];
-        let (b_from, b_to, _) = &w[1];
-        if a_to >= b_from {
-            anyhow::bail!(
-                "Overlapping RPC overrides: range [{a_from}, {a_to}] overlaps [{b_from}, {b_to}]"
-            );
-        }
-    }
-
-    Ok(bounds)
+/// The outer call site short-circuits on the first `Ok(Some(_))`, so this
+/// only models the negative paths.
+enum LookupOutcome {
+    /// At least one provider answered "not found" (`Ok(None)`). Any errors
+    /// from peers are demoted to warnings — the providers that did respond
+    /// agreed the value is not there.
+    NotFound {
+        errors_to_warn: Vec<(String, Error)>,
+    },
+    /// Every provider errored. Caller gets `first` as the representative
+    /// failure; remaining errors should be logged at warn level.
+    AllErrored {
+        first: (String, Error),
+        additional_to_warn: Vec<(String, Error)>,
+    },
 }
 
-/// Find the index of the inclusive `(from, to)` range that covers
-/// `block_number`.
+/// Pure decision step shared by every sequential-fallback lookup
+/// ([`Client::get_tx_position_by_hash`], [`Client::get_eth_block`],
+/// [`Client::get_receipts`]).
 ///
-/// Assumes `ranges` is sorted by `from` (as established by
-/// [`validate_range_overrides`]) and that ranges are non-overlapping, so the
-/// search short-circuits at the first range whose `from > block_number`.
-fn find_range_index(block_number: u64, ranges: &[(u64, u64)]) -> Option<usize> {
-    for (i, (from, to)) in ranges.iter().enumerate() {
-        if block_number < *from {
-            return None;
-        }
-        if block_number <= *to {
-            return Some(i);
-        }
+/// `got_definitive_none` is `true` iff at least one provider returned
+/// `Ok(None)`. `errors` carries every provider that failed to respond.
+///
+/// The caller is expected to have already returned early on the first
+/// `Ok(Some(_))`, so this function only sees the negative arms.
+///
+/// # Panics
+///
+/// Panics if both `!got_definitive_none` and `errors.is_empty()`. That state
+/// means "no provider returned anything", which is only possible if the
+/// caller iterated an empty provider list — and the [`Client`] is constructed
+/// such that there is always at least the primary.
+fn merge_provider_lookup(
+    got_definitive_none: bool,
+    mut errors: Vec<(String, Error)>,
+) -> LookupOutcome {
+    if got_definitive_none {
+        return LookupOutcome::NotFound {
+            errors_to_warn: errors,
+        };
     }
-    None
+
+    assert!(
+        !errors.is_empty(),
+        "merge_provider_lookup invoked without any provider results"
+    );
+
+    let first = errors.remove(0);
+    LookupOutcome::AllErrored {
+        first,
+        additional_to_warn: errors,
+    }
+}
+
+/// Redact the query-string of a URL for logs.
+///
+/// Many RPC providers carry their API key in the `?key=...` query parameter,
+/// so logging the full URL would leak the secret. Path-embedded keys are
+/// **not** redacted by this helper — handle those at the call site.
+fn redact_url_query(url: &str) -> String {
+    url.split_once('?')
+        .map(|(base, _)| format!("{base}?…"))
+        .unwrap_or_else(|| url.to_string())
 }
 
 /// Build a simple Ethereum-compatible Merkle tree from a block
@@ -802,125 +977,82 @@ pub fn simple_merkle_tree(block: &OrderedBlock) -> merkle::KeccakMerkleTree {
 }
 
 #[cfg(test)]
-mod range_override_tests {
-    use super::{find_range_index, validate_range_overrides, RpcRangeOverride};
+mod provider_lookup_tests {
+    use super::{merge_provider_lookup, redact_url_query, Error, LookupOutcome};
 
-    fn ov(from: Option<u64>, to: Option<u64>, url: &str) -> RpcRangeOverride {
-        RpcRangeOverride {
-            from_block: from,
-            to_block: to,
-            url: url.to_string(),
+    fn err(msg: &str) -> Error {
+        Error::ClientError(anyhow::anyhow!(msg.to_string()))
+    }
+
+    #[test]
+    fn at_least_one_none_yields_not_found_and_keeps_errors_for_warnings() {
+        let errors = vec![
+            ("primary".to_string(), err("connection reset")),
+            ("fallback[0]@http://x".to_string(), err("rate limited")),
+        ];
+        let outcome = merge_provider_lookup(true, errors);
+        match outcome {
+            LookupOutcome::NotFound { errors_to_warn } => {
+                assert_eq!(errors_to_warn.len(), 2);
+                assert_eq!(errors_to_warn[0].0, "primary");
+                assert_eq!(errors_to_warn[1].0, "fallback[0]@http://x");
+            }
+            LookupOutcome::AllErrored { .. } => panic!("expected NotFound"),
         }
     }
 
     #[test]
-    fn empty_overrides_validates_to_empty() {
-        let normalized = validate_range_overrides(&[]).expect("empty list is valid");
-        assert!(normalized.is_empty());
+    fn definitive_none_with_no_errors_is_simple_not_found() {
+        let outcome = merge_provider_lookup(true, Vec::new());
+        match outcome {
+            LookupOutcome::NotFound { errors_to_warn } => {
+                assert!(errors_to_warn.is_empty());
+            }
+            LookupOutcome::AllErrored { .. } => panic!("expected NotFound"),
+        }
     }
 
     #[test]
-    fn unbounded_override_is_rejected() {
-        let err = validate_range_overrides(&[ov(None, None, "http://x")]).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("at least one of `from_block` or `to_block`"),
-            "unexpected error: {msg}"
-        );
+    fn no_none_and_some_errors_promotes_first_error() {
+        let errors = vec![
+            ("primary".to_string(), err("first failure")),
+            ("fallback[0]@http://a".to_string(), err("second failure")),
+            ("fallback[1]@http://b".to_string(), err("third failure")),
+        ];
+        let outcome = merge_provider_lookup(false, errors);
+        match outcome {
+            LookupOutcome::AllErrored {
+                first,
+                additional_to_warn,
+            } => {
+                assert_eq!(first.0, "primary");
+                assert_eq!(first.1.to_string(), "Client error first failure");
+                assert_eq!(additional_to_warn.len(), 2);
+                assert_eq!(additional_to_warn[0].0, "fallback[0]@http://a");
+                assert_eq!(additional_to_warn[1].0, "fallback[1]@http://b");
+            }
+            LookupOutcome::NotFound { .. } => panic!("expected AllErrored"),
+        }
     }
 
     #[test]
-    fn inverted_bounds_are_rejected() {
-        let err = validate_range_overrides(&[ov(Some(100), Some(50), "http://x")]).unwrap_err();
-        assert!(
-            err.to_string().contains("from_block"),
-            "unexpected error: {err}"
-        );
+    #[should_panic(expected = "merge_provider_lookup invoked without any provider results")]
+    fn empty_input_panics() {
+        // The caller iterates `[primary, fallbacks..]` so the input is never
+        // empty in practice; assert the defensive check fires loudly if the
+        // invariant is ever broken.
+        let _ = merge_provider_lookup(false, Vec::new());
     }
 
     #[test]
-    fn overlapping_overrides_are_rejected() {
-        let err = validate_range_overrides(&[
-            ov(Some(0), Some(1_000), "http://low"),
-            ov(Some(500), Some(2_000), "http://mid"),
-        ])
-        .unwrap_err();
-        assert!(
-            err.to_string().contains("Overlapping"),
-            "unexpected error: {err}"
-        );
+    fn redact_url_query_strips_after_question_mark() {
+        let redacted = redact_url_query("https://rpc.example.io/v2/foo?key=secret123");
+        assert_eq!(redacted, "https://rpc.example.io/v2/foo?…");
     }
 
     #[test]
-    fn touching_ranges_are_overlapping() {
-        // Ranges are inclusive on both ends, so [0, 100] and [100, 200] both
-        // cover block 100 — that ambiguity is rejected.
-        let err = validate_range_overrides(&[
-            ov(Some(0), Some(100), "http://low"),
-            ov(Some(100), Some(200), "http://hi"),
-        ])
-        .unwrap_err();
-        assert!(err.to_string().contains("Overlapping"));
-    }
-
-    #[test]
-    fn adjacent_ranges_are_allowed() {
-        let normalized = validate_range_overrides(&[
-            ov(Some(0), Some(99), "http://low"),
-            ov(Some(100), Some(200), "http://hi"),
-        ])
-        .expect("adjacent ranges must be allowed");
-        assert_eq!(
-            normalized,
-            vec![
-                (0, 99, "http://low".to_string()),
-                (100, 200, "http://hi".to_string()),
-            ]
-        );
-    }
-
-    #[test]
-    fn validation_normalizes_open_bounds_and_sorts() {
-        let normalized = validate_range_overrides(&[
-            ov(Some(4_000_001), None, "http://recent"),
-            ov(None, Some(4_000_000), "http://archive"),
-        ])
-        .expect("non-overlapping open bounds are valid");
-
-        assert_eq!(
-            normalized,
-            vec![
-                (0, 4_000_000, "http://archive".to_string()),
-                (4_000_001, u64::MAX, "http://recent".to_string()),
-            ]
-        );
-    }
-
-    #[test]
-    fn find_range_index_picks_matching_range() {
-        // Mirrors the user-facing two-bucket example: archive vs recent.
-        let ranges = &[(0, 4_000_000), (4_000_001, u64::MAX)];
-
-        assert_eq!(find_range_index(0, ranges), Some(0));
-        assert_eq!(find_range_index(4_000_000, ranges), Some(0));
-        assert_eq!(find_range_index(4_000_001, ranges), Some(1));
-        assert_eq!(find_range_index(u64::MAX, ranges), Some(1));
-    }
-
-    #[test]
-    fn find_range_index_returns_none_for_gap() {
-        // Block 75 falls between [0, 50] and [100, 200] — no override matches,
-        // so the caller falls back to the default URL.
-        let ranges = &[(0, 50), (100, 200)];
-
-        assert_eq!(find_range_index(75, ranges), None);
-        assert_eq!(find_range_index(50, ranges), Some(0));
-        assert_eq!(find_range_index(100, ranges), Some(1));
-        assert_eq!(find_range_index(201, ranges), None);
-    }
-
-    #[test]
-    fn find_range_index_with_no_ranges_returns_none() {
-        assert_eq!(find_range_index(42, &[]), None);
+    fn redact_url_query_passes_through_when_no_query() {
+        let redacted = redact_url_query("wss://node.example.io/abcdef");
+        assert_eq!(redacted, "wss://node.example.io/abcdef");
     }
 }

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -474,12 +474,6 @@ impl Client {
         out
     }
 
-    /// Returns the configured fallback URLs in declaration order. Useful
-    /// for startup logging.
-    pub fn fallback_urls(&self) -> Vec<&Url> {
-        self.fallback_providers.iter().map(|fp| &fp.url).collect()
-    }
-
     pub fn chain_id(&self) -> u64 {
         self.chain_id
     }

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -957,15 +957,82 @@ fn merge_provider_lookup(
     }
 }
 
-/// Redact the query-string of a URL for logs.
+/// Redact the query-string **and** any secret-looking path segments of a URL
+/// for logs.
 ///
-/// Many RPC providers carry their API key in the `?key=...` query parameter,
-/// so logging the full URL would leak the secret. Path-embedded keys are
-/// **not** redacted by this helper — handle those at the call site.
-fn redact_url_query(url: &str) -> String {
-    url.split_once('?')
-        .map(|(base, _)| format!("{base}?…"))
-        .unwrap_or_else(|| url.to_string())
+/// Many RPC providers carry their API key in the URL — either in the
+/// `?key=...` query parameter (Google Cloud, Infura legacy) or as a trailing
+/// path segment (Chainstack, Alchemy, QuickNode, …). This helper handles
+/// both:
+///
+/// * Anything after the first `?` is replaced with `?…`.
+/// * Any path segment that looks like an opaque secret token — i.e. at
+///   least 16 characters of `[A-Za-z0-9_-]` containing at least one digit
+///   *and* one letter — is replaced with `…` (the segment length is not
+///   leaked).
+///
+/// Human-readable path tokens (`v1`, `projects`, `cc3-testnet-rpckey-2`,
+/// `ethereum-sepolia`, etc.) stay intact because they either contain a
+/// hyphen-separated word or are too short / not mixed-case to trip the
+/// secret heuristic.
+pub fn redact_url_query(url: &str) -> String {
+    // Split off the query string first so we never accidentally redact
+    // inside it (and to keep behavior identical to the previous helper for
+    // `?key=...`-style URLs).
+    let (base, query_marker) = match url.split_once('?') {
+        Some((b, _)) => (b, "?…"),
+        None => (url, ""),
+    };
+
+    // Redact the path. We split on '/' so we can scan each segment
+    // independently; this keeps `scheme://host` untouched (the leading
+    // `scheme:` and the empty pre-`//` segments don't match the secret
+    // heuristic).
+    let redacted_path = base
+        .split('/')
+        .map(|seg| {
+            if looks_like_secret_segment(seg) {
+                "…"
+            } else {
+                seg
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/");
+
+    format!("{redacted_path}{query_marker}")
+}
+
+/// Heuristic: does this path segment look like an opaque secret token
+/// (API key, project hash, …) that we should not log?
+///
+/// Conservative — designed to avoid false positives on routine path
+/// components like `v1`, `rpc`, `ethereum-sepolia`, `cc3-testnet-rpckey-2`.
+fn looks_like_secret_segment(seg: &str) -> bool {
+    if seg.len() < 16 {
+        return false;
+    }
+
+    // Hyphenated multi-word identifiers (e.g. `cc3-testnet-rpckey-2`,
+    // `ethereum-sepolia`) are never secrets in practice — providers don't
+    // shape API keys that way. This single rule covers all the
+    // human-readable path tokens we've seen in proof-gen configs.
+    if seg.contains('-') {
+        return false;
+    }
+
+    let mut has_digit = false;
+    let mut has_letter = false;
+    for ch in seg.chars() {
+        match ch {
+            '0'..='9' => has_digit = true,
+            'A'..='Z' | 'a'..='z' => has_letter = true,
+            '_' => {}
+            _ => return false, // any other char ⇒ not a secret-shaped token
+        }
+    }
+
+    has_digit && has_letter
 }
 
 /// Build a simple Ethereum-compatible Merkle tree from a block
@@ -1051,8 +1118,61 @@ mod provider_lookup_tests {
     }
 
     #[test]
-    fn redact_url_query_passes_through_when_no_query() {
+    fn redact_url_query_passes_through_short_path_when_no_query() {
+        // No query, short path token — nothing to redact.
         let redacted = redact_url_query("wss://node.example.io/abcdef");
         assert_eq!(redacted, "wss://node.example.io/abcdef");
+    }
+
+    #[test]
+    fn redact_url_query_redacts_chainstack_style_path_key() {
+        // Chainstack embeds the API key as a 32-char hex path segment.
+        let redacted = redact_url_query(
+            "https://ethereum-sepolia.core.chainstack.com/efdb96b1ade73fac0eb3f90559b9acee",
+        );
+        assert_eq!(redacted, "https://ethereum-sepolia.core.chainstack.com/…");
+    }
+
+    #[test]
+    fn redact_url_query_redacts_alchemy_style_trailing_token() {
+        let redacted =
+            redact_url_query("https://eth-mainnet.g.alchemy.com/v2/AbCdEf012345MoreSecret67890");
+        // `v2` is short and stays; trailing token is redacted.
+        assert_eq!(redacted, "https://eth-mainnet.g.alchemy.com/v2/…");
+    }
+
+    #[test]
+    fn redact_url_query_keeps_human_readable_path_segments() {
+        // Real-world googleapis URL — the path tokens are identifiers we
+        // *want* to keep for log readability; the actual key sits in `?key=`.
+        let redacted = redact_url_query(
+            "https://blockchain.googleapis.com/v1/projects/cc3-testnet-rpckey-2/locations/us-central1/endpoints/ethereum-sepolia/rpc?key=AIzaSyVxWM",
+        );
+        assert_eq!(
+            redacted,
+            "https://blockchain.googleapis.com/v1/projects/cc3-testnet-rpckey-2/locations/us-central1/endpoints/ethereum-sepolia/rpc?…"
+        );
+    }
+
+    #[test]
+    fn redact_url_query_keeps_pure_letter_paths() {
+        // No digits in the segment ⇒ not a key-shaped token; keep as-is.
+        let redacted = redact_url_query("https://rpc.example.io/abcdefghijklmnopqrst");
+        assert_eq!(redacted, "https://rpc.example.io/abcdefghijklmnopqrst");
+    }
+
+    #[test]
+    fn redact_url_query_keeps_pure_digit_paths() {
+        // No letters ⇒ likely a port/id/ts, not an API key.
+        let redacted = redact_url_query("https://rpc.example.io/1234567890123456");
+        assert_eq!(redacted, "https://rpc.example.io/1234567890123456");
+    }
+
+    #[test]
+    fn redact_url_query_redacts_inner_secret_segment() {
+        // Trailing `/rpc` is a fixed suffix; the secret is the segment in the
+        // middle. Verify each segment is evaluated independently.
+        let redacted = redact_url_query("https://eth.example.io/v1/aB3xQ9MnP2rT7vW4kY8jL6/rpc");
+        assert_eq!(redacted, "https://eth.example.io/v1/…/rpc");
     }
 }

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -344,7 +344,10 @@ impl Client {
             }
         };
 
-        info!("🚀 🌐 Connecting to Ethereum node at {}", url);
+        info!(
+            "🚀 🌐 Connecting to Ethereum node at {}",
+            redact_url_query(url.as_str())
+        );
 
         let chain_id = rpc_provider
             .get_chain_id()

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -405,18 +405,42 @@ impl Client {
         // Reconnect each fallback against its own URL too, otherwise a
         // recovered primary would silently keep using a stale fallback
         // socket until that fallback hit a fault on its own.
+        //
+        // Fallback reconnects are best-effort: a healthy primary should not be
+        // taken down because a backup endpoint is misbehaving. If a fallback
+        // fails to reconnect (transport error or chain_id mismatch), keep the
+        // existing provider in place, log a loud error, and let the next
+        // primary-failure path retry it on its own.
         let mut new_fallbacks = Vec::with_capacity(self.fallback_providers.len());
-        for fp in &self.fallback_providers {
-            let (fp_url, fp_provider, fp_chain_id) = Self::init_rpc(fp.url.as_ref()).await?;
-            if fp_chain_id != chain_id {
-                return Err(Error::ClientError(anyhow::anyhow!(
-                    "Fallback RPC URL chain_id ({fp_chain_id}) does not match primary URL chain_id ({chain_id}) on reconnect"
-                )));
+        for (idx, fp) in self.fallback_providers.iter().enumerate() {
+            match Self::init_rpc(fp.url.as_ref()).await {
+                Ok((fp_url, fp_provider, fp_chain_id)) => {
+                    if fp_chain_id != chain_id {
+                        tracing::error!(
+                            fallback_index = idx,
+                            fallback_url = %redact_url_query(fp.url.as_str()),
+                            fallback_chain_id = fp_chain_id,
+                            primary_chain_id = chain_id,
+                            "⛔ Fallback RPC chain_id mismatch on reconnect; keeping previous fallback provider"
+                        );
+                        new_fallbacks.push(fp.clone());
+                    } else {
+                        new_fallbacks.push(FallbackProvider {
+                            url: fp_url,
+                            provider: fp_provider,
+                        });
+                    }
+                }
+                Err(err) => {
+                    tracing::error!(
+                        fallback_index = idx,
+                        fallback_url = %redact_url_query(fp.url.as_str()),
+                        error = %err,
+                        "⛔ Failed to reconnect fallback RPC; keeping previous fallback provider"
+                    );
+                    new_fallbacks.push(fp.clone());
+                }
             }
-            new_fallbacks.push(FallbackProvider {
-                url: fp_url,
-                provider: fp_provider,
-            });
         }
 
         self.url = url;

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -292,11 +292,44 @@ pub enum ConnectionTransport {
     Ws(WsConnect),
 }
 
+/// One per-block-range RPC URL override.
+///
+/// Block-keyed RPC requests (block fetch, receipts) whose `block_number`
+/// falls within the inclusive range `[from_block, to_block]` are routed to
+/// `url` instead of the [`Client`]'s default URL. Either bound may be `None`
+/// to mean "open-ended on that side".
+///
+/// All override URLs must point to a node that reports the same `chain_id`
+/// as the default URL — this is verified when the [`Client`] is constructed.
+///
+/// Constraints (enforced at construction time):
+/// * Each override must specify at least one of `from_block` or `to_block`
+///   (otherwise it would silently shadow the default URL).
+/// * If both bounds are set, `from_block <= to_block`.
+/// * Overrides must not overlap each other.
+#[derive(Debug, Clone)]
+pub struct RpcRangeOverride {
+    pub from_block: Option<u64>,
+    pub to_block: Option<u64>,
+    pub url: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RangeProvider {
+    pub(crate) from: u64,
+    pub(crate) to: u64,
+    pub(crate) url: Url,
+    pub(crate) provider: AlloyProvider,
+}
+
 #[derive(Debug, Clone)]
 pub struct Client {
     url: Url,
     private_key: Option<String>,
     rpc_provider: AlloyProvider,
+    /// Block-range RPC overrides, sorted by `from`. Empty = no overrides
+    /// (legacy single-URL behavior). See [`RpcRangeOverride`].
+    range_providers: Vec<RangeProvider>,
     // what chain id is implied here? Maybe need to define internal chain ids for different attestation chains
     // and not rely on ethereum chain ids?
     chain_id: u64,
@@ -344,6 +377,37 @@ impl Client {
             url,
             private_key: private_key.map(|s| s.to_owned()),
             rpc_provider,
+            range_providers: Vec::new(),
+            chain_id,
+            #[cfg(feature = "block_cache")]
+            cache: None,
+        })
+    }
+
+    /// Build a [`Client`] with per-block-range RPC URL overrides.
+    ///
+    /// `url` is the default URL used for tip-related calls (subscriptions,
+    /// `eth_blockNumber`, `eth_getTransactionByHash`) and for any block whose
+    /// number is not covered by an entry in `overrides`.
+    ///
+    /// All override URLs are connected to at startup; each must report the
+    /// same `chain_id` as `url` and the override ranges must satisfy the
+    /// validity rules documented on [`RpcRangeOverride`].
+    ///
+    /// When `overrides` is empty this is equivalent to [`Client::new`].
+    pub async fn new_with_overrides(
+        url: &str,
+        overrides: &[RpcRangeOverride],
+        private_key: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let (url, rpc_provider, chain_id) = Self::init_rpc(url).await?;
+        let range_providers = Self::init_range_providers(chain_id, overrides).await?;
+
+        anyhow::Ok(Self {
+            url,
+            private_key: private_key.map(|s| s.to_owned()),
+            rpc_provider,
+            range_providers,
             chain_id,
             #[cfg(feature = "block_cache")]
             cache: None,
@@ -353,11 +417,91 @@ impl Client {
     pub async fn reconnect(&mut self) -> Result<(), Error> {
         let (url, rpc_provider, chain_id) = Self::init_rpc(self.url.as_ref()).await?;
 
+        // Reconnect each range provider against its own URL too, otherwise a
+        // recovered default would silently start serving range-bucket blocks
+        // until each override picked up the network fault on its own.
+        let mut new_ranges = Vec::with_capacity(self.range_providers.len());
+        for rp in &self.range_providers {
+            let (rp_url, rp_provider, rp_chain_id) = Self::init_rpc(rp.url.as_ref()).await?;
+            if rp_chain_id != chain_id {
+                return Err(Error::ClientError(anyhow::anyhow!(
+                    "RPC override URL chain_id ({rp_chain_id}) does not match default URL chain_id ({chain_id}) on reconnect"
+                )));
+            }
+            new_ranges.push(RangeProvider {
+                from: rp.from,
+                to: rp.to,
+                url: rp_url,
+                provider: rp_provider,
+            });
+        }
+
         self.url = url;
         self.rpc_provider = rpc_provider;
+        self.range_providers = new_ranges;
         self.chain_id = chain_id;
 
         Ok(())
+    }
+
+    /// Validate the override list (no network I/O), connect to each override
+    /// URL in declaration order, and verify the chain id matches the default.
+    pub(crate) async fn init_range_providers(
+        default_chain_id: u64,
+        overrides: &[RpcRangeOverride],
+    ) -> anyhow::Result<Vec<RangeProvider>> {
+        // Fail fast on invalid bounds before opening any sockets.
+        let normalized = validate_range_overrides(overrides)?;
+
+        let mut providers: Vec<RangeProvider> = Vec::with_capacity(normalized.len());
+        for (from, to, raw_url) in normalized {
+            let (url, provider, chain_id) =
+                Self::init_rpc(raw_url.as_ref()).await.with_context(|| {
+                    format!("Failed to connect to RPC override URL for block range [{from}, {to}]")
+                })?;
+
+            if chain_id != default_chain_id {
+                anyhow::bail!(
+                    "RPC override for block range [{from}, {to}] reports chain_id {chain_id}, \
+                     which does not match the default URL's chain_id {default_chain_id}; \
+                     all override URLs must point to the same chain"
+                );
+            }
+
+            providers.push(RangeProvider {
+                from,
+                to,
+                url,
+                provider,
+            });
+        }
+
+        Ok(providers)
+    }
+
+    /// Pick the RPC provider for a block-keyed call.
+    ///
+    /// Returns the matching range override's provider when one covers
+    /// `block_number`, otherwise the default `rpc_provider`.
+    fn provider_for_block(&self, block_number: u64) -> &AlloyProvider {
+        let bounds: Vec<(u64, u64)> = self
+            .range_providers
+            .iter()
+            .map(|rp| (rp.from, rp.to))
+            .collect();
+        match find_range_index(block_number, &bounds) {
+            Some(i) => &self.range_providers[i].provider,
+            None => &self.rpc_provider,
+        }
+    }
+
+    /// Returns the configured RPC overrides as `(from, to, url)` tuples
+    /// (sorted by `from`). Useful for startup logging.
+    pub fn range_overrides(&self) -> Vec<(u64, u64, &Url)> {
+        self.range_providers
+            .iter()
+            .map(|rp| (rp.from, rp.to, &rp.url))
+            .collect()
     }
 
     pub fn chain_id(&self) -> u64 {
@@ -494,7 +638,7 @@ impl Client {
     }
 
     async fn get_receipts(&self, number: u64) -> Result<Vec<TransactionReceipt>, Error> {
-        self.rpc_provider
+        self.provider_for_block(number)
             .get_block_receipts(BlockId::Number(BlockNumberOrTag::Number(number)))
             .await
             .map_err(|e| {
@@ -505,7 +649,7 @@ impl Client {
     }
 
     pub async fn get_eth_block(&self, number: u64) -> Result<Block, Error> {
-        self.rpc_provider
+        self.provider_for_block(number)
             .get_block(
                 BlockId::Number(BlockNumberOrTag::Number(number)),
                 true.into(),
@@ -580,10 +724,203 @@ impl Client {
     }
 }
 
+/// Validate a slice of [`RpcRangeOverride`]s, returning normalized
+/// `(from, to, url)` tuples sorted by `from`.
+///
+/// This performs *no* network I/O so it can be exercised cheaply in unit
+/// tests and called as a pre-flight check in [`Client::init_range_providers`].
+///
+/// # Errors
+///
+/// * Either bound is `None` on both sides (would shadow the default URL).
+/// * `from_block > to_block`.
+/// * Any two overrides cover an overlapping block range.
+fn validate_range_overrides(
+    overrides: &[RpcRangeOverride],
+) -> anyhow::Result<Vec<(u64, u64, String)>> {
+    if overrides.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut bounds: Vec<(u64, u64, String)> = Vec::with_capacity(overrides.len());
+    for ov in overrides {
+        if ov.from_block.is_none() && ov.to_block.is_none() {
+            anyhow::bail!(
+                "RPC range override must set at least one of `from_block` or `to_block` \
+                 (an unbounded override would silently shadow the default URL)"
+            );
+        }
+        let from = ov.from_block.unwrap_or(0);
+        let to = ov.to_block.unwrap_or(u64::MAX);
+        if from > to {
+            anyhow::bail!(
+                "RPC range override has from_block ({from}) > to_block ({to}); \
+                 swap the bounds in your config"
+            );
+        }
+        bounds.push((from, to, ov.url.clone()));
+    }
+
+    bounds.sort_by_key(|(from, _, _)| *from);
+    for w in bounds.windows(2) {
+        let (a_from, a_to, _) = &w[0];
+        let (b_from, b_to, _) = &w[1];
+        if a_to >= b_from {
+            anyhow::bail!(
+                "Overlapping RPC overrides: range [{a_from}, {a_to}] overlaps [{b_from}, {b_to}]"
+            );
+        }
+    }
+
+    Ok(bounds)
+}
+
+/// Find the index of the inclusive `(from, to)` range that covers
+/// `block_number`.
+///
+/// Assumes `ranges` is sorted by `from` (as established by
+/// [`validate_range_overrides`]) and that ranges are non-overlapping, so the
+/// search short-circuits at the first range whose `from > block_number`.
+fn find_range_index(block_number: u64, ranges: &[(u64, u64)]) -> Option<usize> {
+    for (i, (from, to)) in ranges.iter().enumerate() {
+        if block_number < *from {
+            return None;
+        }
+        if block_number <= *to {
+            return Some(i);
+        }
+    }
+    None
+}
+
 /// Build a simple Ethereum-compatible Merkle tree from a block
 ///
 /// Uses `KeccakMerkleTree` which matches the POC implementation exactly.
 pub fn simple_merkle_tree(block: &OrderedBlock) -> merkle::KeccakMerkleTree {
     let tx_bytes: Vec<Vec<u8>> = block.items().iter().map(|item| item.to_bytes()).collect();
     merkle::KeccakMerkleTree::new(&tx_bytes)
+}
+
+#[cfg(test)]
+mod range_override_tests {
+    use super::{find_range_index, validate_range_overrides, RpcRangeOverride};
+
+    fn ov(from: Option<u64>, to: Option<u64>, url: &str) -> RpcRangeOverride {
+        RpcRangeOverride {
+            from_block: from,
+            to_block: to,
+            url: url.to_string(),
+        }
+    }
+
+    #[test]
+    fn empty_overrides_validates_to_empty() {
+        let normalized = validate_range_overrides(&[]).expect("empty list is valid");
+        assert!(normalized.is_empty());
+    }
+
+    #[test]
+    fn unbounded_override_is_rejected() {
+        let err = validate_range_overrides(&[ov(None, None, "http://x")]).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("at least one of `from_block` or `to_block`"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn inverted_bounds_are_rejected() {
+        let err = validate_range_overrides(&[ov(Some(100), Some(50), "http://x")]).unwrap_err();
+        assert!(
+            err.to_string().contains("from_block"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn overlapping_overrides_are_rejected() {
+        let err = validate_range_overrides(&[
+            ov(Some(0), Some(1_000), "http://low"),
+            ov(Some(500), Some(2_000), "http://mid"),
+        ])
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("Overlapping"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn touching_ranges_are_overlapping() {
+        // Ranges are inclusive on both ends, so [0, 100] and [100, 200] both
+        // cover block 100 — that ambiguity is rejected.
+        let err = validate_range_overrides(&[
+            ov(Some(0), Some(100), "http://low"),
+            ov(Some(100), Some(200), "http://hi"),
+        ])
+        .unwrap_err();
+        assert!(err.to_string().contains("Overlapping"));
+    }
+
+    #[test]
+    fn adjacent_ranges_are_allowed() {
+        let normalized = validate_range_overrides(&[
+            ov(Some(0), Some(99), "http://low"),
+            ov(Some(100), Some(200), "http://hi"),
+        ])
+        .expect("adjacent ranges must be allowed");
+        assert_eq!(
+            normalized,
+            vec![
+                (0, 99, "http://low".to_string()),
+                (100, 200, "http://hi".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn validation_normalizes_open_bounds_and_sorts() {
+        let normalized = validate_range_overrides(&[
+            ov(Some(4_000_001), None, "http://recent"),
+            ov(None, Some(4_000_000), "http://archive"),
+        ])
+        .expect("non-overlapping open bounds are valid");
+
+        assert_eq!(
+            normalized,
+            vec![
+                (0, 4_000_000, "http://archive".to_string()),
+                (4_000_001, u64::MAX, "http://recent".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn find_range_index_picks_matching_range() {
+        // Mirrors the user-facing two-bucket example: archive vs recent.
+        let ranges = &[(0, 4_000_000), (4_000_001, u64::MAX)];
+
+        assert_eq!(find_range_index(0, ranges), Some(0));
+        assert_eq!(find_range_index(4_000_000, ranges), Some(0));
+        assert_eq!(find_range_index(4_000_001, ranges), Some(1));
+        assert_eq!(find_range_index(u64::MAX, ranges), Some(1));
+    }
+
+    #[test]
+    fn find_range_index_returns_none_for_gap() {
+        // Block 75 falls between [0, 50] and [100, 200] — no override matches,
+        // so the caller falls back to the default URL.
+        let ranges = &[(0, 50), (100, 200)];
+
+        assert_eq!(find_range_index(75, ranges), None);
+        assert_eq!(find_range_index(50, ranges), Some(0));
+        assert_eq!(find_range_index(100, ranges), Some(1));
+        assert_eq!(find_range_index(201, ranges), None);
+    }
+
+    #[test]
+    fn find_range_index_with_no_ranges_returns_none() {
+        assert_eq!(find_range_index(42, &[]), None);
+    }
 }

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -652,6 +652,19 @@ impl Client {
                             "receipts fetched via fallback provider"
                         );
                     }
+                    // Don't silently drop errors from earlier providers:
+                    // if the primary (or an earlier fallback) errored and a
+                    // later fallback served the request, surface those errors
+                    // at WARN so operators can still root-cause flaky peers.
+                    for (err_label, err) in errors.drain(..) {
+                        tracing::warn!(
+                            provider = %err_label,
+                            served_by = %label,
+                            block_number = number,
+                            error = %err,
+                            "receipts fetch: provider errored but another succeeded"
+                        );
+                    }
                     return Ok(receipts);
                 }
                 Ok(None) => got_definitive_none = true,
@@ -719,6 +732,19 @@ impl Client {
                             provider = %label,
                             block_number = number,
                             "block fetched via fallback provider"
+                        );
+                    }
+                    // Don't silently drop errors from earlier providers:
+                    // if the primary (or an earlier fallback) errored and a
+                    // later fallback served the request, surface those errors
+                    // at WARN so operators can still root-cause flaky peers.
+                    for (err_label, err) in errors.drain(..) {
+                        tracing::warn!(
+                            provider = %err_label,
+                            served_by = %label,
+                            block_number = number,
+                            error = %err,
+                            "block fetch: provider errored but another succeeded"
                         );
                     }
                     return Ok(block);
@@ -806,7 +832,10 @@ impl Client {
     /// archive endpoint at all.
     ///
     /// Result-merging policy:
-    /// * The first provider to return `Ok(Some(_))` wins.
+    /// * The first provider to return `Ok(Some(_))` wins. Any errors from
+    ///   earlier providers in the walk are logged at warn level before
+    ///   returning so a flaky primary masked by a healthy fallback still
+    ///   shows up in operator logs.
     /// * If every provider returns `Ok(None)`, the result is `Ok(None)`
     ///   (the tx truly does not exist on this chain).
     /// * If some providers return `Ok(None)` and others error, the errors
@@ -844,6 +873,19 @@ impl Client {
                             block_number = pos.0,
                             tx_index = pos.1,
                             "tx-hash resolved by fallback provider"
+                        );
+                    }
+                    // Don't silently drop errors from earlier providers:
+                    // if the primary (or an earlier fallback) errored and a
+                    // later fallback resolved the tx, surface those errors
+                    // at WARN so operators can still root-cause flaky peers.
+                    for (err_label, err) in errors.drain(..) {
+                        tracing::warn!(
+                            provider = %err_label,
+                            served_by = %label,
+                            tx_hash = %tx_hash,
+                            error = %err,
+                            "tx-hash lookup: provider errored but another succeeded"
                         );
                     }
                     return Ok(Some(pos));

--- a/proof-gen-api-server/bin/server.rs
+++ b/proof-gen-api-server/bin/server.rs
@@ -174,6 +174,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             chains: vec![ChainConfig {
                 chain_key,
                 eth_rpc_url: args.eth_rpc_url,
+                // Per-block-range overrides are only configurable via the
+                // multi-chain YAML; the legacy single-chain CLI path stays
+                // single-URL.
+                eth_rpc_overrides: Vec::new(),
                 archiver_url: args.archiver_url,
                 block_confirmation_depth: args.block_confirmation_depth,
             }],

--- a/proof-gen-api-server/bin/server.rs
+++ b/proof-gen-api-server/bin/server.rs
@@ -165,7 +165,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let chain_key = env::var("CHAIN_KEY")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(1);
+            .unwrap_or(2);
         Config {
             bind_host: args.bind_host,
             bind_port: args.bind_port,

--- a/proof-gen-api-server/bin/server.rs
+++ b/proof-gen-api-server/bin/server.rs
@@ -161,7 +161,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         c
     } else {
-        // Legacy single-chain mode: chain key from CHAIN_KEY env (default 1).
+        // Legacy single-chain mode: chain key from CHAIN_KEY env (default 2).
         let chain_key = env::var("CHAIN_KEY")
             .ok()
             .and_then(|s| s.parse().ok())

--- a/proof-gen-api-server/bin/server.rs
+++ b/proof-gen-api-server/bin/server.rs
@@ -174,10 +174,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             chains: vec![ChainConfig {
                 chain_key,
                 eth_rpc_url: args.eth_rpc_url,
-                // Per-block-range overrides are only configurable via the
-                // multi-chain YAML; the legacy single-chain CLI path stays
-                // single-URL.
-                eth_rpc_overrides: Vec::new(),
+                // Fallback RPC URLs are only configurable via the multi-chain
+                // YAML; the legacy single-chain CLI path stays single-URL.
+                eth_rpc_fallback_urls: Vec::new(),
                 archiver_url: args.archiver_url,
                 block_confirmation_depth: args.block_confirmation_depth,
             }],

--- a/proof-gen-api-server/bin/server.rs
+++ b/proof-gen-api-server/bin/server.rs
@@ -161,11 +161,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         c
     } else {
-        // Legacy single-chain mode: chain key from CHAIN_KEY env (default 2).
+        // Legacy single-chain mode: chain key from CHAIN_KEY env (default 1).
         let chain_key = env::var("CHAIN_KEY")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(2);
+            .unwrap_or(1);
         Config {
             bind_host: args.bind_host,
             bind_port: args.bind_port,

--- a/proof-gen-api-server/config.example.yaml
+++ b/proof-gen-api-server/config.example.yaml
@@ -4,7 +4,7 @@
 # Creditcoin3 WebSocket URL: set CC3_RPC_URL in .env (or pass --cc3-rpc-url), not in this file.
 #
 # Without --config / PROOF_GEN_CONFIG_FILE: legacy single-chain mode (CLI/env only).
-# Supported chain key defaults to CHAIN_KEY (default 2); ETH RPC from --eth-rpc-url / ETH_RPC_URL.
+# Supported chain key defaults to CHAIN_KEY (default 1); ETH RPC from --eth-rpc-url / ETH_RPC_URL.
 # Multi-chain allowlists and per-chain eth_rpc_url require this YAML (or equivalent env wiring).
 ---
 bind_host: "0.0.0.0"
@@ -15,8 +15,9 @@ chains:
   - chain_key: 2
     eth_rpc_url: "http://localhost:8545"
     # archiver_url: "http://localhost:8080"  # optional per chain
-    # block_confirmation_depth: 0  # Blocks to lag behind chain tip for reorg protection.
-    #                               # Default: 0 (no lag). Set to 12 for Ethereum mainnet.
+    block_confirmation_depth: 32  # Blocks to lag behind chain tip for reorg protection.
+    #                              # Suggested: 32 for Ethereum-style L1 chains; tune per source chain.
+    #                              # Default when omitted: 0 (no lag), only safe for local/dev networks.
     #
     # Ordered fallback RPC URLs (optional).
     # The eth client always tries `eth_rpc_url` (primary) first for every

--- a/proof-gen-api-server/config.example.yaml
+++ b/proof-gen-api-server/config.example.yaml
@@ -18,27 +18,21 @@ chains:
     # block_confirmation_depth: 0  # Blocks to lag behind chain tip for reorg protection.
     #                               # Default: 0 (no lag). Set to 12 for Ethereum mainnet.
     #
-    # Per-block-range RPC URL overrides (optional).
-    # When a block-keyed RPC call's block_number falls within an override's
-    # [from_block, to_block] range (both bounds inclusive; either may be
-    # omitted to mean open-ended), that override's URL is used instead of
-    # `eth_rpc_url`. Useful when different block ranges live on different
-    # providers (and therefore require different API keys), e.g. a cheap
-    # "recent" endpoint plus a more expensive "archive" endpoint.
+    # Ordered fallback RPC URLs (optional).
+    # The eth client always tries `eth_rpc_url` (primary) first for every
+    # operation, then walks `eth_rpc_fallback_urls` in declaration order
+    # whenever the primary returns "not found" or a transport error for
+    # a block fetch / tx-hash lookup. Useful when the primary is a cheap
+    # "recent-only" endpoint and you keep a more expensive "archive"
+    # endpoint as backup for old data.
     #
     # Validation rules (enforced at startup):
-    #   * Every entry must set at least one of `from_block` / `to_block`
-    #     (use `eth_rpc_url` directly for the default URL).
-    #   * `from_block <= to_block` when both are set.
-    #   * Ranges must not overlap each other (touching ranges that share a
-    #     boundary block also count as overlapping).
-    #   * All override URLs must report the same chain_id as `eth_rpc_url`.
-    # Blocks not covered by any override fall back to `eth_rpc_url`.
-    # eth_rpc_overrides:
-    #   - to_block: 4000000
-    #     url: "https://archive.example.io/v2/<KEY_FOR_OLD_BLOCKS>"
-    #   - from_block: 4000001
-    #     url: "https://recent.example.io/v2/<KEY_FOR_RECENT_BLOCKS>"
+    #   * Each URL must be non-empty (whitespace is trimmed).
+    #   * Each URL must be unique within the chain's fallback list.
+    #   * All fallback URLs must report the same chain_id as `eth_rpc_url`
+    #     (verified at connect time).
+    # eth_rpc_fallback_urls:
+    #   - "https://archive.example.io/v2/<KEY_FOR_OLD_BLOCKS>"
   # Second local chain (e.g. second Anvil on another port) — uncomment for multi-chain dev/CI:
   - chain_key: 3
     eth_rpc_url: "http://localhost:8546"

--- a/proof-gen-api-server/config.example.yaml
+++ b/proof-gen-api-server/config.example.yaml
@@ -32,7 +32,7 @@ chains:
     #   * All fallback URLs must report the same chain_id as `eth_rpc_url`
     #     (verified at connect time).
     # eth_rpc_fallback_urls:
-    #   - "https://archive.example.io/v2/<KEY_FOR_OLD_BLOCKS>"
+    #   - "https://archive.example.com/v2/<KEY_FOR_OLD_BLOCKS>"
   # Second local chain (e.g. second Anvil on another port) — uncomment for multi-chain dev/CI:
   - chain_key: 3
     eth_rpc_url: "http://localhost:8546"

--- a/proof-gen-api-server/config.example.yaml
+++ b/proof-gen-api-server/config.example.yaml
@@ -17,6 +17,28 @@ chains:
     # archiver_url: "http://localhost:8080"  # optional per chain
     # block_confirmation_depth: 0  # Blocks to lag behind chain tip for reorg protection.
     #                               # Default: 0 (no lag). Set to 12 for Ethereum mainnet.
+    #
+    # Per-block-range RPC URL overrides (optional).
+    # When a block-keyed RPC call's block_number falls within an override's
+    # [from_block, to_block] range (both bounds inclusive; either may be
+    # omitted to mean open-ended), that override's URL is used instead of
+    # `eth_rpc_url`. Useful when different block ranges live on different
+    # providers (and therefore require different API keys), e.g. a cheap
+    # "recent" endpoint plus a more expensive "archive" endpoint.
+    #
+    # Validation rules (enforced at startup):
+    #   * Every entry must set at least one of `from_block` / `to_block`
+    #     (use `eth_rpc_url` directly for the default URL).
+    #   * `from_block <= to_block` when both are set.
+    #   * Ranges must not overlap each other (touching ranges that share a
+    #     boundary block also count as overlapping).
+    #   * All override URLs must report the same chain_id as `eth_rpc_url`.
+    # Blocks not covered by any override fall back to `eth_rpc_url`.
+    # eth_rpc_overrides:
+    #   - to_block: 4000000
+    #     url: "https://archive.example.io/v2/<KEY_FOR_OLD_BLOCKS>"
+    #   - from_block: 4000001
+    #     url: "https://recent.example.io/v2/<KEY_FOR_RECENT_BLOCKS>"
   # Second local chain (e.g. second Anvil on another port) — uncomment for multi-chain dev/CI:
   - chain_key: 3
     eth_rpc_url: "http://localhost:8546"

--- a/proof-gen-api-server/src/config.rs
+++ b/proof-gen-api-server/src/config.rs
@@ -20,52 +20,19 @@ pub const DEFAULT_MAX_BATCH_SPAN: u64 = 1_000;
 #[derive(Debug, Clone)]
 pub struct ChainConfig {
     pub chain_key: u64,
-    /// Default RPC URL used for tip-related calls (subscription, current
-    /// block height) and for any block-keyed call whose `block_number` is
-    /// not covered by an entry in [`Self::eth_rpc_overrides`].
+    /// Primary RPC URL: tried first for every operation, and the only URL
+    /// used for tip-related calls (subscription, current block height).
     pub eth_rpc_url: String,
-    /// Per-block-range RPC URL overrides. When a block-keyed RPC call's
-    /// `block_number` falls within an override's `[from_block, to_block]`
-    /// range (both bounds inclusive; either may be `None` for an
-    /// open-ended side), that override's URL is used instead of
-    /// [`Self::eth_rpc_url`]. See [`RpcRangeOverride`].
-    ///
-    /// Useful when different block ranges live on different RPC providers
-    /// (and therefore require different API keys), e.g. a cheap "recent"
-    /// endpoint plus a more expensive "archive" endpoint for old blocks.
-    pub eth_rpc_overrides: Vec<RpcRangeOverride>,
+    /// Ordered fallback RPC URLs. The [`eth::Client`] tries the primary
+    /// first and walks this list in declaration order whenever the primary
+    /// returns `Ok(None)` or a transport error for a block fetch / tx-hash
+    /// lookup. Useful when the primary is a cheap "recent-only" endpoint
+    /// and you keep a more expensive "archive" endpoint for old data.
+    pub eth_rpc_fallback_urls: Vec<String>,
     pub archiver_url: Option<String>,
     /// Number of blocks to lag behind the EVM chain tip for reorg protection.
     /// See [`continuity::ContinuityConfig::block_confirmation_depth`].
     pub block_confirmation_depth: u64,
-}
-
-/// One per-block-range RPC URL override for a single chain.
-///
-/// This is the runtime mirror of [`RpcRangeOverrideFile`] (the YAML
-/// representation). It also converts cleanly into [`eth::RpcRangeOverride`]
-/// at the point where the [`eth::Client`] is constructed.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RpcRangeOverride {
-    /// Inclusive lower bound (in source-chain block numbers). `None` means
-    /// "no lower bound" (i.e. matches blocks `0..=to_block`).
-    pub from_block: Option<u64>,
-    /// Inclusive upper bound. `None` means "no upper bound" (i.e. matches
-    /// blocks `from_block..=u64::MAX`).
-    pub to_block: Option<u64>,
-    /// RPC endpoint used when this override matches. Typically embeds an
-    /// API key in the URL path or query string.
-    pub url: String,
-}
-
-impl From<&RpcRangeOverride> for eth::RpcRangeOverride {
-    fn from(o: &RpcRangeOverride) -> Self {
-        eth::RpcRangeOverride {
-            from_block: o.from_block,
-            to_block: o.to_block,
-            url: o.url.clone(),
-        }
-    }
 }
 
 /// Server configuration after CLI / file resolution.
@@ -93,7 +60,7 @@ impl Config {
             chains: vec![ChainConfig {
                 chain_key,
                 eth_rpc_url: "http://mock".to_string(),
-                eth_rpc_overrides: Vec::new(),
+                eth_rpc_fallback_urls: Vec::new(),
                 archiver_url: None,
                 block_confirmation_depth: 0,
             }],
@@ -147,38 +114,22 @@ pub struct ConfigFile {
 pub struct ChainConfigFile {
     pub chain_key: u64,
     pub eth_rpc_url: String,
-    /// Optional list of per-block-range RPC URL overrides. See
-    /// [`RpcRangeOverrideFile`] for the YAML shape and validation rules.
+    /// Optional ordered list of fallback RPC URLs. The first non-empty
+    /// answer wins; the primary `eth_rpc_url` is always tried first.
+    ///
+    /// ```yaml
+    /// eth_rpc_url: "https://recent.example/v2/<KEY_RECENT>"
+    /// eth_rpc_fallback_urls:
+    ///   - "https://archive.example/v2/<KEY_ARCHIVE>"
+    /// ```
     #[serde(default)]
-    pub eth_rpc_overrides: Vec<RpcRangeOverrideFile>,
+    pub eth_rpc_fallback_urls: Vec<String>,
     #[serde(default)]
     pub archiver_url: Option<String>,
     /// Number of blocks to lag behind the EVM chain tip for reorg protection.
     /// Defaults to 0 (no lag) for backward compatibility.
     #[serde(default)]
     pub block_confirmation_depth: u64,
-}
-
-/// YAML representation of one entry in `eth_rpc_overrides`.
-///
-/// Either bound may be omitted to mean "open-ended on that side", but at
-/// least one bound must be present (otherwise the override would silently
-/// shadow `eth_rpc_url`). Both bounds are inclusive.
-///
-/// ```yaml
-/// eth_rpc_overrides:
-///   - to_block: 4000000
-///     url: "https://archive.example/v2/<KEY_A>"
-///   - from_block: 4000001
-///     url: "https://recent.example/v2/<KEY_B>"
-/// ```
-#[derive(Debug, Clone, Deserialize)]
-pub struct RpcRangeOverrideFile {
-    #[serde(default)]
-    pub from_block: Option<u64>,
-    #[serde(default)]
-    pub to_block: Option<u64>,
-    pub url: String,
 }
 
 fn default_max_batch_size() -> NonZeroUsize {
@@ -200,11 +151,12 @@ impl ConfigFile {
             if !seen.insert(c.chain_key) {
                 bail!("duplicate chain_key {} in config", c.chain_key);
             }
-            let eth_rpc_overrides = validate_rpc_overrides(c.chain_key, c.eth_rpc_overrides)?;
+            let eth_rpc_fallback_urls =
+                validate_fallback_urls(c.chain_key, c.eth_rpc_fallback_urls)?;
             chains.push(ChainConfig {
                 chain_key: c.chain_key,
                 eth_rpc_url: c.eth_rpc_url,
-                eth_rpc_overrides,
+                eth_rpc_fallback_urls,
                 archiver_url: c.archiver_url,
                 block_confirmation_depth: c.block_confirmation_depth,
             });
@@ -223,88 +175,46 @@ impl ConfigFile {
     }
 }
 
-/// Validate a chain's `eth_rpc_overrides` (purely structural — no network
-/// I/O). Returns the runtime [`RpcRangeOverride`] vector preserving the
-/// declaration order; `eth::Client` will sort by `from_block` and re-validate
-/// non-overlap when it actually opens connections.
+/// Validate a chain's `eth_rpc_fallback_urls` (purely structural — no network
+/// I/O). Returns the trimmed list, preserving declaration order.
 ///
 /// # Errors
 ///
-/// * Any override has neither `from_block` nor `to_block`
-///   ("require_default" semantics — the bare `eth_rpc_url` is the implicit
-///   default; an unbounded override would silently shadow it).
-/// * Any override has `from_block > to_block`.
-/// * Two overrides cover an overlapping block range (touching ranges with
-///   a shared boundary count as overlapping, since both endpoints would
-///   match a block at the boundary).
+/// * Any URL is empty / whitespace-only.
+/// * The same URL appears twice in one chain's fallback list (likely
+///   misconfiguration — duplicates would just hit the same endpoint twice).
 ///
 /// `chain_key` is included in error messages to help users locate the
 /// offending entry in a multi-chain config.
-fn validate_rpc_overrides(
-    chain_key: u64,
-    overrides: Vec<RpcRangeOverrideFile>,
-) -> Result<Vec<RpcRangeOverride>> {
-    if overrides.is_empty() {
+fn validate_fallback_urls(chain_key: u64, urls: Vec<String>) -> Result<Vec<String>> {
+    if urls.is_empty() {
         return Ok(Vec::new());
     }
 
-    // Pre-flight bound checks.
-    let mut bounds: Vec<(u64, u64, RpcRangeOverride)> = Vec::with_capacity(overrides.len());
-    for ov in overrides {
-        if ov.from_block.is_none() && ov.to_block.is_none() {
+    let mut trimmed: Vec<String> = Vec::with_capacity(urls.len());
+    for (idx, raw) in urls.into_iter().enumerate() {
+        let url = raw.trim().to_string();
+        if url.is_empty() {
             bail!(
-                "chain_key {chain_key}: every entry in `eth_rpc_overrides` must set at least \
-                 one of `from_block` or `to_block` (an unbounded override would silently \
-                 shadow `eth_rpc_url`); use `eth_rpc_url` directly for the default URL"
+                "chain_key {chain_key}: `eth_rpc_fallback_urls[{idx}]` is empty; \
+                 remove the entry or set a real URL"
             );
         }
-        let from = ov.from_block.unwrap_or(0);
-        let to = ov.to_block.unwrap_or(u64::MAX);
-        if from > to {
+        if trimmed.iter().any(|existing| existing == &url) {
             bail!(
-                "chain_key {chain_key}: `eth_rpc_overrides` entry has from_block ({from}) \
-                 > to_block ({to}); swap the bounds in your config"
+                "chain_key {chain_key}: duplicate URL in `eth_rpc_fallback_urls` (index {idx}); \
+                 each fallback must be a distinct endpoint"
             );
         }
-        bounds.push((
-            from,
-            to,
-            RpcRangeOverride {
-                from_block: ov.from_block,
-                to_block: ov.to_block,
-                url: ov.url,
-            },
-        ));
+        trimmed.push(url);
     }
 
-    // Overlap check (sort by `from`; sliding window).
-    let mut sorted = bounds.clone();
-    sorted.sort_by_key(|(from, _, _)| *from);
-    for w in sorted.windows(2) {
-        let (a_from, a_to, _) = &w[0];
-        let (b_from, b_to, _) = &w[1];
-        if a_to >= b_from {
-            bail!(
-                "chain_key {chain_key}: `eth_rpc_overrides` entries overlap — \
-                 [{a_from}, {a_to}] overlaps [{b_from}, {b_to}]"
-            );
-        }
-    }
-
-    Ok(bounds.into_iter().map(|(_, _, ov)| ov).collect())
+    Ok(trimmed)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn ov_file(from: Option<u64>, to: Option<u64>, url: &str) -> RpcRangeOverrideFile {
-        RpcRangeOverrideFile {
-            from_block: from,
-            to_block: to,
-            url: url.to_string(),
-        }
-    }
 
     fn parse(yaml: &str) -> Result<Config> {
         let file: ConfigFile = serde_yaml::from_str(yaml)?;
@@ -312,102 +222,80 @@ mod tests {
     }
 
     #[test]
-    fn validate_overrides_accepts_empty_list() {
-        let out = validate_rpc_overrides(2, vec![]).unwrap();
+    fn validate_fallbacks_accepts_empty_list() {
+        let out = validate_fallback_urls(2, vec![]).unwrap();
         assert!(out.is_empty());
     }
 
     #[test]
-    fn validate_overrides_rejects_unbounded_entry() {
-        let err = validate_rpc_overrides(2, vec![ov_file(None, None, "http://x")]).unwrap_err();
+    fn validate_fallbacks_rejects_empty_url() {
+        let err = validate_fallback_urls(2, vec!["   ".to_string()]).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("chain_key 2"), "missing chain_key: {msg}");
         assert!(
-            msg.contains("at least one of `from_block` or `to_block`"),
+            msg.contains("`eth_rpc_fallback_urls[0]` is empty"),
             "wrong error: {msg}"
         );
     }
 
     #[test]
-    fn validate_overrides_rejects_inverted_bounds() {
-        let err =
-            validate_rpc_overrides(7, vec![ov_file(Some(100), Some(50), "http://x")]).unwrap_err();
+    fn validate_fallbacks_rejects_duplicate_url() {
+        let err = validate_fallback_urls(
+            7,
+            vec![
+                "https://archive.example/v2/KEY_A".to_string(),
+                "https://archive.example/v2/KEY_A".to_string(),
+            ],
+        )
+        .unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("chain_key 7"), "missing chain_key: {msg}");
         assert!(
-            msg.contains("from_block (100) > to_block (50)"),
+            msg.contains("duplicate URL in `eth_rpc_fallback_urls`"),
             "wrong error: {msg}"
         );
     }
 
     #[test]
-    fn validate_overrides_rejects_overlap() {
-        let err = validate_rpc_overrides(
-            3,
-            vec![
-                ov_file(Some(0), Some(1_000), "http://low"),
-                ov_file(Some(500), Some(2_000), "http://mid"),
-            ],
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("overlap"), "wrong error: {err}");
+    fn validate_fallbacks_trims_whitespace() {
+        // Operators sometimes have stray whitespace from copy/paste; trim it
+        // rather than failing with an opaque DNS error later.
+        let out =
+            validate_fallback_urls(2, vec!["  https://archive.example/v2/KEY_A  ".to_string()])
+                .unwrap();
+        assert_eq!(out, vec!["https://archive.example/v2/KEY_A".to_string()]);
     }
 
     #[test]
-    fn validate_overrides_treats_touching_ranges_as_overlap() {
-        // Both ends inclusive — block 100 would match both ranges.
-        let err = validate_rpc_overrides(
-            3,
-            vec![
-                ov_file(Some(0), Some(100), "http://low"),
-                ov_file(Some(100), Some(200), "http://hi"),
-            ],
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("overlap"));
+    fn validate_fallbacks_keeps_declaration_order() {
+        let out = validate_fallback_urls(2, vec!["http://b".to_string(), "http://a".to_string()])
+            .unwrap();
+        assert_eq!(out, vec!["http://b".to_string(), "http://a".to_string()]);
     }
 
     #[test]
-    fn validate_overrides_keeps_declaration_order() {
-        // Declaration order is preserved (downstream `eth::Client` will sort
-        // by `from_block` when wiring real connections).
-        let out = validate_rpc_overrides(
-            2,
-            vec![
-                ov_file(Some(4_000_001), None, "http://recent"),
-                ov_file(None, Some(4_000_000), "http://archive"),
-            ],
-        )
-        .unwrap();
-        assert_eq!(out.len(), 2);
-        assert_eq!(out[0].url, "http://recent");
-        assert_eq!(out[1].url, "http://archive");
-    }
-
-    #[test]
-    fn yaml_round_trip_with_two_bucket_overrides() {
+    fn yaml_round_trip_with_fallback_urls() {
         let yaml = r#"
 bind_host: "0.0.0.0"
 bind_port: 3100
 chains:
   - chain_key: 2
-    eth_rpc_url: "https://default.example/v2/KEY_DEFAULT"
-    eth_rpc_overrides:
-      - to_block: 4000000
-        url: "https://archive.example/v2/KEY_A"
-      - from_block: 4000001
-        url: "https://recent.example/v2/KEY_B"
+    eth_rpc_url: "https://recent.example/v2/KEY_RECENT"
+    eth_rpc_fallback_urls:
+      - "https://archive.example/v2/KEY_ARCHIVE"
 "#;
         let cfg = parse(yaml).expect("yaml should parse");
         assert_eq!(cfg.chains.len(), 1);
         let chain = &cfg.chains[0];
-        assert_eq!(chain.eth_rpc_overrides.len(), 2);
-        assert_eq!(chain.eth_rpc_overrides[0].to_block, Some(4_000_000));
-        assert_eq!(chain.eth_rpc_overrides[1].from_block, Some(4_000_001));
+        assert_eq!(chain.eth_rpc_fallback_urls.len(), 1);
+        assert_eq!(
+            chain.eth_rpc_fallback_urls[0],
+            "https://archive.example/v2/KEY_ARCHIVE"
+        );
     }
 
     #[test]
-    fn yaml_without_overrides_keeps_field_empty() {
+    fn yaml_without_fallbacks_keeps_field_empty() {
         let yaml = r#"
 bind_host: "0.0.0.0"
 bind_port: 3100
@@ -416,24 +304,24 @@ chains:
     eth_rpc_url: "http://localhost:8545"
 "#;
         let cfg = parse(yaml).expect("yaml should parse");
-        assert!(cfg.chains[0].eth_rpc_overrides.is_empty());
+        assert!(cfg.chains[0].eth_rpc_fallback_urls.is_empty());
     }
 
     #[test]
-    fn yaml_with_invalid_overrides_fails_to_parse() {
+    fn yaml_with_empty_fallback_url_fails_to_parse() {
         let yaml = r#"
 bind_host: "0.0.0.0"
 bind_port: 3100
 chains:
   - chain_key: 2
     eth_rpc_url: "http://localhost:8545"
-    eth_rpc_overrides:
-      - url: "http://oops-no-bounds"
+    eth_rpc_fallback_urls:
+      - ""
 "#;
         let err = parse(yaml).unwrap_err().to_string();
         assert!(
-            err.contains("at least one of `from_block` or `to_block`"),
-            "expected unbounded-override error, got: {err}"
+            err.contains("`eth_rpc_fallback_urls[0]` is empty"),
+            "expected empty-url error, got: {err}"
         );
     }
 }

--- a/proof-gen-api-server/src/config.rs
+++ b/proof-gen-api-server/src/config.rs
@@ -20,11 +20,52 @@ pub const DEFAULT_MAX_BATCH_SPAN: u64 = 1_000;
 #[derive(Debug, Clone)]
 pub struct ChainConfig {
     pub chain_key: u64,
+    /// Default RPC URL used for tip-related calls (subscription, current
+    /// block height) and for any block-keyed call whose `block_number` is
+    /// not covered by an entry in [`Self::eth_rpc_overrides`].
     pub eth_rpc_url: String,
+    /// Per-block-range RPC URL overrides. When a block-keyed RPC call's
+    /// `block_number` falls within an override's `[from_block, to_block]`
+    /// range (both bounds inclusive; either may be `None` for an
+    /// open-ended side), that override's URL is used instead of
+    /// [`Self::eth_rpc_url`]. See [`RpcRangeOverride`].
+    ///
+    /// Useful when different block ranges live on different RPC providers
+    /// (and therefore require different API keys), e.g. a cheap "recent"
+    /// endpoint plus a more expensive "archive" endpoint for old blocks.
+    pub eth_rpc_overrides: Vec<RpcRangeOverride>,
     pub archiver_url: Option<String>,
     /// Number of blocks to lag behind the EVM chain tip for reorg protection.
     /// See [`continuity::ContinuityConfig::block_confirmation_depth`].
     pub block_confirmation_depth: u64,
+}
+
+/// One per-block-range RPC URL override for a single chain.
+///
+/// This is the runtime mirror of [`RpcRangeOverrideFile`] (the YAML
+/// representation). It also converts cleanly into [`eth::RpcRangeOverride`]
+/// at the point where the [`eth::Client`] is constructed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RpcRangeOverride {
+    /// Inclusive lower bound (in source-chain block numbers). `None` means
+    /// "no lower bound" (i.e. matches blocks `0..=to_block`).
+    pub from_block: Option<u64>,
+    /// Inclusive upper bound. `None` means "no upper bound" (i.e. matches
+    /// blocks `from_block..=u64::MAX`).
+    pub to_block: Option<u64>,
+    /// RPC endpoint used when this override matches. Typically embeds an
+    /// API key in the URL path or query string.
+    pub url: String,
+}
+
+impl From<&RpcRangeOverride> for eth::RpcRangeOverride {
+    fn from(o: &RpcRangeOverride) -> Self {
+        eth::RpcRangeOverride {
+            from_block: o.from_block,
+            to_block: o.to_block,
+            url: o.url.clone(),
+        }
+    }
 }
 
 /// Server configuration after CLI / file resolution.
@@ -52,6 +93,7 @@ impl Config {
             chains: vec![ChainConfig {
                 chain_key,
                 eth_rpc_url: "http://mock".to_string(),
+                eth_rpc_overrides: Vec::new(),
                 archiver_url: None,
                 block_confirmation_depth: 0,
             }],
@@ -105,12 +147,38 @@ pub struct ConfigFile {
 pub struct ChainConfigFile {
     pub chain_key: u64,
     pub eth_rpc_url: String,
+    /// Optional list of per-block-range RPC URL overrides. See
+    /// [`RpcRangeOverrideFile`] for the YAML shape and validation rules.
+    #[serde(default)]
+    pub eth_rpc_overrides: Vec<RpcRangeOverrideFile>,
     #[serde(default)]
     pub archiver_url: Option<String>,
     /// Number of blocks to lag behind the EVM chain tip for reorg protection.
     /// Defaults to 0 (no lag) for backward compatibility.
     #[serde(default)]
     pub block_confirmation_depth: u64,
+}
+
+/// YAML representation of one entry in `eth_rpc_overrides`.
+///
+/// Either bound may be omitted to mean "open-ended on that side", but at
+/// least one bound must be present (otherwise the override would silently
+/// shadow `eth_rpc_url`). Both bounds are inclusive.
+///
+/// ```yaml
+/// eth_rpc_overrides:
+///   - to_block: 4000000
+///     url: "https://archive.example/v2/<KEY_A>"
+///   - from_block: 4000001
+///     url: "https://recent.example/v2/<KEY_B>"
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+pub struct RpcRangeOverrideFile {
+    #[serde(default)]
+    pub from_block: Option<u64>,
+    #[serde(default)]
+    pub to_block: Option<u64>,
+    pub url: String,
 }
 
 fn default_max_batch_size() -> NonZeroUsize {
@@ -132,9 +200,11 @@ impl ConfigFile {
             if !seen.insert(c.chain_key) {
                 bail!("duplicate chain_key {} in config", c.chain_key);
             }
+            let eth_rpc_overrides = validate_rpc_overrides(c.chain_key, c.eth_rpc_overrides)?;
             chains.push(ChainConfig {
                 chain_key: c.chain_key,
                 eth_rpc_url: c.eth_rpc_url,
+                eth_rpc_overrides,
                 archiver_url: c.archiver_url,
                 block_confirmation_depth: c.block_confirmation_depth,
             });
@@ -150,5 +220,220 @@ impl ConfigFile {
             max_batch_size: self.max_batch_size,
             max_batch_span: self.max_batch_span,
         })
+    }
+}
+
+/// Validate a chain's `eth_rpc_overrides` (purely structural — no network
+/// I/O). Returns the runtime [`RpcRangeOverride`] vector preserving the
+/// declaration order; `eth::Client` will sort by `from_block` and re-validate
+/// non-overlap when it actually opens connections.
+///
+/// # Errors
+///
+/// * Any override has neither `from_block` nor `to_block`
+///   ("require_default" semantics — the bare `eth_rpc_url` is the implicit
+///   default; an unbounded override would silently shadow it).
+/// * Any override has `from_block > to_block`.
+/// * Two overrides cover an overlapping block range (touching ranges with
+///   a shared boundary count as overlapping, since both endpoints would
+///   match a block at the boundary).
+///
+/// `chain_key` is included in error messages to help users locate the
+/// offending entry in a multi-chain config.
+fn validate_rpc_overrides(
+    chain_key: u64,
+    overrides: Vec<RpcRangeOverrideFile>,
+) -> Result<Vec<RpcRangeOverride>> {
+    if overrides.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Pre-flight bound checks.
+    let mut bounds: Vec<(u64, u64, RpcRangeOverride)> = Vec::with_capacity(overrides.len());
+    for ov in overrides {
+        if ov.from_block.is_none() && ov.to_block.is_none() {
+            bail!(
+                "chain_key {chain_key}: every entry in `eth_rpc_overrides` must set at least \
+                 one of `from_block` or `to_block` (an unbounded override would silently \
+                 shadow `eth_rpc_url`); use `eth_rpc_url` directly for the default URL"
+            );
+        }
+        let from = ov.from_block.unwrap_or(0);
+        let to = ov.to_block.unwrap_or(u64::MAX);
+        if from > to {
+            bail!(
+                "chain_key {chain_key}: `eth_rpc_overrides` entry has from_block ({from}) \
+                 > to_block ({to}); swap the bounds in your config"
+            );
+        }
+        bounds.push((
+            from,
+            to,
+            RpcRangeOverride {
+                from_block: ov.from_block,
+                to_block: ov.to_block,
+                url: ov.url,
+            },
+        ));
+    }
+
+    // Overlap check (sort by `from`; sliding window).
+    let mut sorted = bounds.clone();
+    sorted.sort_by_key(|(from, _, _)| *from);
+    for w in sorted.windows(2) {
+        let (a_from, a_to, _) = &w[0];
+        let (b_from, b_to, _) = &w[1];
+        if a_to >= b_from {
+            bail!(
+                "chain_key {chain_key}: `eth_rpc_overrides` entries overlap — \
+                 [{a_from}, {a_to}] overlaps [{b_from}, {b_to}]"
+            );
+        }
+    }
+
+    Ok(bounds.into_iter().map(|(_, _, ov)| ov).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ov_file(from: Option<u64>, to: Option<u64>, url: &str) -> RpcRangeOverrideFile {
+        RpcRangeOverrideFile {
+            from_block: from,
+            to_block: to,
+            url: url.to_string(),
+        }
+    }
+
+    fn parse(yaml: &str) -> Result<Config> {
+        let file: ConfigFile = serde_yaml::from_str(yaml)?;
+        file.into_config("ws://test".to_string())
+    }
+
+    #[test]
+    fn validate_overrides_accepts_empty_list() {
+        let out = validate_rpc_overrides(2, vec![]).unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn validate_overrides_rejects_unbounded_entry() {
+        let err = validate_rpc_overrides(2, vec![ov_file(None, None, "http://x")]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("chain_key 2"), "missing chain_key: {msg}");
+        assert!(
+            msg.contains("at least one of `from_block` or `to_block`"),
+            "wrong error: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_overrides_rejects_inverted_bounds() {
+        let err =
+            validate_rpc_overrides(7, vec![ov_file(Some(100), Some(50), "http://x")]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("chain_key 7"), "missing chain_key: {msg}");
+        assert!(
+            msg.contains("from_block (100) > to_block (50)"),
+            "wrong error: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_overrides_rejects_overlap() {
+        let err = validate_rpc_overrides(
+            3,
+            vec![
+                ov_file(Some(0), Some(1_000), "http://low"),
+                ov_file(Some(500), Some(2_000), "http://mid"),
+            ],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("overlap"), "wrong error: {err}");
+    }
+
+    #[test]
+    fn validate_overrides_treats_touching_ranges_as_overlap() {
+        // Both ends inclusive — block 100 would match both ranges.
+        let err = validate_rpc_overrides(
+            3,
+            vec![
+                ov_file(Some(0), Some(100), "http://low"),
+                ov_file(Some(100), Some(200), "http://hi"),
+            ],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("overlap"));
+    }
+
+    #[test]
+    fn validate_overrides_keeps_declaration_order() {
+        // Declaration order is preserved (downstream `eth::Client` will sort
+        // by `from_block` when wiring real connections).
+        let out = validate_rpc_overrides(
+            2,
+            vec![
+                ov_file(Some(4_000_001), None, "http://recent"),
+                ov_file(None, Some(4_000_000), "http://archive"),
+            ],
+        )
+        .unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].url, "http://recent");
+        assert_eq!(out[1].url, "http://archive");
+    }
+
+    #[test]
+    fn yaml_round_trip_with_two_bucket_overrides() {
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 2
+    eth_rpc_url: "https://default.example/v2/KEY_DEFAULT"
+    eth_rpc_overrides:
+      - to_block: 4000000
+        url: "https://archive.example/v2/KEY_A"
+      - from_block: 4000001
+        url: "https://recent.example/v2/KEY_B"
+"#;
+        let cfg = parse(yaml).expect("yaml should parse");
+        assert_eq!(cfg.chains.len(), 1);
+        let chain = &cfg.chains[0];
+        assert_eq!(chain.eth_rpc_overrides.len(), 2);
+        assert_eq!(chain.eth_rpc_overrides[0].to_block, Some(4_000_000));
+        assert_eq!(chain.eth_rpc_overrides[1].from_block, Some(4_000_001));
+    }
+
+    #[test]
+    fn yaml_without_overrides_keeps_field_empty() {
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 2
+    eth_rpc_url: "http://localhost:8545"
+"#;
+        let cfg = parse(yaml).expect("yaml should parse");
+        assert!(cfg.chains[0].eth_rpc_overrides.is_empty());
+    }
+
+    #[test]
+    fn yaml_with_invalid_overrides_fails_to_parse() {
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 2
+    eth_rpc_url: "http://localhost:8545"
+    eth_rpc_overrides:
+      - url: "http://oops-no-bounds"
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(
+            err.contains("at least one of `from_block` or `to_block`"),
+            "expected unbounded-override error, got: {err}"
+        );
     }
 }

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -77,17 +77,16 @@ impl Server {
                 of = config.chains.len(),
                 chain_key = chain.chain_key,
                 eth_rpc_url = %redact_url_query(&chain.eth_rpc_url),
-                eth_rpc_override_count = chain.eth_rpc_overrides.len(),
+                eth_rpc_fallback_count = chain.eth_rpc_fallback_urls.len(),
                 archiver_url = ?chain.archiver_url.as_ref().map(|u| redact_url_query(u)),
                 "🚀 [startup] configuring source chain"
             );
-            for ov in &chain.eth_rpc_overrides {
+            for (fb_idx, url) in chain.eth_rpc_fallback_urls.iter().enumerate() {
                 debug!(
                     chain_key = chain.chain_key,
-                    from_block = ?ov.from_block,
-                    to_block = ?ov.to_block,
-                    url = %redact_url_query(&ov.url),
-                    "[startup] eth_rpc override registered"
+                    fallback_index = fb_idx,
+                    url = %redact_url_query(url),
+                    "[startup] eth_rpc fallback registered"
                 );
             }
             let builder = Self::build_continuity_for_chain(
@@ -135,8 +134,7 @@ impl Server {
             .ok_or_else(|| anyhow!("Failed to get supported chain for chain_key {chain_key}"))?;
         let supported_chain_id = supported_chain.chain_id;
 
-        let eth_overrides: Vec<eth::RpcRangeOverride> =
-            chain.eth_rpc_overrides.iter().map(Into::into).collect();
+        let eth_fallback_urls: &[String] = &chain.eth_rpc_fallback_urls;
 
         let eth_client = if let Some(ref redis_url) = global.redis_url {
             debug!(
@@ -144,7 +142,7 @@ impl Server {
                 redis_url = %redact_url_query(redis_url),
                 cluster_mode = global.redis_cluster_mode,
                 eth_rpc_url = %redact_url_query(&chain.eth_rpc_url),
-                eth_rpc_override_count = eth_overrides.len(),
+                eth_rpc_fallback_count = eth_fallback_urls.len(),
                 "🚀 [startup] connecting source chain ETH client with Redis block cache"
             );
             let block_cache_metrics = prom_metrics.block_cache_metrics();
@@ -153,18 +151,18 @@ impl Server {
                 redis_cluster_mode: global.redis_cluster_mode,
                 metrics: block_cache_metrics,
             };
-            EthClient::new_with_cache_and_overrides(
+            EthClient::new_with_cache_and_fallbacks(
                 &chain.eth_rpc_url,
-                &eth_overrides,
+                eth_fallback_urls,
                 None,
                 cache_config,
             )
             .await
             .with_context(|| {
                 format!(
-                    "Ethereum/source RPC + Redis cache failed for chain_key={chain_key} (eth_rpc_url={}, override_count={}, redis={})",
+                    "Ethereum/source RPC + Redis cache failed for chain_key={chain_key} (eth_rpc_url={}, fallback_count={}, redis={})",
                     redact_url_query(&chain.eth_rpc_url),
-                    eth_overrides.len(),
+                    eth_fallback_urls.len(),
                     redact_url_query(redis_url)
                 )
             })?
@@ -172,16 +170,16 @@ impl Server {
             debug!(
                 chain_key,
                 eth_rpc_url = %redact_url_query(&chain.eth_rpc_url),
-                eth_rpc_override_count = eth_overrides.len(),
+                eth_rpc_fallback_count = eth_fallback_urls.len(),
                 "🚀 [startup] connecting source chain ETH client (no Redis)"
             );
-            EthClient::new_with_overrides(&chain.eth_rpc_url, &eth_overrides, None)
+            EthClient::new_with_fallbacks(&chain.eth_rpc_url, eth_fallback_urls, None)
                 .await
                 .with_context(|| {
                     format!(
-                        "Ethereum/source RPC connection failed for chain_key={chain_key} (eth_rpc_url={}, override_count={})",
+                        "Ethereum/source RPC connection failed for chain_key={chain_key} (eth_rpc_url={}, fallback_count={})",
                         redact_url_query(&chain.eth_rpc_url),
-                        eth_overrides.len()
+                        eth_fallback_urls.len()
                     )
                 })?
         };

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -25,12 +25,10 @@ pub use networking::build_app;
 pub use services::continuity_service::ContinuityService;
 pub use services::errors::ErrorResponse;
 
-/// Hide `?query` in logs so keys in URLs are not fully printed.
-fn redact_url_query(url: &str) -> String {
-    url.split_once('?')
-        .map(|(base, _)| format!("{base}?…"))
-        .unwrap_or_else(|| url.to_string())
-}
+/// Re-export of [`eth::redact_url_query`] so existing call sites in this
+/// crate keep working unchanged. The eth-side helper redacts both `?query`
+/// strings *and* secret-looking path segments (Chainstack/Alchemy style).
+use eth::redact_url_query;
 
 pub struct Server {
     config: Config,

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -77,9 +77,19 @@ impl Server {
                 of = config.chains.len(),
                 chain_key = chain.chain_key,
                 eth_rpc_url = %redact_url_query(&chain.eth_rpc_url),
+                eth_rpc_override_count = chain.eth_rpc_overrides.len(),
                 archiver_url = ?chain.archiver_url.as_ref().map(|u| redact_url_query(u)),
                 "🚀 [startup] configuring source chain"
             );
+            for ov in &chain.eth_rpc_overrides {
+                debug!(
+                    chain_key = chain.chain_key,
+                    from_block = ?ov.from_block,
+                    to_block = ?ov.to_block,
+                    url = %redact_url_query(&ov.url),
+                    "[startup] eth_rpc override registered"
+                );
+            }
             let builder = Self::build_continuity_for_chain(
                 &config,
                 cc3_client.clone(),
@@ -125,12 +135,16 @@ impl Server {
             .ok_or_else(|| anyhow!("Failed to get supported chain for chain_key {chain_key}"))?;
         let supported_chain_id = supported_chain.chain_id;
 
+        let eth_overrides: Vec<eth::RpcRangeOverride> =
+            chain.eth_rpc_overrides.iter().map(Into::into).collect();
+
         let eth_client = if let Some(ref redis_url) = global.redis_url {
             debug!(
                 chain_key,
                 redis_url = %redact_url_query(redis_url),
                 cluster_mode = global.redis_cluster_mode,
                 eth_rpc_url = %redact_url_query(&chain.eth_rpc_url),
+                eth_rpc_override_count = eth_overrides.len(),
                 "🚀 [startup] connecting source chain ETH client with Redis block cache"
             );
             let block_cache_metrics = prom_metrics.block_cache_metrics();
@@ -139,27 +153,35 @@ impl Server {
                 redis_cluster_mode: global.redis_cluster_mode,
                 metrics: block_cache_metrics,
             };
-            EthClient::new_with_cache(&chain.eth_rpc_url, None, cache_config)
-                .await
-                .with_context(|| {
-                    format!(
-                        "Ethereum/source RPC + Redis cache failed for chain_key={chain_key} (eth_rpc_url={}, redis={})",
-                        redact_url_query(&chain.eth_rpc_url),
-                        redact_url_query(redis_url)
-                    )
-                })?
+            EthClient::new_with_cache_and_overrides(
+                &chain.eth_rpc_url,
+                &eth_overrides,
+                None,
+                cache_config,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "Ethereum/source RPC + Redis cache failed for chain_key={chain_key} (eth_rpc_url={}, override_count={}, redis={})",
+                    redact_url_query(&chain.eth_rpc_url),
+                    eth_overrides.len(),
+                    redact_url_query(redis_url)
+                )
+            })?
         } else {
             debug!(
                 chain_key,
                 eth_rpc_url = %redact_url_query(&chain.eth_rpc_url),
+                eth_rpc_override_count = eth_overrides.len(),
                 "🚀 [startup] connecting source chain ETH client (no Redis)"
             );
-            EthClient::new(&chain.eth_rpc_url, None)
+            EthClient::new_with_overrides(&chain.eth_rpc_url, &eth_overrides, None)
                 .await
                 .with_context(|| {
                     format!(
-                        "Ethereum/source RPC connection failed for chain_key={chain_key} (eth_rpc_url={})",
-                        redact_url_query(&chain.eth_rpc_url)
+                        "Ethereum/source RPC connection failed for chain_key={chain_key} (eth_rpc_url={}, override_count={})",
+                        redact_url_query(&chain.eth_rpc_url),
+                        eth_overrides.len()
                     )
                 })?
         };


### PR DESCRIPTION
# Description of proposed changes

Adds an ordered list of **fallback RPC URLs** per source chain in `proof-gen-api-server`. The eth client always tries the primary `eth_rpc_url` first, then walks `eth_rpc_fallback_urls` in declaration order whenever the primary returns "not found" or a transport error for a block fetch / receipts fetch / tx-hash lookup.

This replaces the earlier per-block-range override approach (initial commit on this branch), which had a hard limitation: tx-hash lookups have no block number to route on, so a tx mined in the "archive" range would 404 against the recent-only primary even though the archive endpoint had it.

## Why

Each source chain is in practice served by two very different access patterns:

- **Hot path** (recent blocks, near tip): high QPS, latency-sensitive, cheap on most providers.
- **Cold path** (deep historical blocks for back-fills / catch-up + tx-hash lookups for old txs): low QPS but requires archive support, metered separately, 5–50× more expensive.

A single `eth_rpc_url` forces a tradeoff: pay for archive on every call, or 404 on old data. With an ordered fallback list the primary stays cheap and recent-only, and the (typically more expensive) archive endpoint only gets queried when the primary can't answer.

Because tx-hash lookups carry no block-number information, the fallback walk is the *only* way to make `/proof-by-tx` work for old transactions — which was exactly the failure mode that motivated this change.

## How it works

- `ChainConfig` gains `eth_rpc_fallback_urls: Vec<String>`.
- `eth::Client` gains `new_with_fallbacks` and `new_with_cache_and_fallbacks` (cache-aware variant). On startup each fallback URL is connected and its `chain_id` is verified against the primary — mismatch fails fast.
- Block-keyed and tx-hash calls (`get_eth_block`, `get_receipts`, `get_tx_position_by_hash`) now walk providers via `providers_with_labels()`:
  - Order is `[primary, fallback[0], fallback[1], ...]`.
  - First `Ok(Some(_))` wins; remaining providers are not queried.
  - If at least one provider returns `Ok(None)`, the result is "not found" (peers that errored are demoted to `WARN`).
  - If every provider errors, the **first** error is returned and the rest are logged at `WARN`.
- Tip-side calls (`subscribe`, `get_last_block`) stay on the primary only — fallbacks are a historical-routing concern.
- `reconnect()` re-connects every fallback URL too and re-asserts `chain_id` parity, so a recovered primary can't silently keep using a stale fallback socket.
- Cache integration: `block_cache::get_block` short-circuits on hit; on miss, it calls `try_fetch_block`, which transparently uses the fallback walk. Cached entries store the merged result regardless of which provider answered.

## Logging

- Per-call logs are silent when the primary answers (the boring path), so we don't spam logs for deployments with no fallbacks.
- `INFO` log line emitted when a fallback serves a request, with provider label (`fallback[i]@<base-url>?…`), block number / tx hash, and the index/position. Operators can confirm at a glance which provider handled which request.
- `WARN` for demoted errors (peer errored but another said `not found`, or peer errored but another succeeded).
- `ERROR` only when **every** provider failed.
- All logged URLs go through `eth::redact_url_query`, which scrubs both query strings *and* secret-shaped path segments:
  - Anything after `?` is replaced with `?…` (covers `?key=...` style — Google Cloud, Infura legacy).
  - Any path segment that looks like an opaque token — ≥ 16 chars of `[A-Za-z0-9_]`, no hyphens, contains both a digit and a letter — is replaced with `…` (covers Chainstack-style trailing path keys, Alchemy `/v2/<KEY>`, etc.). Length is not leaked.
  - Human-readable identifiers (`v1`, `projects`, `ethereum-sepolia`, `cc3-testnet-rpckey-2`) stay intact — they're either short, hyphenated, or pure-alpha/pure-digit, so the heuristic ignores them.
  - The previous duplicate copy in `proof-gen-api-server` is removed; both crates now share the canonical eth-side helper to prevent drift.

## Validation (startup, no network I/O for the structural part)

- Each URL must be non-empty (whitespace is trimmed).
- Each URL must be unique within a chain's fallback list (duplicates would just hit the same endpoint twice and silently double the cost on a miss).
- Then per-URL: `chain_id` parity check against the primary at connect time.
- Errors include the offending `chain_key` and the offending fallback index.

## Usage

YAML (`config.example.yaml`):

```yaml
chains:
  - chain_key: 1
    eth_rpc_url: "https://recent.example/v2/<KEY_RECENT>"
    eth_rpc_fallback_urls:
      - "https://archive.example/v2/<KEY_ARCHIVE>"
```

- `eth_rpc_fallback_urls` is fully optional. Empty list ≡ pre-PR behavior (primary-only).
- Any number of fallbacks is allowed; they are tried in declared order.
- Available **only** via the multi-chain YAML path. The legacy single-chain CLI/env mode (`--eth-rpc-url`) stays single-URL by design.

## Tests

- `proof-gen-api-server::config` — 9 unit tests: empty list, empty/whitespace URL rejection, duplicate URL rejection, whitespace trimming, declaration order preservation, YAML round-trip with and without fallbacks, YAML invalid-fallback parse error.
- `eth::provider_lookup_tests` — covers the `merge_provider_lookup` decision matrix and `redact_url_query`:
  - At least one `None` → `NotFound` and peer errors demoted to warnings.
  - `None` with no errors → simple `NotFound`.
  - All errors → first error promoted, rest demoted to warnings.
  - Empty input panics (defensive — caller always passes non-empty).
  - Redaction: `?key=...` strip; short paths pass through; Chainstack-style trailing hex token redacted; Alchemy `/v2/<KEY>` redacted; googleapis path tokens kept intact while `?key=` is stripped; pure-letter and pure-digit long segments are kept (not key-shaped); inner secret segment with surrounding fixed segments is redacted in place.

## Notes / things reviewers may want to push back on

- Fan-out is **sequential**, not parallel. Trade-off: minimizes calls to expensive archive endpoints (fast 90% case never reaches them), but adds latency on the not-found-on-primary path. Parallel fan-out is a future option if latency on cold-path lookups becomes a concern.
- Primary-only writes / subscriptions are intentional — fallbacks are a *read-side historical safety net*, not a load balancer.
- No per-URL health / circuit breaker yet. If a fallback is consistently unreachable it'll keep getting tried. Worth revisiting once we have observability on fallback-served-rate.

---

Practical tips for PR review & merge:

- [x] All GitHub Actions report PASS
- [x] Newly added code/functions have unit tests
  - [x] Coverage tools report all newly added lines as covered
  - [x] The positive scenario is exercised
  - [x] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable (n/a — no on-chain events)
  - [ ] Assert on changes made to storage if applicable (n/a)
- [x] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
