### PR TITLE
feat(proof-gen): restart proof gen server when CC3 attestations stall (CSUB-2039)

### DIFF
--- a/proof-gen-api-server/bin/server.rs
+++ b/proof-gen-api-server/bin/server.rs
@@ -4,9 +4,7 @@ use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-use proof_gen_api_server::config::{
-    ChainConfig, Config, DEFAULT_ATTESTATION_LIVENESS_TIMEOUT_MINUTES,
-};
+use proof_gen_api_server::config::{ChainConfig, Config};
 use proof_gen_api_server::Server;
 
 #[derive(Parser, Debug)]
@@ -100,9 +98,9 @@ pub struct ProofGenApiServer {
 
     #[arg(
         long,
-        default_value_t = DEFAULT_ATTESTATION_LIVENESS_TIMEOUT_MINUTES,
+        default_value = "5",
         env = "ATTESTATION_LIVENESS_TIMEOUT_MINUTES",
-        help = "Maximum time in minutes the proof gen server tolerates between attestation events from CC3 before the /api/v1/health endpoint reports the listener as stalled (HTTP 503). Wire into a k8s liveness probe so the server is restarted and re-subscribes to attestation events. Defaults to 5 minutes."
+        help = "Maximum time in minutes the proof gen server tolerates between attestation events from CC3 before the /api/v1/health endpoint reports the listener as stalled (HTTP 503)."
     )]
     attestation_liveness_timeout_minutes: u64,
 

--- a/proof-gen-api-server/bin/server.rs
+++ b/proof-gen-api-server/bin/server.rs
@@ -4,7 +4,9 @@ use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-use proof_gen_api_server::config::{ChainConfig, Config};
+use proof_gen_api_server::config::{
+    ChainConfig, Config, DEFAULT_ATTESTATION_LIVENESS_TIMEOUT_MINUTES,
+};
 use proof_gen_api_server::Server;
 
 #[derive(Parser, Debug)]
@@ -98,6 +100,14 @@ pub struct ProofGenApiServer {
 
     #[arg(
         long,
+        default_value_t = DEFAULT_ATTESTATION_LIVENESS_TIMEOUT_MINUTES,
+        env = "ATTESTATION_LIVENESS_TIMEOUT_MINUTES",
+        help = "Maximum time in minutes the proof gen server tolerates between attestation events from CC3 before the /api/v1/health endpoint reports the listener as stalled (HTTP 503). Wire into a k8s liveness probe so the server is restarted and re-subscribes to attestation events. Defaults to 5 minutes."
+    )]
+    attestation_liveness_timeout_minutes: u64,
+
+    #[arg(
+        long,
         default_value = "0",
         env = "BLOCK_CONFIRMATION_DEPTH",
         help = "Number of blocks to lag behind the EVM chain tip when validating block existence. \
@@ -159,6 +169,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 c.max_batch_span = n;
             }
         }
+        // ATTESTATION_LIVENESS_TIMEOUT_MINUTES env/CLI overrides YAML when explicitly set.
+        if let Ok(raw) = env::var("ATTESTATION_LIVENESS_TIMEOUT_MINUTES") {
+            if let Ok(n) = raw.parse::<u64>() {
+                c.attestation_liveness_timeout_minutes = n;
+            }
+        }
         c
     } else {
         // Legacy single-chain mode: chain key from CHAIN_KEY env (default 2).
@@ -184,6 +200,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             redis_cluster_mode: resolved_redis_cluster_mode,
             max_batch_size: args.max_batch_size,
             max_batch_span: args.max_batch_span,
+            attestation_liveness_timeout_minutes: args.attestation_liveness_timeout_minutes,
         }
     };
 

--- a/proof-gen-api-server/config.example.yaml
+++ b/proof-gen-api-server/config.example.yaml
@@ -45,3 +45,9 @@ max_batch_size: 10
 # Maximum allowed block span (highest − lowest block) in a single batch request.
 # Prevents small batches from forcing proof generation over extremely large ranges.
 max_batch_span: 1000
+
+# Maximum tolerated gap (in minutes) between CC3 attestation events. If no
+# `BlockAttested` event is observed for at least this long, /api/v1/health
+# returns HTTP 503 so a k8s liveness probe can restart the server and force a
+# fresh CC3 subscription. Defaults to 5 if omitted (CSUB-2039).
+# attestation_liveness_timeout_minutes: 5

--- a/proof-gen-api-server/src/config.rs
+++ b/proof-gen-api-server/src/config.rs
@@ -16,12 +16,10 @@ pub const DEFAULT_MAX_BATCH_SIZE: NonZeroUsize = match NonZeroUsize::new(10) {
 /// from forcing proof generation over an extremely large block range.
 pub const DEFAULT_MAX_BATCH_SPAN: u64 = 1_000;
 
-/// Default `attestation_liveness_timeout_minutes` (5 minutes) - if no new
+/// Default `attestation_liveness_timeout_minutes` - if no new
 /// attestation event is observed from CC3 for at least this long, the
 /// `check_attestation_event_timer` health check will return
 /// [`crate::services::errors::ServiceError::AttestationLivenessInterrupted`].
-/// Operators are expected to wire this into a liveness probe so the proof gen
-/// server is restarted and re-subscribes to attestation events.
 pub const DEFAULT_ATTESTATION_LIVENESS_TIMEOUT_MINUTES: u64 = 5;
 
 /// One source chain (EVM) served by this process, keyed on Creditcoin3.
@@ -56,10 +54,8 @@ pub struct Config {
     pub max_batch_size: NonZeroUsize,
     pub max_batch_span: u64,
     /// Maximum time (in minutes) the proof gen server tolerates between
-    /// attestation events from CC3 before
-    /// [`crate::services::continuity_service::ContinuityService::check_attestation_event_timer`]
-    /// reports the listener as stalled. See
-    /// [`DEFAULT_ATTESTATION_LIVENESS_TIMEOUT_MINUTES`].
+    /// attestation events from CC3 before check_attestation_event_timer
+    /// reports the listener as stalled.
     pub attestation_liveness_timeout_minutes: u64,
 }
 
@@ -123,8 +119,6 @@ pub struct ConfigFile {
     pub max_batch_size: NonZeroUsize,
     #[serde(default = "default_max_batch_span")]
     pub max_batch_span: u64,
-    /// Optional override for the attestation liveness timeout in minutes.
-    /// Defaults to [`DEFAULT_ATTESTATION_LIVENESS_TIMEOUT_MINUTES`].
     #[serde(default = "default_attestation_liveness_timeout_minutes")]
     pub attestation_liveness_timeout_minutes: u64,
 }

--- a/proof-gen-api-server/src/config.rs
+++ b/proof-gen-api-server/src/config.rs
@@ -16,6 +16,14 @@ pub const DEFAULT_MAX_BATCH_SIZE: NonZeroUsize = match NonZeroUsize::new(10) {
 /// from forcing proof generation over an extremely large block range.
 pub const DEFAULT_MAX_BATCH_SPAN: u64 = 1_000;
 
+/// Default `attestation_liveness_timeout_minutes` (5 minutes) - if no new
+/// attestation event is observed from CC3 for at least this long, the
+/// `check_attestation_event_timer` health check will return
+/// [`crate::services::errors::ServiceError::AttestationLivenessInterrupted`].
+/// Operators are expected to wire this into a liveness probe so the proof gen
+/// server is restarted and re-subscribes to attestation events.
+pub const DEFAULT_ATTESTATION_LIVENESS_TIMEOUT_MINUTES: u64 = 5;
+
 /// One source chain (EVM) served by this process, keyed on Creditcoin3.
 #[derive(Debug, Clone)]
 pub struct ChainConfig {
@@ -47,6 +55,12 @@ pub struct Config {
     pub redis_cluster_mode: bool,
     pub max_batch_size: NonZeroUsize,
     pub max_batch_span: u64,
+    /// Maximum time (in minutes) the proof gen server tolerates between
+    /// attestation events from CC3 before
+    /// [`crate::services::continuity_service::ContinuityService::check_attestation_event_timer`]
+    /// reports the listener as stalled. See
+    /// [`DEFAULT_ATTESTATION_LIVENESS_TIMEOUT_MINUTES`].
+    pub attestation_liveness_timeout_minutes: u64,
 }
 
 impl Config {
@@ -68,6 +82,7 @@ impl Config {
             redis_cluster_mode: false,
             max_batch_size: DEFAULT_MAX_BATCH_SIZE,
             max_batch_span: DEFAULT_MAX_BATCH_SPAN,
+            attestation_liveness_timeout_minutes: DEFAULT_ATTESTATION_LIVENESS_TIMEOUT_MINUTES,
         }
     }
 
@@ -108,6 +123,10 @@ pub struct ConfigFile {
     pub max_batch_size: NonZeroUsize,
     #[serde(default = "default_max_batch_span")]
     pub max_batch_span: u64,
+    /// Optional override for the attestation liveness timeout in minutes.
+    /// Defaults to [`DEFAULT_ATTESTATION_LIVENESS_TIMEOUT_MINUTES`].
+    #[serde(default = "default_attestation_liveness_timeout_minutes")]
+    pub attestation_liveness_timeout_minutes: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -138,6 +157,10 @@ fn default_max_batch_size() -> NonZeroUsize {
 
 fn default_max_batch_span() -> u64 {
     DEFAULT_MAX_BATCH_SPAN
+}
+
+fn default_attestation_liveness_timeout_minutes() -> u64 {
+    DEFAULT_ATTESTATION_LIVENESS_TIMEOUT_MINUTES
 }
 
 impl ConfigFile {
@@ -171,6 +194,7 @@ impl ConfigFile {
             redis_cluster_mode: self.redis_cluster_mode,
             max_batch_size: self.max_batch_size,
             max_batch_span: self.max_batch_span,
+            attestation_liveness_timeout_minutes: self.attestation_liveness_timeout_minutes,
         })
     }
 }

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -296,6 +296,11 @@ impl Server {
             metrics.clone(),
             self.config.max_batch_size.get(),
             self.config.max_batch_span,
+            std::time::Duration::from_secs(
+                self.config
+                    .attestation_liveness_timeout_minutes
+                    .saturating_mul(60),
+            ),
         )
         .await?;
 

--- a/proof-gen-api-server/src/networking/routes/health.rs
+++ b/proof-gen-api-server/src/networking/routes/health.rs
@@ -19,16 +19,7 @@ pub struct HealthCheckResponse {
     eth_rpc_connected: bool,
     /// `true` when the proof gen server has observed an attestation event
     /// from CC3 within the configured `attestation_liveness_timeout_minutes`.
-    /// When `false`, the CC3 attestation event listener is considered stalled
-    /// and the response is returned with HTTP 503 so a k8s liveness probe can
-    /// trigger a restart (CSUB-2039).
     attestation_event_listener_alive: bool,
-    /// Seconds since the most recent attestation event was observed from CC3
-    /// (or service startup if none have been observed yet).
-    seconds_since_last_attestation_event: u64,
-    /// Configured maximum tolerated gap between attestation events, in
-    /// seconds. Returned for operator visibility.
-    attestation_liveness_timeout_seconds: u64,
     total_proof_requests: i64,
     uptime_seconds: u64,
 }
@@ -36,21 +27,14 @@ pub struct HealthCheckResponse {
 /// Main health check endpoint - validates upstream services and CC3
 /// attestation event liveness.
 ///
-/// Returns HTTP 200 when everything is healthy, HTTP 503 when the CC3
-/// attestation event listener appears stalled (no `BlockAttested` event
-/// received in the last `attestation_liveness_timeout_minutes`). Operators
-/// should wire this endpoint into a liveness probe so the orchestrator
-/// restarts the server and re-establishes the subscription.
+/// Returns HTTP 200 when everything is healthy, HTTP 503 when connectivity is
+/// in a disrupted state or attestation liveness is interrupted.
 #[utoipa::path(
     get,
     path = "/api/v1/health",
     responses(
         (status = 200, description = "Service health status", body = HealthCheckResponse),
-        (
-            status = 503,
-            description = "Service unhealthy (e.g. CC3 attestation event listener stalled)",
-            body = HealthCheckResponse
-        )
+        (status = 503, description = "Service unhealthy", body = HealthCheckResponse)
     )
 )]
 pub async fn health_check(
@@ -76,22 +60,7 @@ pub async fn health_check(
         Ok(Err(_)) | Err(_) => 0,
     };
 
-    // Attestation liveness check (CSUB-2039). Cheap in-memory check, no need
-    // to gate it behind HEALTH_CHECK_TIMEOUT.
-    let liveness_check = service.check_attestation_event_timer().await;
-    let attestation_event_listener_alive = liveness_check.is_ok();
-    let seconds_since_last_attestation_event =
-        service.time_since_last_attestation_event().await.as_secs();
-    let attestation_liveness_timeout_seconds = service.attestation_liveness_timeout().as_secs();
-
-    if let Err(ref err) = liveness_check {
-        tracing::error!(
-            elapsed_secs = seconds_since_last_attestation_event,
-            timeout_secs = attestation_liveness_timeout_seconds,
-            error = %err,
-            "CC3 attestation event listener appears stalled; reporting unhealthy from /api/v1/health so the orchestrator can restart this proof gen server (CSUB-2039)"
-        );
-    }
+    let attestation_event_listener_alive = service.check_attestation_event_timer().await.is_ok();
 
     let healthy = cc3_connected && eth_connected && attestation_event_listener_alive;
     let status = if healthy {
@@ -100,10 +69,7 @@ pub async fn health_check(
         "degraded".to_string()
     };
 
-    // Surface attestation-listener stalls as 503 specifically so liveness
-    // probes can act on it. CC3/ETH RPC blips alone keep the legacy 200
-    // behaviour to avoid disrupting existing readiness probes.
-    let http_status = if attestation_event_listener_alive {
+    let http_status = if healthy {
         StatusCode::OK
     } else {
         StatusCode::SERVICE_UNAVAILABLE
@@ -116,8 +82,6 @@ pub async fn health_check(
             cc3_rpc_connected: cc3_connected,
             eth_rpc_connected: eth_connected,
             attestation_event_listener_alive,
-            seconds_since_last_attestation_event,
-            attestation_liveness_timeout_seconds,
             total_proof_requests,
             uptime_seconds: service.uptime_seconds(),
         }),

--- a/proof-gen-api-server/src/networking/routes/health.rs
+++ b/proof-gen-api-server/src/networking/routes/health.rs
@@ -10,8 +10,6 @@ use utoipa::ToSchema;
 use crate::services::continuity_service::ContinuityService;
 
 const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
-// 15 minute grace window on restart
-const GRACE_WINDOW_DURATION: Duration = Duration::from_secs(15 * 60);
 
 /// Health check response schema for OpenAPI
 #[derive(Serialize, ToSchema)]
@@ -71,10 +69,7 @@ pub async fn health_check(
         "degraded".to_string()
     };
 
-    // If we are in our re-start grace window, then don't use a failure
-    // status code. This would trigger another restart through k8s.
-    let in_grace_window: bool = Duration::from_secs(service.uptime_seconds()) < GRACE_WINDOW_DURATION;
-    let http_status = if healthy || in_grace_window {
+    let http_status = if healthy {
         StatusCode::OK
     } else {
         StatusCode::SERVICE_UNAVAILABLE

--- a/proof-gen-api-server/src/networking/routes/health.rs
+++ b/proof-gen-api-server/src/networking/routes/health.rs
@@ -10,6 +10,8 @@ use utoipa::ToSchema;
 use crate::services::continuity_service::ContinuityService;
 
 const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
+// 15 minute grace window on restart
+const GRACE_WINDOW_DURATION: Duration = Duration::from_secs(15 * 60);
 
 /// Health check response schema for OpenAPI
 #[derive(Serialize, ToSchema)]
@@ -69,7 +71,10 @@ pub async fn health_check(
         "degraded".to_string()
     };
 
-    let http_status = if healthy {
+    // If we are in our re-start grace window, then don't use a failure
+    // status code. This would trigger another restart through k8s.
+    let in_grace_window: bool = Duration::from_secs(service.uptime_seconds()) < GRACE_WINDOW_DURATION;
+    let http_status = if healthy || in_grace_window {
         StatusCode::OK
     } else {
         StatusCode::SERVICE_UNAVAILABLE

--- a/proof-gen-api-server/src/networking/routes/health.rs
+++ b/proof-gen-api-server/src/networking/routes/health.rs
@@ -1,3 +1,5 @@
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
 use axum::{Extension, Json};
 use serde::Serialize;
 use std::sync::Arc;
@@ -15,19 +17,45 @@ pub struct HealthCheckResponse {
     status: String,
     cc3_rpc_connected: bool,
     eth_rpc_connected: bool,
+    /// `true` when the proof gen server has observed an attestation event
+    /// from CC3 within the configured `attestation_liveness_timeout_minutes`.
+    /// When `false`, the CC3 attestation event listener is considered stalled
+    /// and the response is returned with HTTP 503 so a k8s liveness probe can
+    /// trigger a restart (CSUB-2039).
+    attestation_event_listener_alive: bool,
+    /// Seconds since the most recent attestation event was observed from CC3
+    /// (or service startup if none have been observed yet).
+    seconds_since_last_attestation_event: u64,
+    /// Configured maximum tolerated gap between attestation events, in
+    /// seconds. Returned for operator visibility.
+    attestation_liveness_timeout_seconds: u64,
     total_proof_requests: i64,
     uptime_seconds: u64,
 }
 
-/// Main health check endpoint - validates upstream services
+/// Main health check endpoint - validates upstream services and CC3
+/// attestation event liveness.
+///
+/// Returns HTTP 200 when everything is healthy, HTTP 503 when the CC3
+/// attestation event listener appears stalled (no `BlockAttested` event
+/// received in the last `attestation_liveness_timeout_minutes`). Operators
+/// should wire this endpoint into a liveness probe so the orchestrator
+/// restarts the server and re-establishes the subscription.
 #[utoipa::path(
     get,
     path = "/api/v1/health",
-    responses((status = 200, description = "Service health status", body = HealthCheckResponse))
+    responses(
+        (status = 200, description = "Service health status", body = HealthCheckResponse),
+        (
+            status = 503,
+            description = "Service unhealthy (e.g. CC3 attestation event listener stalled)",
+            body = HealthCheckResponse
+        )
+    )
 )]
 pub async fn health_check(
     Extension(service): Extension<Arc<ContinuityService>>,
-) -> Json<HealthCheckResponse> {
+) -> impl IntoResponse {
     // Check RPC connectivity in parallel with timeout
     let (total_requests, cc3_connected, eth_connected) = tokio::join!(
         async { timeout(HEALTH_CHECK_TIMEOUT, service.get_proofs_counts()).await },
@@ -48,17 +76,50 @@ pub async fn health_check(
         Ok(Err(_)) | Err(_) => 0,
     };
 
-    let status = if cc3_connected && eth_connected {
+    // Attestation liveness check (CSUB-2039). Cheap in-memory check, no need
+    // to gate it behind HEALTH_CHECK_TIMEOUT.
+    let liveness_check = service.check_attestation_event_timer().await;
+    let attestation_event_listener_alive = liveness_check.is_ok();
+    let seconds_since_last_attestation_event =
+        service.time_since_last_attestation_event().await.as_secs();
+    let attestation_liveness_timeout_seconds = service.attestation_liveness_timeout().as_secs();
+
+    if let Err(ref err) = liveness_check {
+        tracing::error!(
+            elapsed_secs = seconds_since_last_attestation_event,
+            timeout_secs = attestation_liveness_timeout_seconds,
+            error = %err,
+            "CC3 attestation event listener appears stalled; reporting unhealthy from /api/v1/health so the orchestrator can restart this proof gen server (CSUB-2039)"
+        );
+    }
+
+    let healthy = cc3_connected && eth_connected && attestation_event_listener_alive;
+    let status = if healthy {
         "healthy".to_string()
     } else {
         "degraded".to_string()
     };
 
-    Json(HealthCheckResponse {
-        status,
-        cc3_rpc_connected: cc3_connected,
-        eth_rpc_connected: eth_connected,
-        total_proof_requests,
-        uptime_seconds: service.uptime_seconds(),
-    })
+    // Surface attestation-listener stalls as 503 specifically so liveness
+    // probes can act on it. CC3/ETH RPC blips alone keep the legacy 200
+    // behaviour to avoid disrupting existing readiness probes.
+    let http_status = if attestation_event_listener_alive {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+
+    (
+        http_status,
+        Json(HealthCheckResponse {
+            status,
+            cc3_rpc_connected: cc3_connected,
+            eth_rpc_connected: eth_connected,
+            attestation_event_listener_alive,
+            seconds_since_last_attestation_event,
+            attestation_liveness_timeout_seconds,
+            total_proof_requests,
+            uptime_seconds: service.uptime_seconds(),
+        }),
+    )
 }

--- a/proof-gen-api-server/src/prom/mod.rs
+++ b/proof-gen-api-server/src/prom/mod.rs
@@ -471,6 +471,7 @@ mod labels {
         EmptyTxHashes,
         TooManyTxHashes,
         BatchSpanTooLarge,
+        AttestationLivenessInterrupted,
         Internal,
     }
 

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -367,6 +367,9 @@ mod tests {
     use continuity::{mocks::make_mock_providers, ContinuityBuilder, ContinuityConfig};
     use std::sync::Arc;
 
+    const DEFAULT_ATTESTATION_LIVENESS_TIMEOUT: Duration = std::time::Duration::from_secs(5 * 60);
+    const DEFAULT_MAX_BATCH_SPAN: u64 = 1000;
+
     struct FoundEthProvider;
 
     #[async_trait]
@@ -452,29 +455,15 @@ mod tests {
     }
 
     async fn make_service(eth_provider: Arc<dyn EthRpcProvider>) -> ContinuityService {
-        make_service_with_batch_span(eth_provider, 1_000).await
-    }
-
-    async fn make_service_with_batch_span(
-        eth_provider: Arc<dyn EthRpcProvider>,
-        max_batch_span: u64,
-    ) -> ContinuityService {
-        make_service_full(
+        make_service_with_configuration(
             eth_provider,
-            max_batch_span,
-            std::time::Duration::from_secs(5 * 60),
+            DEFAULT_MAX_BATCH_SPAN,
+            DEFAULT_ATTESTATION_LIVENESS_TIMEOUT,
         )
         .await
     }
 
-    async fn make_service_with_liveness_timeout(
-        eth_provider: Arc<dyn EthRpcProvider>,
-        attestation_liveness_timeout: std::time::Duration,
-    ) -> ContinuityService {
-        make_service_full(eth_provider, 1_000, attestation_liveness_timeout).await
-    }
-
-    async fn make_service_full(
+    async fn make_service_with_configuration(
         eth_provider: Arc<dyn EthRpcProvider>,
         max_batch_span: u64,
         attestation_liveness_timeout: std::time::Duration,
@@ -852,7 +841,12 @@ mod tests {
     #[tokio::test]
     async fn batch_span_exceeding_limit_is_rejected() {
         // Set a tight max_batch_span of 50 blocks
-        let svc = make_service_with_batch_span(Arc::new(FoundEthProvider), 50).await;
+        let svc = make_service_with_configuration(
+            Arc::new(FoundEthProvider),
+            50,
+            DEFAULT_ATTESTATION_LIVENESS_TIMEOUT,
+        )
+        .await;
         let chain = svc.chain_state(2).unwrap();
 
         // Blocks 100 and 200 are 100 apart, which exceeds the 50-block limit
@@ -888,7 +882,12 @@ mod tests {
     #[tokio::test]
     async fn batch_span_within_limit_is_accepted() {
         // Set max_batch_span of 50 blocks
-        let svc = make_service_with_batch_span(Arc::new(FoundEthProvider), 50).await;
+        let svc = make_service_with_configuration(
+            Arc::new(FoundEthProvider),
+            50,
+            DEFAULT_ATTESTATION_LIVENESS_TIMEOUT,
+        )
+        .await;
         let chain = svc.chain_state(2).unwrap();
 
         // Blocks 100 and 140 are 40 apart, which is within the 50-block limit.
@@ -917,7 +916,12 @@ mod tests {
     #[tokio::test]
     async fn single_block_batch_always_passes_span_check() {
         // Even with max_batch_span = 0, a single-block batch has span 0 and should pass.
-        let svc = make_service_with_batch_span(Arc::new(FoundEthProvider), 0).await;
+        let svc = make_service_with_configuration(
+            Arc::new(FoundEthProvider),
+            0,
+            DEFAULT_ATTESTATION_LIVENESS_TIMEOUT,
+        )
+        .await;
         let chain = svc.chain_state(2).unwrap();
 
         let queries = vec![ProofQuery {
@@ -935,13 +939,7 @@ mod tests {
 
     #[tokio::test]
     async fn check_attestation_event_timer_passes_when_within_timeout() {
-        // Generous timeout, no attestation inserted: should still pass because
-        // the timer is seeded at service start.
-        let svc = make_service_with_liveness_timeout(
-            Arc::new(FoundEthProvider),
-            std::time::Duration::from_secs(60),
-        )
-        .await;
+        let svc = make_service(Arc::new(FoundEthProvider)).await;
 
         svc.check_attestation_event_timer()
             .await
@@ -952,8 +950,9 @@ mod tests {
     async fn check_attestation_event_timer_trips_after_timeout() {
         // 0-duration timeout means "any elapsed time trips the check". This
         // also exercises the boundary condition (>= timeout).
-        let svc = make_service_with_liveness_timeout(
+        let svc = make_service_with_configuration(
             Arc::new(FoundEthProvider),
+            DEFAULT_MAX_BATCH_SPAN,
             std::time::Duration::from_secs(0),
         )
         .await;
@@ -973,13 +972,7 @@ mod tests {
 
     #[tokio::test]
     async fn insert_attestation_resets_liveness_timer() {
-        // Build the service with a generous timeout so we control the elapsed
-        // window with `time_since_last_attestation_event`.
-        let svc = make_service_with_liveness_timeout(
-            Arc::new(FoundEthProvider),
-            std::time::Duration::from_secs(3600),
-        )
-        .await;
+        let svc = make_service(Arc::new(FoundEthProvider)).await;
 
         // Spin a bit so the timer has a non-zero elapsed value.
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
@@ -992,32 +985,6 @@ mod tests {
         assert!(
             after < before,
             "insert_attestation should reset the liveness timer (before={before:?}, after={after:?})"
-        );
-    }
-
-    #[tokio::test]
-    async fn insert_attestation_resets_timer_for_unserved_chain_key() {
-        // The fix from CSUB-2039 specifies the timer should be reset on every
-        // call to `insert_attestation`. Chain filtering happens *after* the
-        // reset because a fresh event for any chain still proves the CC3
-        // listener is alive.
-        let svc = make_service_with_liveness_timeout(
-            Arc::new(FoundEthProvider),
-            std::time::Duration::from_secs(3600),
-        )
-        .await;
-
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        let before = svc.time_since_last_attestation_event().await;
-        assert!(before >= std::time::Duration::from_millis(10));
-
-        // chain_key 999 is not configured on this service.
-        svc.insert_attestation(999, 1, H256::zero()).await;
-
-        let after = svc.time_since_last_attestation_event().await;
-        assert!(
-            after < before,
-            "timer should reset even for events on chains we don't serve (before={before:?}, after={after:?})"
         );
     }
 

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -953,12 +953,12 @@ mod tests {
         let svc = make_service_with_configuration(
             Arc::new(FoundEthProvider),
             DEFAULT_MAX_BATCH_SPAN,
-            std::time::Duration::from_secs(0),
+            std::time::Duration::from_secs(1),
         )
         .await;
 
-        // Yield once so a tiny bit of time passes since service construction.
-        tokio::task::yield_now().await;
+        // Spin a bit so the timer has gone over its timeout.
+        tokio::time::sleep(std::time::Duration::from_millis(1010)).await;
 
         let err = svc
             .check_attestation_event_timer()

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -459,6 +459,26 @@ mod tests {
         eth_provider: Arc<dyn EthRpcProvider>,
         max_batch_span: u64,
     ) -> ContinuityService {
+        make_service_full(
+            eth_provider,
+            max_batch_span,
+            std::time::Duration::from_secs(5 * 60),
+        )
+        .await
+    }
+
+    async fn make_service_with_liveness_timeout(
+        eth_provider: Arc<dyn EthRpcProvider>,
+        attestation_liveness_timeout: std::time::Duration,
+    ) -> ContinuityService {
+        make_service_full(eth_provider, 1_000, attestation_liveness_timeout).await
+    }
+
+    async fn make_service_full(
+        eth_provider: Arc<dyn EthRpcProvider>,
+        max_batch_span: u64,
+        attestation_liveness_timeout: std::time::Duration,
+    ) -> ContinuityService {
         let chain_key = 2;
         let (cc_provider, _) = make_mock_providers(chain_key);
         let builder = Arc::new(ContinuityBuilder::new_with_providers(
@@ -466,9 +486,15 @@ mod tests {
             cc_provider,
             eth_provider,
         ));
-        ContinuityService::new(vec![builder], NoopMetrics::new(), 10, max_batch_span)
-            .await
-            .expect("service init should succeed with mocks")
+        ContinuityService::new(
+            vec![builder],
+            NoopMetrics::new(),
+            10,
+            max_batch_span,
+            attestation_liveness_timeout,
+        )
+        .await
+        .expect("service init should succeed with mocks")
     }
 
     #[tokio::test]
@@ -905,6 +931,94 @@ mod tests {
                 "single-block batch should never fail span check, got {err:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn check_attestation_event_timer_passes_when_within_timeout() {
+        // Generous timeout, no attestation inserted: should still pass because
+        // the timer is seeded at service start.
+        let svc = make_service_with_liveness_timeout(
+            Arc::new(FoundEthProvider),
+            std::time::Duration::from_secs(60),
+        )
+        .await;
+
+        svc.check_attestation_event_timer()
+            .await
+            .expect("liveness check should pass within timeout");
+    }
+
+    #[tokio::test]
+    async fn check_attestation_event_timer_trips_after_timeout() {
+        // 0-duration timeout means "any elapsed time trips the check". This
+        // also exercises the boundary condition (>= timeout).
+        let svc = make_service_with_liveness_timeout(
+            Arc::new(FoundEthProvider),
+            std::time::Duration::from_secs(0),
+        )
+        .await;
+
+        // Yield once so a tiny bit of time passes since service construction.
+        tokio::task::yield_now().await;
+
+        let err = svc
+            .check_attestation_event_timer()
+            .await
+            .expect_err("liveness check should trip with a 0s timeout");
+        assert!(
+            matches!(err, ServiceError::AttestationLivenessInterrupted { .. }),
+            "unexpected error variant: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn insert_attestation_resets_liveness_timer() {
+        // Build the service with a generous timeout so we control the elapsed
+        // window with `time_since_last_attestation_event`.
+        let svc = make_service_with_liveness_timeout(
+            Arc::new(FoundEthProvider),
+            std::time::Duration::from_secs(3600),
+        )
+        .await;
+
+        // Spin a bit so the timer has a non-zero elapsed value.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let before = svc.time_since_last_attestation_event().await;
+        assert!(before >= std::time::Duration::from_millis(10));
+
+        svc.insert_attestation(2, 100, H256::zero()).await;
+
+        let after = svc.time_since_last_attestation_event().await;
+        assert!(
+            after < before,
+            "insert_attestation should reset the liveness timer (before={before:?}, after={after:?})"
+        );
+    }
+
+    #[tokio::test]
+    async fn insert_attestation_resets_timer_for_unserved_chain_key() {
+        // The fix from CSUB-2039 specifies the timer should be reset on every
+        // call to `insert_attestation`. Chain filtering happens *after* the
+        // reset because a fresh event for any chain still proves the CC3
+        // listener is alive.
+        let svc = make_service_with_liveness_timeout(
+            Arc::new(FoundEthProvider),
+            std::time::Duration::from_secs(3600),
+        )
+        .await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let before = svc.time_since_last_attestation_event().await;
+        assert!(before >= std::time::Duration::from_millis(10));
+
+        // chain_key 999 is not configured on this service.
+        svc.insert_attestation(999, 1, H256::zero()).await;
+
+        let after = svc.time_since_last_attestation_event().await;
+        assert!(
+            after < before,
+            "timer should reset even for events on chains we don't serve (before={before:?}, after={after:?})"
+        );
     }
 
     // ---------------------------------------------------------------------

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -289,9 +289,7 @@ impl ContinuityService {
             metrics,
             max_batch_size,
             max_batch_span,
-            // Seed with `now` so the timer effectively starts ticking from
-            // service startup; if attestations never arrive we'll still trip
-            // the liveness check after `attestation_liveness_timeout`.
+            // Seed with `now` so we time out if attestations never arrive
             last_attestation_event_at: tokio::sync::RwLock::new(now),
             attestation_liveness_timeout,
         })
@@ -423,15 +421,9 @@ impl ContinuityService {
     /// Insert an attestation into the in-memory cache (called from event handler).
     ///
     /// Resets the attestation liveness timer (see
-    /// [`Self::check_attestation_event_timer`]) on every call, even when the
-    /// event is for a chain we don't serve, because a fresh event from CC3
-    /// still proves the listener is alive. The fix from CSUB-2039 relies on
-    /// this reset happening here so a stalled listener can be detected by the
-    /// liveness probe and the orchestrator can restart the server.
+    /// [`Self::check_attestation_event_timer`]) on every call.
     pub async fn insert_attestation(&self, chain_key: u64, block_number: u64, digest: H256) {
-        // Reset liveness timer first — we want the timer to track "last
-        // attestation event observed from CC3", regardless of whether the
-        // event is for a chain this server happens to serve.
+        // Reset liveness timer first
         *self.last_attestation_event_at.write().await = Instant::now();
 
         if let Some(chain) = self.chains.get(&chain_key) {
@@ -448,14 +440,6 @@ impl ContinuityService {
             );
         }
     }
-
-    /// Returns the configured attestation liveness timeout. Exposed for the
-    /// `/api/v1/health` response so operators can see what threshold is in
-    /// effect.
-    pub fn attestation_liveness_timeout(&self) -> Duration {
-        self.attestation_liveness_timeout
-    }
-
     /// Returns how long it has been since the last observed attestation event
     /// from CC3 (or service startup if none have been observed yet).
     pub async fn time_since_last_attestation_event(&self) -> Duration {
@@ -470,11 +454,9 @@ impl ContinuityService {
     /// `BlockAttested` event was received from CC3. The intent is that callers
     /// (the `/api/v1/health` endpoint, a k8s liveness probe, etc.) surface
     /// this as a failure so the orchestrator restarts the server and
-    /// re-establishes the subscription. See CSUB-2039: "We should have had an
-    /// attestation, because it's been five minutes, let's re-connect just in
-    /// case."
+    /// re-establishes the subscription.
     pub async fn check_attestation_event_timer(&self) -> ServiceResult<()> {
-        let elapsed = self.time_since_last_attestation_event().await;
+        let elapsed = self.last_attestation_event_at.read().await.elapsed();
         if elapsed >= self.attestation_liveness_timeout {
             return Err(ServiceError::AttestationLivenessInterrupted {
                 elapsed_secs: elapsed.as_secs(),

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -188,7 +188,7 @@ impl ContinuityService {
         if builders.is_empty() {
             anyhow::bail!("ContinuityService requires at least one ContinuityBuilder");
         }
-        if Duration::is_zero(&attestation_liveness_timeout) { 
+        if Duration::is_zero(&attestation_liveness_timeout) {
             anyhow::bail!("ContinuityService requires attestation liveness timeout > 0");
         }
 

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -8,7 +8,7 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
 };
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::prom::Metrics;
 use crate::services::continuity_service::helpers::*;
@@ -161,6 +161,16 @@ pub struct ContinuityService {
     /// request.  Prevents a small batch from forcing proof generation over an
     /// extremely large block range.
     max_batch_span: u64,
+    /// Instant of the most recently observed `BlockAttested` event from CC3,
+    /// or service-start when no event has been seen yet. Used by
+    /// [`ContinuityService::check_attestation_event_timer`] to detect a stalled
+    /// CC3 attestation event listener so the server can be restarted and
+    /// re-subscribe (see CSUB-2039).
+    last_attestation_event_at: tokio::sync::RwLock<Instant>,
+    /// Maximum tolerated gap between attestation events from CC3. If exceeded,
+    /// [`ContinuityService::check_attestation_event_timer`] returns
+    /// [`ServiceError::AttestationLivenessInterrupted`].
+    attestation_liveness_timeout: Duration,
 }
 
 impl ContinuityService {
@@ -173,6 +183,7 @@ impl ContinuityService {
         metrics: Metrics,
         max_batch_size: usize,
         max_batch_span: u64,
+        attestation_liveness_timeout: Duration,
     ) -> anyhow::Result<Self> {
         if builders.is_empty() {
             anyhow::bail!("ContinuityService requires at least one ContinuityBuilder");
@@ -270,13 +281,19 @@ impl ContinuityService {
             );
         }
 
+        let now = Instant::now();
         Ok(Self {
             chains,
-            start_time: Instant::now(),
+            start_time: now,
             total_proof_requests: AtomicU64::new(0),
             metrics,
             max_batch_size,
             max_batch_span,
+            // Seed with `now` so the timer effectively starts ticking from
+            // service startup; if attestations never arrive we'll still trip
+            // the liveness check after `attestation_liveness_timeout`.
+            last_attestation_event_at: tokio::sync::RwLock::new(now),
+            attestation_liveness_timeout,
         })
     }
 
@@ -404,7 +421,19 @@ impl ContinuityService {
     }
 
     /// Insert an attestation into the in-memory cache (called from event handler).
+    ///
+    /// Resets the attestation liveness timer (see
+    /// [`Self::check_attestation_event_timer`]) on every call, even when the
+    /// event is for a chain we don't serve, because a fresh event from CC3
+    /// still proves the listener is alive. The fix from CSUB-2039 relies on
+    /// this reset happening here so a stalled listener can be detected by the
+    /// liveness probe and the orchestrator can restart the server.
     pub async fn insert_attestation(&self, chain_key: u64, block_number: u64, digest: H256) {
+        // Reset liveness timer first — we want the timer to track "last
+        // attestation event observed from CC3", regardless of whether the
+        // event is for a chain this server happens to serve.
+        *self.last_attestation_event_at.write().await = Instant::now();
+
         if let Some(chain) = self.chains.get(&chain_key) {
             chain
                 .attestation_cache
@@ -418,6 +447,41 @@ impl ContinuityService {
                 "🔧 📦 📜 attestation cached"
             );
         }
+    }
+
+    /// Returns the configured attestation liveness timeout. Exposed for the
+    /// `/api/v1/health` response so operators can see what threshold is in
+    /// effect.
+    pub fn attestation_liveness_timeout(&self) -> Duration {
+        self.attestation_liveness_timeout
+    }
+
+    /// Returns how long it has been since the last observed attestation event
+    /// from CC3 (or service startup if none have been observed yet).
+    pub async fn time_since_last_attestation_event(&self) -> Duration {
+        self.last_attestation_event_at.read().await.elapsed()
+    }
+
+    /// Health check: confirms the CC3 attestation event listener is still
+    /// delivering events.
+    ///
+    /// Returns [`ServiceError::AttestationLivenessInterrupted`] if more than
+    /// `attestation_liveness_timeout` has elapsed since the most recent
+    /// `BlockAttested` event was received from CC3. The intent is that callers
+    /// (the `/api/v1/health` endpoint, a k8s liveness probe, etc.) surface
+    /// this as a failure so the orchestrator restarts the server and
+    /// re-establishes the subscription. See CSUB-2039: "We should have had an
+    /// attestation, because it's been five minutes, let's re-connect just in
+    /// case."
+    pub async fn check_attestation_event_timer(&self) -> ServiceResult<()> {
+        let elapsed = self.time_since_last_attestation_event().await;
+        if elapsed >= self.attestation_liveness_timeout {
+            return Err(ServiceError::AttestationLivenessInterrupted {
+                elapsed_secs: elapsed.as_secs(),
+                timeout_secs: self.attestation_liveness_timeout.as_secs(),
+            });
+        }
+        Ok(())
     }
 
     /// Truncate attestation and checkpoint caches to the given revert height.

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -188,6 +188,9 @@ impl ContinuityService {
         if builders.is_empty() {
             anyhow::bail!("ContinuityService requires at least one ContinuityBuilder");
         }
+        if Duration::is_zero(&attestation_liveness_timeout) { 
+            anyhow::bail!("ContinuityService requires attestation liveness timeout > 0");
+        }
 
         let mut chains = HashMap::new();
         for builder in builders {

--- a/proof-gen-api-server/src/services/errors.rs
+++ b/proof-gen-api-server/src/services/errors.rs
@@ -143,6 +143,11 @@ pub enum ServiceError {
         span: u64,
         max_span: u64,
     },
+    #[error("No new attestation events received in {elapsed_secs}s (>= configured liveness timeout of {timeout_secs}s); the CC3 attestation event listener appears stalled and the proof gen server should be restarted to re-establish the subscription")]
+    AttestationLivenessInterrupted {
+        elapsed_secs: u64,
+        timeout_secs: u64,
+    },
 }
 
 impl ServiceError {
@@ -152,6 +157,7 @@ impl ServiceError {
             ServiceError::RpcUnavailable { .. }
                 | ServiceError::BlockNotReady { .. }
                 | ServiceError::BlockNotOnSourceChain { .. }
+                | ServiceError::AttestationLivenessInterrupted { .. }
         )
     }
     pub fn code(&self) -> &'static str {
@@ -176,6 +182,7 @@ impl ServiceError {
             ServiceError::TooManyTxHashes => "TooManyTxHashes",
             ServiceError::EmptyTxHashes => "EmptyTxHashes",
             ServiceError::BatchSpanTooLarge { .. } => "BatchSpanTooLarge",
+            ServiceError::AttestationLivenessInterrupted { .. } => "AttestationLivenessInterrupted",
         }
     }
 
@@ -193,7 +200,9 @@ impl ServiceError {
             | Self::EmptyTxHashes
             | Self::TooManyTxHashes
             | Self::BatchSpanTooLarge { .. } => StatusCode::BAD_REQUEST,
-            Self::RpcUnavailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
+            Self::RpcUnavailable { .. } | Self::AttestationLivenessInterrupted { .. } => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
             Self::TxHashLookupUnavailable { .. } => StatusCode::NOT_IMPLEMENTED,
             Self::TxHashNotFound { .. } | Self::BlockNotOnSourceChain { .. } => {
                 StatusCode::NOT_FOUND
@@ -329,6 +338,9 @@ impl GetErrorType for ServiceError {
             ServiceError::EmptyTxHashes => ErrorType::EmptyTxHashes,
             ServiceError::TooManyTxHashes => ErrorType::TooManyTxHashes,
             ServiceError::BatchSpanTooLarge { .. } => ErrorType::BatchSpanTooLarge,
+            ServiceError::AttestationLivenessInterrupted { .. } => {
+                ErrorType::AttestationLivenessInterrupted
+            }
         }
     }
 }

--- a/proof-gen-api-server/src/services/errors.rs
+++ b/proof-gen-api-server/src/services/errors.rs
@@ -143,7 +143,7 @@ pub enum ServiceError {
         span: u64,
         max_span: u64,
     },
-    #[error("No new attestation events received in {elapsed_secs}s (>= configured liveness timeout of {timeout_secs}s); the CC3 attestation event listener appears stalled and the proof gen server should be restarted to re-establish the subscription")]
+    #[error("No new attestation events received in {elapsed_secs}s (>= configured liveness timeout of {timeout_secs}s)")]
     AttestationLivenessInterrupted {
         elapsed_secs: u64,
         timeout_secs: u64,

--- a/proof-gen-api-server/tests/route_tests.rs
+++ b/proof-gen-api-server/tests/route_tests.rs
@@ -214,9 +214,10 @@ async fn test_swagger_json_route_should_return_valid_json() {
     let response = app.oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    // 32 KiB is plenty of headroom as we add new endpoints / response variants;
-    // the previous 10 KiB cap was tight enough to break on the next addition.
-    let bytes = axum::body::to_bytes(response.into_body(), 32 * 1024)
+    // The OpenAPI JSON has grown with each new schema; pick a generous limit
+    // so adding one more field doesn't silently fail this test for spurious
+    // reasons. We only care that it parses as valid JSON.
+    let bytes = axum::body::to_bytes(response.into_body(), 256 * 1024)
         .await
         .unwrap();
     // note: if we can deserialize without error it must be valid json, no?

--- a/proof-gen-api-server/tests/test_utils.rs
+++ b/proof-gen-api-server/tests/test_utils.rs
@@ -202,9 +202,15 @@ mod anvil_integration {
         }
 
         let service = Arc::new(
-            ContinuityService::new(builders, NoopMetrics::new(), 10, 1_000)
-                .await
-                .expect("service init"),
+            ContinuityService::new(
+                builders,
+                NoopMetrics::new(),
+                10,
+                1_000,
+                std::time::Duration::from_secs(5 * 60),
+            )
+            .await
+            .expect("service init"),
         );
         build_app(
             service,


### PR DESCRIPTION
## Summary:
1. Creates a new health condition. If we haven't seen a new attestation event in the last 5 minutes then the proof gen server is considered unhealthy. 
      a. While this condition might have false positives in the case of a stalled attestation chain, that doesn't really hurt anything.
      b. This acts as a strong failsafe preventing prolonged periods of down time.
2. If any of our health check conditions fail, we now respond to the health check with a 503 error. This will cause k8s to restart the pod. Previously we were returning 200's even when rpcs were broken.

Fix for [CSUB-2039](https://gluwa.atlassian.net/browse/CSUB-2039): when the CC3 `BlockAttested` event listener silently stops delivering events on cc3 devnet sepolia, every proof request starts failing with *"not yet attested"* while the proof gen server still reports itself as healthy. We add an attestation-liveness watchdog so a k8s liveness probe can restart the server and force a fresh CC3 subscription.

[CSUB-2039]: https://gluwa.atlassian.net/browse/CSUB-2039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ