### PR TITLE
fix(proof-gen-api): bracket query with mixed cache halves

### DIFF
--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -26,7 +26,10 @@ impl ContinuityService {
     /// Build a continuity proof.
     ///
     /// Flow:
-    /// 1. Resolve checkpoint boundaries from local cache (attestation first, then checkpoint)
+    /// 1. Resolve checkpoint boundaries from local cache. Try attestation
+    ///    bounds first (tightest), then checkpoint bounds, then a mixed
+    ///    cross-cache bracket as a final fallback for the steady-state gap
+    ///    that follows a checkpoint prune (see [`ContinuityService::get_mixed_boundaries`]).
     /// 2. Build proof from eth provider roots (archiver or chain)
     pub(crate) async fn build_continuity(
         &self,
@@ -42,30 +45,20 @@ impl ContinuityService {
             })?;
 
         // Step 1: Resolve boundaries from local caches.
-        // Try attestation bounds first (more granular), then fall back to checkpoint bounds.
+        // Try attestation bounds first (more granular), fall back to checkpoint
+        // bounds, and finally to a mixed (one half from each cache) bracket
+        // before bailing.
         let (lower, lower_digest, upper, upper_digest) = if let Some(bounds) = self
             .get_attestation_boundaries(chain, min_query, max_query)
             .await
         {
-            tracing::debug!(
-                min_query,
-                max_query,
-                lower = bounds.0,
-                upper = bounds.2,
-                "resolved boundaries from attestation cache"
-            );
             bounds
         } else if let Some(bounds) = self
             .get_checkpoint_boundaries(chain, min_query, max_query)
             .await
         {
-            tracing::debug!(
-                min_query,
-                max_query,
-                lower = bounds.0,
-                upper = bounds.2,
-                "resolved boundaries from checkpoint cache"
-            );
+            bounds
+        } else if let Some(bounds) = self.get_mixed_boundaries(chain, min_query, max_query).await {
             bounds
         } else {
             return Err(self
@@ -815,5 +808,254 @@ mod tests {
         let chain = svc.chain_state(2).unwrap();
         let att = chain.attestation_cache.read().await;
         assert!(att.contains_key(&500), "chain 2 cache must be untouched");
+    }
+
+    // ---------------------------------------------------------------------
+    // Regression tests for the split-bracket bug:
+    //
+    // After a checkpoint at block H lands, `prune_attestations_at_or_below`
+    // drops every attestation `<= H`. A query for the very first attestation
+    // strictly above H then leaves the attestation cache with only the upper
+    // half (the queried block itself, no entry below) and the checkpoint cache
+    // with only the lower half (the checkpoint at H, no entry at or above
+    // until the next checkpoint lands). Each cache alone fails to bracket the
+    // query; mixing one half from each succeeds and is sound because both
+    // caches store on-chain digests for the same digest sequence.
+    // ---------------------------------------------------------------------
+
+    /// Reset both caches to a known minimal state that mirrors the
+    /// production split-bracket scenario:
+    ///   attestation_cache = { upper_block: <digest> }
+    ///   checkpoint_cache  = { lower_block: <digest> }
+    /// where `lower_block < upper_block` and neither cache has the other half.
+    async fn install_split_bracket(
+        chain: &Arc<ChainState>,
+        lower_checkpoint: u64,
+        lower_digest: H256,
+        upper_attestation: u64,
+        upper_digest: H256,
+    ) {
+        let mut att = chain.attestation_cache.write().await;
+        att.clear();
+        att.insert(upper_attestation, upper_digest);
+        drop(att);
+
+        let mut cp = chain.checkpoint_cache.write().await;
+        cp.clear();
+        cp.insert(lower_checkpoint, lower_digest);
+    }
+
+    #[tokio::test]
+    async fn split_bracket_each_cache_alone_fails() {
+        // Sanity check: confirm that the production split-bracket shape
+        // genuinely defeats both single-cache lookups. If this ever starts
+        // passing on its own, the mixed-bracket fallback would be unreachable
+        // and the regression test below would no longer cover what it claims.
+        let svc = make_service(Arc::new(FoundEthProvider)).await;
+        let chain = svc.chain_state(2).unwrap();
+
+        let lower = 10_797_800_u64;
+        let upper = 10_797_810_u64;
+        let lower_digest = H256::from_low_u64_be(0xA1);
+        let upper_digest = H256::from_low_u64_be(0xB2);
+        install_split_bracket(chain, lower, lower_digest, upper, upper_digest).await;
+
+        let att_only = svc.get_attestation_boundaries(chain, upper, upper).await;
+        assert!(
+            att_only.is_none(),
+            "attestation cache alone must not bracket the query (no lower half)"
+        );
+
+        let cp_only = svc.get_checkpoint_boundaries(chain, upper, upper).await;
+        assert!(
+            cp_only.is_none(),
+            "checkpoint cache alone must not bracket the query (no upper half)"
+        );
+    }
+
+    #[tokio::test]
+    async fn split_bracket_mixed_lookup_combines_cp_lower_with_att_upper() {
+        // Reproduces the dump shape from the production failure: query block
+        // 10_797_810 sits exactly at the smallest attestation cache key and
+        // exactly at the smallest cache key strictly above the latest
+        // checkpoint. Each cache holds only one half; the mixed lookup must
+        // combine `cp_lower` with `att_upper` and return both on-chain
+        // digests untouched so the proof builder can anchor the digest chain.
+        let svc = make_service(Arc::new(FoundEthProvider)).await;
+        let chain = svc.chain_state(2).unwrap();
+
+        let lower = 10_797_800_u64;
+        let upper = 10_797_810_u64;
+        let lower_digest = H256::from_low_u64_be(0xA1);
+        let upper_digest = H256::from_low_u64_be(0xB2);
+        install_split_bracket(chain, lower, lower_digest, upper, upper_digest).await;
+
+        let bounds = svc.get_mixed_boundaries(chain, upper, upper).await;
+        assert!(
+            bounds.is_some(),
+            "mixed lookup should bracket the query when each cache holds one half"
+        );
+        let (lo_block, lo_digest, up_block, up_digest) = bounds.unwrap();
+        assert_eq!(lo_block, lower, "lower must come from the checkpoint cache");
+        assert_eq!(
+            lo_digest, lower_digest,
+            "lower digest must be the on-chain checkpoint digest, untouched"
+        );
+        assert_eq!(
+            up_block, upper,
+            "upper must come from the attestation cache"
+        );
+        assert_eq!(
+            up_digest, upper_digest,
+            "upper digest must be the on-chain attestation digest, untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn split_bracket_mixed_lookup_falls_back_to_att_lower_with_cp_upper() {
+        // Symmetric case: the only half in the attestation cache is the
+        // lower, and the only half in the checkpoint cache is the upper.
+        // Mixed lookup must still bracket the query.
+        let svc = make_service(Arc::new(FoundEthProvider)).await;
+        let chain = svc.chain_state(2).unwrap();
+
+        let lower = 10_797_805_u64;
+        let upper = 10_797_900_u64;
+        let lower_digest = H256::from_low_u64_be(0xC3);
+        let upper_digest = H256::from_low_u64_be(0xD4);
+
+        // attestation cache holds the lower; checkpoint cache holds the upper.
+        let mut att = chain.attestation_cache.write().await;
+        att.clear();
+        att.insert(lower, lower_digest);
+        drop(att);
+
+        let mut cp = chain.checkpoint_cache.write().await;
+        cp.clear();
+        cp.insert(upper, upper_digest);
+        drop(cp);
+
+        let query = 10_797_810_u64;
+        let bounds = svc.get_mixed_boundaries(chain, query, query).await;
+        assert!(bounds.is_some(), "mixed lookup should bracket the query");
+        let (lo_block, lo_digest, up_block, up_digest) = bounds.unwrap();
+        assert_eq!(lo_block, lower);
+        assert_eq!(lo_digest, lower_digest);
+        assert_eq!(up_block, upper);
+        assert_eq!(up_digest, upper_digest);
+    }
+
+    #[tokio::test]
+    async fn split_bracket_mixed_lookup_prefers_attestation_upper_when_both_have_upper() {
+        // When both caches happen to expose an upper, the attestation upper
+        // is tighter and should win. Lower comes from the checkpoint cache
+        // because that path is tried first.
+        let svc = make_service(Arc::new(FoundEthProvider)).await;
+        let chain = svc.chain_state(2).unwrap();
+
+        let cp_lower = 10_797_800_u64;
+        let att_upper = 10_797_810_u64;
+        let cp_upper = 10_797_900_u64;
+        let cp_lower_digest = H256::from_low_u64_be(0xE5);
+        let att_upper_digest = H256::from_low_u64_be(0xF6);
+        let cp_upper_digest = H256::from_low_u64_be(0x07);
+
+        let mut att = chain.attestation_cache.write().await;
+        att.clear();
+        att.insert(att_upper, att_upper_digest);
+        drop(att);
+
+        let mut cp = chain.checkpoint_cache.write().await;
+        cp.clear();
+        cp.insert(cp_lower, cp_lower_digest);
+        cp.insert(cp_upper, cp_upper_digest);
+        drop(cp);
+
+        let bounds = svc.get_mixed_boundaries(chain, att_upper, att_upper).await;
+        let (lo_block, _, up_block, up_digest) =
+            bounds.expect("mixed lookup should resolve when both halves are present");
+        assert_eq!(lo_block, cp_lower);
+        assert_eq!(up_block, att_upper, "tighter attestation upper must win");
+        assert_eq!(up_digest, att_upper_digest);
+    }
+
+    #[tokio::test]
+    async fn split_bracket_mixed_lookup_returns_none_when_neither_half_pair_exists() {
+        // No lower in either cache → mixed lookup must still return None.
+        let svc = make_service(Arc::new(FoundEthProvider)).await;
+        let chain = svc.chain_state(2).unwrap();
+
+        let upper = 10_797_810_u64;
+        let upper_digest = H256::from_low_u64_be(0xB2);
+        let mut att = chain.attestation_cache.write().await;
+        att.clear();
+        att.insert(upper, upper_digest);
+        drop(att);
+
+        let mut cp = chain.checkpoint_cache.write().await;
+        cp.clear();
+        drop(cp);
+
+        let bounds = svc.get_mixed_boundaries(chain, upper, upper).await;
+        assert!(
+            bounds.is_none(),
+            "mixed lookup must not invent a lower anchor when neither cache has one"
+        );
+    }
+
+    #[tokio::test]
+    async fn split_bracket_mixed_lookup_does_not_mutate_caches() {
+        // The fallback is read-only: it must not insert, remove, or otherwise
+        // touch the cache contents. A future refactor that, for example,
+        // "backfills" the missing half across caches would silently shift the
+        // pruning invariant and is explicitly out of scope here.
+        let svc = make_service(Arc::new(FoundEthProvider)).await;
+        let chain = svc.chain_state(2).unwrap();
+
+        let lower = 10_797_800_u64;
+        let upper = 10_797_810_u64;
+        install_split_bracket(
+            chain,
+            lower,
+            H256::from_low_u64_be(1),
+            upper,
+            H256::from_low_u64_be(2),
+        )
+        .await;
+
+        let att_before: Vec<(u64, H256)> = chain
+            .attestation_cache
+            .read()
+            .await
+            .iter()
+            .map(|(&k, &v)| (k, v))
+            .collect();
+        let cp_before: Vec<(u64, H256)> = chain
+            .checkpoint_cache
+            .read()
+            .await
+            .iter()
+            .map(|(&k, &v)| (k, v))
+            .collect();
+
+        let _ = svc.get_mixed_boundaries(chain, upper, upper).await;
+
+        let att_after: Vec<(u64, H256)> = chain
+            .attestation_cache
+            .read()
+            .await
+            .iter()
+            .map(|(&k, &v)| (k, v))
+            .collect();
+        let cp_after: Vec<(u64, H256)> = chain
+            .checkpoint_cache
+            .read()
+            .await
+            .iter()
+            .map(|(&k, &v)| (k, v))
+            .collect();
+
+        assert_eq!(att_before, att_after, "attestation cache must be untouched");
+        assert_eq!(cp_before, cp_after, "checkpoint cache must be untouched");
     }
 }

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -52,13 +52,34 @@ impl ContinuityService {
             .get_attestation_boundaries(chain, min_query, max_query)
             .await
         {
+            tracing::debug!(
+                min_query,
+                max_query,
+                lower = bounds.0,
+                upper = bounds.2,
+                "resolved boundaries from attestation cache"
+            );
             bounds
         } else if let Some(bounds) = self
             .get_checkpoint_boundaries(chain, min_query, max_query)
             .await
         {
+            tracing::debug!(
+                min_query,
+                max_query,
+                lower = bounds.0,
+                upper = bounds.2,
+                "resolved boundaries from checkpoint cache"
+            );
             bounds
         } else if let Some(bounds) = self.get_mixed_boundaries(chain, min_query, max_query).await {
+            tracing::debug!(
+                min_query,
+                max_query,
+                lower = bounds.0,
+                upper = bounds.2,
+                "resolved boundaries from mixed cache bracket (one half per cache)"
+            );
             bounds
         } else {
             return Err(self

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -526,6 +526,61 @@ impl ContinuityService {
         }
     }
 
+    /// Look up boundaries that combine one half from each cache, used as a
+    /// fallback when neither the attestation cache nor the checkpoint cache
+    /// brackets the query on its own.
+    ///
+    /// Both caches store `(block_number, on_chain_digest)` pairs that anchor
+    /// the same digest sequence: a checkpoint at block `H` and an attestation
+    /// at block `H` reference the exact same on-chain root. The proof builder
+    /// only needs one anchor strictly below `min_query` and one anchor at or
+    /// above `max_query`; it does not care which cache they come from.
+    ///
+    /// This function exists to handle the steady state introduced by
+    /// [`Self::prune_attestations_at_or_below`]: when a checkpoint at block
+    /// `H` lands, all attestations `<= H` are dropped from the attestation
+    /// cache. A query for the very first post-checkpoint attestation block
+    /// then leaves the attestation cache with only the upper half (no entry
+    /// strictly below) and the checkpoint cache with only the lower half (no
+    /// entry at or above, since the next checkpoint has not landed yet).
+    /// Each cache alone fails to bracket the query, even though the two
+    /// halves together describe a perfectly valid anchor pair.
+    ///
+    /// Tries `(checkpoint_lower, attestation_upper)` first because the
+    /// attestation upper is tighter; falls back to
+    /// `(attestation_lower, checkpoint_upper)` for the symmetric case.
+    /// Returns `(lower_block, lower_digest, upper_block, upper_digest)` or
+    /// `None` if the two caches still cannot jointly bracket the query.
+    pub async fn get_mixed_boundaries(
+        &self,
+        chain: &Arc<ChainState>,
+        min_query: u64,
+        max_query: u64,
+    ) -> Option<(u64, H256, u64, H256)> {
+        let att = chain.attestation_cache.read().await;
+        let cp = chain.checkpoint_cache.read().await;
+
+        // Lower halves: greatest entry strictly before min_query.
+        let att_lower = att.range(..min_query).next_back().map(|(&k, &v)| (k, v));
+        let cp_lower = cp.range(..min_query).next_back().map(|(&k, &v)| (k, v));
+
+        // Upper halves: smallest entry at or above max_query.
+        let att_upper = att.range(max_query..).next().map(|(&k, &v)| (k, v));
+        let cp_upper = cp.range(max_query..).next().map(|(&k, &v)| (k, v));
+
+        // Prefer the attestation upper (tighter) paired with the checkpoint lower.
+        if let (Some((lo_block, lo_digest)), Some((up_block, up_digest))) = (cp_lower, att_upper) {
+            return Some((lo_block, lo_digest, up_block, up_digest));
+        }
+
+        // Symmetric fallback: attestation lower with checkpoint upper.
+        if let (Some((lo_block, lo_digest)), Some((up_block, up_digest))) = (att_lower, cp_upper) {
+            return Some((lo_block, lo_digest, up_block, up_digest));
+        }
+
+        None
+    }
+
     /// Look up checkpoint boundaries around a query range from the local cache.
     /// Returns `(lower_block, lower_digest, upper_block, upper_digest)` or `None` if not found.
     ///


### PR DESCRIPTION
## Problem

After #918 landed, `CheckpointReached` triggers `prune_attestations_at_or_below(checkpoint_height)`, which drops every attestation `<= checkpoint_height` from the proof-gen-api cache. The pruning itself is correct — the on-chain pallet evicts those entries from `AttestationRemovalQueues` once they exceed `AttestationRetentionDuration`, and serving proofs anchored on stale attestation digests would surface as `"Continuity proof does not match attestation or checkpoint"` at verify time.

The pruning leaves a structural gap, though. Once a checkpoint at block `H` lands, a query for the very first attestation block strictly above `H` (and before the next checkpoint lands) sees:

```
attestation_cache: lower=None,  upper=<query block itself>
checkpoint_cache:  lower=H,     upper=None
```

`build_continuity` tries the attestation cache, then falls back to the checkpoint cache, then bails. Each cache alone fails to bracket the query, so the request is rejected even though the two halves together describe a valid `(lower, upper)` anchor pair.

Production dump that motivated this:

```
min_query=max_query=10797810
checkpoint cache: greatest_strictly_before=Some(10797800), smallest_at_or_after=None
attestation cache: greatest_strictly_before=None,           smallest_at_or_after=Some(10797810)
```

## Fix

Add a third fallback arm `get_mixed_boundaries` to `build_continuity`. It reads both caches and returns the first viable cross-cache pair:

1. `(checkpoint_lower, attestation_upper)` — preferred because the attestation upper is tighter
2. `(attestation_lower, checkpoint_upper)` — symmetric fallback

Soundness: both caches store `(block_number, on_chain_digest)` pairs that anchor the same digest sequence. A checkpoint at block `H` and an attestation at block `H` reference the same on-chain root. `build_proof_from_roots` only requires:
- `lower < min_query` (anchor we extend from)
- `upper >= max_query` (anchor we verify against)

It does not care which cache the anchor came from, and it already reconciles the upper digest after building (`helpers.rs:127-145`), so a faulty cross-cache pair would be rejected by the same path that catches a faulty same-cache pair.

No pallet, retention, or prune-semantics changes. Read-only on both caches.

## Why not loosen the prune?

Considered and rejected. The prune doc-comment already explains it: any attestation we keep past the on-chain queue eviction window points at a digest the verifier no longer recognizes. Mirroring `AttestationRetentionDuration` exactly would couple the off-chain cache to per-chain mutable governance state, race the pallet's eviction, and only paper over the bug — wherever the post-prune attestation floor sits, the same `range(..floor)` empty-set issue still exists at that floor block. The fix here is independent of retention and closes the gap rather than reducing its frequency.

## Tests

Six new regression tests in `helpers.rs`:

- `split_bracket_each_cache_alone_fails` — sanity check that the production shape genuinely defeats both single-cache lookups
- `split_bracket_mixed_lookup_combines_cp_lower_with_att_upper` — exact reproduction of the dump (block `10_797_810`)
- `split_bracket_mixed_lookup_falls_back_to_att_lower_with_cp_upper` — symmetric case
- `split_bracket_mixed_lookup_prefers_attestation_upper_when_both_have_upper` — tie-breaker (tighter upper wins)
- `split_bracket_mixed_lookup_returns_none_when_neither_half_pair_exists` — no-anchor case
- `split_bracket_mixed_lookup_does_not_mutate_caches` — read-only invariant; locks out future "backfill" refactors

All 22 tests in the module pass; `cargo fmt` and `cargo clippy --tests -D warnings` clean.
