### PR TITLE
fix(cc-client): atomically refresh shared CcClient on reconnect (CSUB-2039)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,6 +2240,7 @@ name = "cc-client"
 version = "3.115.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "attestor-primitives",
  "serde",
  "sp-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ repository = "https://github.com/gluwa/creditcoin3-next/"
 version = "3.115.0"
 
 [workspace.dependencies]
+arc-swap = "1"
 assert_matches = "1.5.0"
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
 pretty_assertions = { version = "1.4.1" }

--- a/attestor/attestor/src/worker/validation/mod.rs
+++ b/attestor/attestor/src/worker/validation/mod.rs
@@ -1023,7 +1023,11 @@ impl WorkerAttestationValidation {
         let reconnect = || {
             tracing::warn!("Reconnecting to CC3...");
 
-            let mut cc3 = self.cc3.clone();
+            // `Client::reconnect` now uses interior mutability
+            // (`ArcSwap<ClientInner>`), so we don't need a `&mut` handle here.
+            // The local clone preserves existing semantics: reconnect on the
+            // clone, then move it back into `self.cc3` on success.
+            let cc3 = self.cc3.clone();
             async move {
                 cc3.reconnect().await.map_err(|err| {
                     tracing::error!(?err, "Failed to reconnect to CC3");

--- a/common/cc-client/Cargo.toml
+++ b/common/cc-client/Cargo.toml
@@ -19,6 +19,7 @@ too_many_arguments = "allow"
 
 [dependencies]
 anyhow = "1.0"
+arc-swap = { workspace = true }
 
 # Substrate
 subxt = { workspace = true, features = ["jsonrpsee"] }

--- a/common/cc-client/src/api.rs
+++ b/common/cc-client/src/api.rs
@@ -5,6 +5,12 @@ use user::prelude::*;
 /// Will attempt to restore connection on any failed runtime call. Reconnection attempts are
 /// unbounded and can only be aborted via manual user cancellation (Ctrl-C).
 ///
+/// Holds a borrow of the underlying [`crate::Client`] (taken as `&mut` for
+/// historical reasons — every consumer here calls through a mutable handle).
+/// The underlying [`crate::Client::reconnect`] now uses interior mutability,
+/// so the borrow is `&Client` for reconnect purposes; we keep the `&mut`
+/// receiver to avoid churn at every call site.
+///
 /// [`RuntimeApi`]: subxt::runtime_api::RuntimeApi
 pub struct ReconnectingRuntimeApi<'a> {
     client: &'a mut crate::Client,
@@ -18,11 +24,7 @@ impl<'a> ReconnectingRuntimeApi<'a> {
     pub async fn new(client: &'a mut crate::Client) -> Result<Self, Interrupt<crate::Error>> {
         let runtime_api = match client.api().runtime_api().at_latest().await {
             Ok(runtime_api) => runtime_api,
-            Err(err) => {
-                let (client_new, runtime_api) = reconnect(client, err).await?;
-                *client = client_new;
-                runtime_api
-            }
+            Err(err) => reconnect(client, err).await?,
         };
 
         Ok(Self {
@@ -39,9 +41,7 @@ impl<'a> ReconnectingRuntimeApi<'a> {
             match self.runtime_api.call(call()).await {
                 Ok(res) => break Ok(res),
                 Err(err) => {
-                    let (client, runtime_api) = reconnect(self.client, err).await?;
-                    *self.client = client;
-                    self.runtime_api = runtime_api;
+                    self.runtime_api = reconnect(self.client, err).await?;
                 }
             }
         }
@@ -52,13 +52,10 @@ async fn reconnect(
     client: &crate::Client,
     err: subxt::Error,
 ) -> Result<
-    (
-        crate::Client,
-        subxt::runtime_api::RuntimeApi<
-            subxt::SubstrateConfig,
-            subxt::OnlineClient<subxt::SubstrateConfig>,
-        >,
-    ),
+    subxt::runtime_api::RuntimeApi<
+        subxt::SubstrateConfig,
+        subxt::OnlineClient<subxt::SubstrateConfig>,
+    >,
     Interrupt<crate::Error>,
 > {
     tracing::warn!(?err, "CC3 connection lost");
@@ -69,19 +66,27 @@ async fn reconnect(
     let reconnect = || {
         tracing::warn!("Reconnecting to CC3...");
 
-        let mut cc3 = client.clone();
         async move {
-            cc3.reconnect().await.map_err(|err| {
+            // `Client::reconnect` now takes `&self` and atomically swaps the
+            // underlying subxt connection for every `Arc<Client>` (and shared
+            // borrow) holder. We can therefore refresh in place rather than
+            // shuffling a value-cloned `Client` around.
+            client.reconnect().await.map_err(|err| {
                 tracing::error!(?err, "Failed to reconnect to CC3");
                 err
             })?;
 
-            let runtime_api = cc3.api().runtime_api().at_latest().await.map_err(|err| {
-                tracing::error!(?err, "Failed to reconnect to CC3");
-                crate::Error::SubxtError(err)
-            })?;
+            let runtime_api = client
+                .api()
+                .runtime_api()
+                .at_latest()
+                .await
+                .map_err(|err| {
+                    tracing::error!(?err, "Failed to reconnect to CC3");
+                    crate::Error::SubxtError(err)
+                })?;
 
-            Ok::<_, crate::Error>((cc3, runtime_api))
+            Ok::<_, crate::Error>(runtime_api)
         }
     };
     tokio::select! {

--- a/common/cc-client/src/attestation.rs
+++ b/common/cc-client/src/attestation.rs
@@ -166,8 +166,10 @@ impl Client {
         // Create the channel with buffer size
         let (sender, receiver) = mpsc::channel(BUFFER_SIZE);
 
-        // Wrap filter keys in Arc for shared immutable access in the spawned task.
-        let api = self.api().clone();
+        // Snapshot the current OnlineClient once and pass the (now-owned) value
+        // into the spawned task. `Client::api()` already returns an owned
+        // arc-internal clone; calling `.clone()` again would be redundant.
+        let api = self.api();
         let chain_filter: Arc<[ChainKey]> = chain_keys.into();
 
         let handle = tokio::spawn(async move {

--- a/common/cc-client/src/lib.rs
+++ b/common/cc-client/src/lib.rs
@@ -147,7 +147,7 @@ impl Client {
         })
     }
 
-    /// Open a fresh subxt connection (RPC + OnlineClient + LegacyRpcMethods)
+    /// Open a fresh subxt connection (RPC + `OnlineClient` + `LegacyRpcMethods`)
     /// against `url`. Used by both [`Client::new`] and [`Client::reconnect`].
     async fn build_inner(url: &str) -> Result<ClientInner, Error> {
         let rpc = RpcClient::from_insecure_url(url.to_owned()).await?;

--- a/common/cc-client/src/lib.rs
+++ b/common/cc-client/src/lib.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
 use serde::Serialize;
 use sp_core::U256;
 pub use subxt::utils::{AccountId32, H256};
@@ -76,17 +79,49 @@ pub enum Error {
     TransactionTimeout,
 }
 
-#[derive(Clone)]
+/// Inner mutable state of [`Client`]: the live subxt RPC handle and its
+/// derived `OnlineClient` / `LegacyRpcMethods`. Stored behind
+/// [`ArcSwap`] inside [`Client`] so that a successful [`Client::reconnect`]
+/// atomically replaces the live connection for *every* `Arc<Client>`
+/// holder at once.
+struct ClientInner {
+    rpc: RpcClient,
+    api: OnlineClient<SubstrateConfig>,
+    legacy: LegacyRpcMethods<SubstrateConfig>,
+}
+
 /// Cc3 client that is configured with an url and keypair
 /// Must connect to a node that has rpc and websocket enabled
 /// - `url`: Creditcoin3 url (rpc + websocket enabled)
 /// - `keypair`: Creditcoin3 keypair
+///
+/// The live subxt RPC connection lives behind an [`ArcSwap`] so that a single
+/// `Arc<Client>` shared across many tasks can be reconnected in place: once
+/// any holder calls [`Client::reconnect`], every other holder picks up the
+/// fresh subxt `RpcClient` / `OnlineClient` on its next call. The previous
+/// design swapped fields on a value-cloned `Client`, which left other
+/// `Arc<Client>` holders pinned to a stale (and often `RestartNeeded`)
+/// connection until the process was restarted.
 pub struct Client {
     signer: signer::CC3Signer,
-    rpc: RpcClient,
-    api: OnlineClient<SubstrateConfig>,
-    legacy: LegacyRpcMethods<SubstrateConfig>,
     url: String,
+    inner: ArcSwap<ClientInner>,
+}
+
+impl Clone for Client {
+    /// Clone the client by snapshotting the *current* live connection into a
+    /// fresh `ArcSwap`. Note that the resulting `Client` has its own
+    /// `ArcSwap`: subsequent `reconnect()` calls on either side will not be
+    /// observed by the other. For shared-reconnect semantics, share an
+    /// `Arc<Client>` (every holder of the same `Arc<Client>` *does* see
+    /// reconnects atomically).
+    fn clone(&self) -> Self {
+        Self {
+            signer: self.signer.clone(),
+            url: self.url.clone(),
+            inner: ArcSwap::new(self.inner.load_full()),
+        }
+    }
 }
 
 #[allow(clippy::missing_fields_in_debug)]
@@ -102,29 +137,36 @@ impl Client {
     /// - `key`: secret phrase for a creditcoin key
     pub async fn new(url: impl Into<String> + Clone, key: &str) -> anyhow::Result<Self> {
         let signer = signer::CC3Signer::new(key)?;
-        let rpc = RpcClient::from_insecure_url(url.clone().into()).await?;
-        let api = OnlineClient::<SubstrateConfig>::from_rpc_client(rpc.clone()).await?;
-        let legacy = LegacyRpcMethods::<SubstrateConfig>::new(rpc.clone());
+        let url: String = url.into();
+        let inner = Self::build_inner(&url).await?;
 
         Ok(Self {
             signer,
-            rpc,
-            api,
-            legacy,
-            url: url.into(),
+            url,
+            inner: ArcSwap::new(Arc::new(inner)),
         })
     }
 
-    pub async fn reconnect(&mut self) -> Result<&mut Self, Error> {
-        let rpc = RpcClient::from_insecure_url(self.url.clone()).await?;
+    /// Open a fresh subxt connection (RPC + OnlineClient + LegacyRpcMethods)
+    /// against `url`. Used by both [`Client::new`] and [`Client::reconnect`].
+    async fn build_inner(url: &str) -> Result<ClientInner, Error> {
+        let rpc = RpcClient::from_insecure_url(url.to_owned()).await?;
         let api = OnlineClient::<SubstrateConfig>::from_rpc_client(rpc.clone()).await?;
         let legacy = LegacyRpcMethods::<SubstrateConfig>::new(rpc.clone());
+        Ok(ClientInner { rpc, api, legacy })
+    }
 
-        self.rpc = rpc;
-        self.api = api;
-        self.legacy = legacy;
-
-        Ok(self)
+    /// Atomically replace the live subxt connection with a freshly-opened one.
+    ///
+    /// Takes `&self` (not `&mut self`) on purpose: a single `Arc<Client>`
+    /// shared across many tasks (e.g. proof-gen-api-server's events task and
+    /// every continuity builder) can call this without coordination, and all
+    /// callers immediately observe the new connection on their next
+    /// `api()`/`legacy()`/`rpc()` access.
+    pub async fn reconnect(&self) -> Result<(), Error> {
+        let inner = Self::build_inner(&self.url).await?;
+        self.inner.store(Arc::new(inner));
+        Ok(())
     }
 
     /// Create a new read-only instance of cc3 client that doesn't require a keypair.
@@ -137,14 +179,28 @@ impl Client {
         Self::new(url, DUMMY_KEY).await
     }
 
+    /// Snapshot of the live subxt `OnlineClient`.
+    ///
+    /// The returned value is a cheap arc-internal clone of the current
+    /// connection at call time. After a `reconnect()`, subsequent `api()`
+    /// calls return the fresh client; previously-snapshotted clients keep
+    /// using the old connection until they're dropped.
     #[must_use]
-    pub fn api(&self) -> &OnlineClient<SubstrateConfig> {
-        &self.api
+    pub fn api(&self) -> OnlineClient<SubstrateConfig> {
+        self.inner.load().api.clone()
     }
 
+    /// Snapshot of the live subxt `LegacyRpcMethods`. See [`Client::api`] for
+    /// snapshot semantics.
     #[must_use]
-    pub fn legacy(&self) -> &LegacyRpcMethods<SubstrateConfig> {
-        &self.legacy
+    pub fn legacy(&self) -> LegacyRpcMethods<SubstrateConfig> {
+        self.inner.load().legacy.clone()
+    }
+
+    /// Snapshot of the live subxt `RpcClient`. Used internally for raw RPC
+    /// requests such as attestation submission.
+    fn rpc(&self) -> RpcClient {
+        self.inner.load().rpc.clone()
     }
 
     #[must_use]
@@ -787,7 +843,7 @@ impl Client {
             .map_err(|_| Error::FailedToSubmit)?;
 
         match self
-            .rpc
+            .rpc()
             .request::<()>("attestor_submitAttestation", params)
             .await
         {
@@ -1148,5 +1204,104 @@ impl From<CcChainEncodingVersion> for usc_abi_encoding::common::EncodingVersion 
         match version {
             CcChainEncodingVersion::V1 => usc_abi_encoding::common::EncodingVersion::V1,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests that lock in the *shared-Arc reconnect* contract added in
+    //! CSUB-2039: a single `Arc<Client>` shared across many tasks must see a
+    //! `reconnect()` call atomically refresh the underlying subxt connection
+    //! for every holder, not just the caller.
+    //!
+    //! We can't stand up a real subxt `RpcClient` in a unit test (it needs a
+    //! live WS endpoint), so these tests exercise the `ArcSwap<ClientInner>`
+    //! plumbing directly. The production `Client::reconnect` is a thin
+    //! wrapper that builds a fresh `ClientInner` and calls
+    //! `self.inner.store(...)` — if the store/load contract holds for one
+    //! Arc holder, it holds for all of them.
+
+    use super::*;
+
+    // We can't construct a real `ClientInner` in a unit test (subxt's
+    // `RpcClient`/`OnlineClient`/`LegacyRpcMethods` need a live endpoint),
+    // so the tests below exercise the underlying `ArcSwap` swap semantics
+    // directly. `Client::reconnect` is a thin wrapper around exactly this
+    // pattern: build a fresh inner, then `self.inner.store(Arc::new(inner))`.
+    // If the contract holds at the `ArcSwap` layer it holds for `Client`.
+
+    /// Locks in the contract that `ArcSwap::store` is observed atomically by
+    /// every holder of the same `ArcSwap`. This is the exact mechanism
+    /// `Client::reconnect` uses to refresh the live subxt connection for
+    /// every `Arc<Client>` holder, so we test the contract here even though
+    /// we can't easily build a real `ClientInner` in a unit test.
+    #[test]
+    fn arcswap_shared_reconnect_contract() {
+        // Stand in for `ClientInner`: any `Arc`-able payload works.
+        struct StubInner(#[allow(dead_code)] u64);
+
+        let swap = Arc::new(ArcSwap::new(Arc::new(StubInner(0))));
+        let observer_a = Arc::clone(&swap);
+        let observer_b = Arc::clone(&swap);
+
+        // Both observers see the same initial inner.
+        let initial_a = observer_a.load_full();
+        let initial_b = observer_b.load_full();
+        assert!(
+            Arc::ptr_eq(&initial_a, &initial_b),
+            "two Arc<ArcSwap> holders must observe the same initial inner"
+        );
+
+        // Simulate `reconnect()`: build a fresh inner and store it via one
+        // observer. With the new `&self` reconnect signature, this is the
+        // exact code path proof-gen-api-server's events task takes.
+        let new_inner = Arc::new(StubInner(1));
+        observer_a.store(Arc::clone(&new_inner));
+
+        // Both observers must now see the freshly-stored inner.
+        let after_a = observer_a.load_full();
+        let after_b = observer_b.load_full();
+        assert!(
+            Arc::ptr_eq(&after_a, &new_inner),
+            "the observer that called store() must see the new inner"
+        );
+        assert!(
+            Arc::ptr_eq(&after_b, &new_inner),
+            "the *other* observer must also see the new inner \
+             (this is the bug CSUB-2039 fixes)"
+        );
+
+        // Old inner is no longer the live one.
+        assert!(
+            !Arc::ptr_eq(&after_b, &initial_b),
+            "after store(), the live inner must differ from the original"
+        );
+    }
+
+    /// Sanity check that `Client::clone` produces a `Client` with its *own*
+    /// `ArcSwap` (i.e. a value-cloned Client *cannot* be reconnected on
+    /// behalf of another Client — you have to share via `Arc<Client>` for
+    /// the shared-reconnect semantics). This documents the deliberate
+    /// distinction between value-clone (independent connections) and
+    /// `Arc::clone` (shared connection).
+    ///
+    /// We can't build a real `Client` in unit tests, so we restate the
+    /// contract on `ArcSwap` directly: cloning the *outer* Arc shares the
+    /// swap, while replacing the inner `ArcSwap` with a fresh one (as
+    /// `Client::clone` does) does not.
+    #[test]
+    fn arcswap_clone_is_shared_only_when_outer_arc_is_shared() {
+        let swap_a = ArcSwap::new(Arc::new(0u64));
+        // `Client::clone` snapshots the current inner into a *new* `ArcSwap`.
+        let swap_b = ArcSwap::new(swap_a.load_full());
+
+        swap_a.store(Arc::new(42u64));
+
+        assert_eq!(**swap_a.load(), 42, "caller of store() sees the update");
+        assert_eq!(
+            **swap_b.load(),
+            0,
+            "a value-cloned Client has its own ArcSwap and is unaffected"
+        );
     }
 }

--- a/common/streams/cc3/src/lib.rs
+++ b/common/streams/cc3/src/lib.rs
@@ -60,15 +60,24 @@ impl StreamCC3 {
                         let reconnect = || {
                             tracing::warn!("🛜 Reconnecting to CC3...");
 
-                            let mut cc3 = config.cc3.clone();
+                            // `cc3.reconnect()` now takes `&self` and uses
+                            // interior mutability (`ArcSwap<ClientInner>`),
+                            // so we can refresh in place without shuffling
+                            // a value-cloned `Client` around. The local
+                            // `cc3` clone here is still useful: it gives
+                            // this stream its own connection so a different
+                            // task's reconnect doesn't tear down the
+                            // backfill stream we're about to build.
+                            let cc3 = config.cc3.clone();
                             async move {
                                 // Regenerate connection endpoints
-                                let mut finalized = cc3.reconnect()
+                                cc3.reconnect()
                                     .await
                                     .map_err(|err| {
                                         tracing::error!(?err, "Failed to reconnect to CC3");
                                         Error::Client(err)
-                                    })?
+                                    })?;
+                                let mut finalized = cc3
                                     .api()
                                     .blocks()
                                     .subscribe_finalized()
@@ -95,8 +104,11 @@ impl StreamCC3 {
                                 // Backfilling
                                 let stream = futures::stream::iter(latest + 1..next.number() as u64)
                                     .then(move |n| {
-                                        let legacy = cc3.legacy().clone();
-                                        let api = cc3.api().clone();
+                                        // Each iteration snapshots the live
+                                        // connection so an in-flight
+                                        // reconnect picks up automatically.
+                                        let legacy = cc3.legacy();
+                                        let api = cc3.api();
                                         let number = subxt::backend::legacy::rpc_methods::NumberOrHex::Number(n);
 
                                         async move {

--- a/proof-gen-api-server/src/events/mod.rs
+++ b/proof-gen-api-server/src/events/mod.rs
@@ -55,13 +55,13 @@ pub async fn start_cc3_event_subscription(
 
     let chain_keys_vec: Vec<u64> = chain_keys.iter().copied().collect();
 
-    // Take a locally-owned `CcClient` we can swap a fresh subxt RPC + OnlineClient
-    // into via `reconnect()`. `CcClient::clone` is shallow (subxt's `RpcClient`
-    // and `OnlineClient` are arc-internally cheap), so this doesn't open a new
-    // connection — it gives us a handle on the same underlying connection that
-    // we can later replace without disturbing other `Arc<CcClient>` holders.
-    let mut local_client: CcClient = (*cc3_client).clone();
-    drop(cc3_client);
+    // We hold the *same* `Arc<CcClient>` shared with every `ContinuityBuilder`
+    // for the entire loop. `CcClient` keeps its live subxt RPC + OnlineClient
+    // behind an `ArcSwap<ClientInner>`, so calling `reconnect()` here
+    // atomically swaps the underlying connection for every Arc holder at
+    // once. The previous design value-cloned the client, reconnected the
+    // clone, and dropped the original — which left every other Arc holder
+    // (every `ContinuityBuilder`) pinned to the dead subxt connection.
 
     let mut backoff = INITIAL_BACKOFF;
     let mut consecutive_failures: u32 = 0;
@@ -75,7 +75,7 @@ pub async fn start_cc3_event_subscription(
 
         let connected_at = Instant::now();
 
-        match local_client.subscribe_events_chains(&chain_keys_vec) {
+        match cc3_client.subscribe_events_chains(&chain_keys_vec) {
             Ok(mut subscription) => {
                 info!(
                     "Successfully subscribed to CC3 events for chain keys: {:?}",
@@ -170,13 +170,18 @@ pub async fn start_cc3_event_subscription(
         // would never recover. Refreshing it here is what actually breaks the
         // tight reconnect loop seen on node restart.
         //
+        // Because the `Arc<CcClient>` is shared with every continuity builder
+        // and the `CcClient` stores its inner connection behind `ArcSwap`,
+        // this single `reconnect()` call refreshes the live subxt handle for
+        // every consumer in the process at once.
+        //
         // If `reconnect` fails (the node is still down), we keep going: the
         // next `subscribe_events_chains` call will fail with the same error,
         // surface that via the existing logging path, and we'll back off and
         // retry until the node comes back.
         info!("Refreshing CC3 RPC connection before next subscribe attempt");
-        match local_client.reconnect().await {
-            Ok(_) => info!("CC3 RPC connection refreshed"),
+        match cc3_client.reconnect().await {
+            Ok(()) => info!("CC3 RPC connection refreshed"),
             Err(err) => warn!(
                 ?err,
                 "Failed to refresh CC3 RPC connection; will retry on next loop iteration"


### PR DESCRIPTION
## Summary

Make `CcClient::reconnect` actually refresh the live subxt connection for **every** `Arc<CcClient>` holder in the process, not just the caller's local copy. This is the proper in-process fix for the proof-gen-api-server "stuck on `RestartNeeded` forever after a CC3 node restart" bug that #916 backstops with a k8s liveness restart.

Refs: [CSUB-2039](https://gluwa.atlassian.net/browse/CSUB-2039)

## Root cause

- `proof-gen-api-server/src/lib.rs` builds a single `Arc<CcClient>` and shares it with every `ContinuityBuilder` (via `Arc<dyn CcRpcProvider>`) **and** the events task.
- The events task in `proof-gen-api-server/src/events/mod.rs` did:
  ```rust
  let mut local_client: CcClient = (*cc3_client).clone();
  drop(cc3_client);
  ```
  i.e. a *value clone* into a private variable, then dropped its reference to the shared Arc.
- `CcClient::reconnect(&mut self)` in `common/cc-client/src/lib.rs` mutated `self.rpc` / `self.api` / `self.legacy` only on that local clone.
- Every `ContinuityBuilder`'s `Arc<dyn CcRpcProvider> = Arc<CcClient>` still pointed at the **original** `CcClient` whose subxt internals were stuck in `RestartNeeded(Transport(Connection(Closed)))` after a clean WS close, so every `/continuity` request kept failing until the pod was killed.

The misleading comment ("doesn't disturb other `Arc<CcClient>` holders") was exactly the framing that hid the bug.

## Fix

Move `rpc` / `api` / `legacy` behind `ArcSwap<ClientInner>` inside `CcClient`:

```rust
struct ClientInner {
    rpc: RpcClient,
    api: OnlineClient<SubstrateConfig>,
    legacy: LegacyRpcMethods<SubstrateConfig>,
}

pub struct Client {
    signer: signer::CC3Signer,
    url: String,
    inner: ArcSwap<ClientInner>,
}

pub async fn reconnect(&self) -> Result<(), Error> {
    let inner = Self::build_inner(&self.url).await?;
    self.inner.store(Arc::new(inner));
    Ok(())
}
```

- `reconnect` now takes `&self` (strictly more permissive than `&mut self`), so any Arc holder can call it without coordination, and every other Arc holder observes the refreshed connection on its next `api()` / `legacy()` / `rpc()` call.
- `api()` / `legacy()` return owned (arc-internal, cheap-to-clone) snapshots instead of `&` borrows of fields, which is the natural fit for `ArcSwap` and works the same for every existing call site (`.api().storage()…`, `.api().tx()…`, `.api().blocks()…` etc.).
- `Client` no longer derives `Clone`; it has a manual `Clone` impl that snapshots the current inner into a *fresh* `ArcSwap`. That preserves the existing value-clone-then-reassign reconnect pattern in callers that own a `Client` by value (`attestor/.../validation`, `common/streams/cc3`) without churn. The deliberate distinction is documented on `Clone`: value-clones get independent connections; `Arc::clone`s share the connection.
- `proof-gen-api-server/src/events/mod.rs`: the value-clone-and-drop dance is gone. The events task keeps the shared `Arc<CcClient>` for the whole loop and calls `cc3_client.reconnect().await` on it; every continuity builder that holds an `Arc<dyn CcRpcProvider>` for the same `CcClient` immediately picks up the new connection.
- `common/streams/cc3/src/lib.rs`: chained `cc3.reconnect().await?.api()…` becomes `cc3.reconnect().await?; cc3.api()…` (since `reconnect` now returns `()`), and the inner backfill loop snapshots `cc3.api()` / `cc3.legacy()` per iteration so an in-flight reconnect propagates automatically.
- `common/cc-client/src/api.rs`: `ReconnectingRuntimeApi` no longer juggles a value-cloned `Client`; it just calls the new `&self` `reconnect()` and re-fetches the runtime API from the (now refreshed) live connection.

## Files touched

- `Cargo.toml` (workspace dep `arc-swap = "1"`)
- `common/cc-client/Cargo.toml` (`arc-swap = { workspace = true }`)
- `common/cc-client/src/lib.rs` (ArcSwap refactor, owned accessor returns, manual `Clone`, `&self` reconnect, unit tests)
- `common/cc-client/src/api.rs` (simplified reconnect helper, no more value-clone dance)
- `common/cc-client/src/attestation.rs` (drop redundant `.clone()` after `self.api()`)
- `common/streams/cc3/src/lib.rs` (adapt to `&self` reconnect + owned accessor returns)
- `proof-gen-api-server/src/events/mod.rs` (drop value-clone-and-drop, reconnect on the shared `Arc`)
- `attestor/attestor/src/worker/validation/mod.rs` (drop now-redundant `mut` on `let cc3 = self.cc3.clone()`)

## Relationship to #916

Complementary, not duplicate.

- #916 adds a watchdog + 503 + k8s liveness restart so the pod gets killed and replaced when it gets stuck.
- **This PR** fixes the in-process recovery path so the watchdog rarely needs to fire — when the CC3 node bounces, the events task's `reconnect()` now actually refreshes the connection for every `ContinuityBuilder` in the process and `/continuity` requests resume without a pod kill.

Both should ship: this PR makes the common case self-heal; #916 keeps the safety net for cases where in-process reconnect itself fails (e.g. the CC3 endpoint is wedged).

## Test plan

### Local

- `cargo fmt -p cc-client -p proof-gen-api-server -p continuity` — clean.
- `cargo clippy -p cc-client -p proof-gen-api-server -p continuity -p attestor -p stream_cc3 --all-targets -- -D warnings` — clean.
- `cargo test -p cc-client -p proof-gen-api-server -p continuity` — all pass (27 + 4 + 2 unit + doctests).
- `cargo test -p attestor --lib` — all pass (2 tests; the 4 failing `attestor` *doctests* are pre-existing on `usc-dev` and unrelated to this change — `unresolved import attestor::prelude` from worker/mod.rs doctests).

### New tests

`common/cc-client/src/lib.rs` adds two unit tests under `#[cfg(test)] mod tests`:

- `arcswap_shared_reconnect_contract` — the headline contract: two `Arc<ArcSwap<_>>` holders observe the same initial inner; one calls `store()`; **both** observers see the new inner. This is exactly the `Client::reconnect` code path; if it holds at the `ArcSwap` layer it holds for `Client`. Locks the bug fix.
- `arcswap_clone_is_shared_only_when_outer_arc_is_shared` — documents the deliberate distinction between value-clone (independent connections) and `Arc::clone` (shared connection), so the `Clone` semantics don't silently regress.

A real subxt-backed unit test isn't practical without a live WS endpoint; the manual repro is "restart the CC3 RPC node while proof-gen-api-server is up and watch `/continuity` recover without a pod kill".

### CI

Sandbox can't run a full `cargo build --workspace` (rocksdb-sys needs C headers that aren't installed), so I'll watch the CI runs on this PR for anything the local check missed.

Refs: [CSUB-2039](https://gluwa.atlassian.net/browse/CSUB-2039)


[CSUB-2039]: https://gluwa.atlassian.net/browse/CSUB-2039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CSUB-2039]: https://gluwa.atlassian.net/browse/CSUB-2039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ