### PR TITLE
feat(proof-gen-api-server): emoji prefixes for log lines

### DIFF
--- a/common/cc-client/src/attestation.rs
+++ b/common/cc-client/src/attestation.rs
@@ -176,11 +176,11 @@ impl Client {
             let mut blocks_sub = match api.blocks().subscribe_finalized().await {
                 Ok(sub) => sub,
                 Err(e) => {
-                    error!("Failed to start finalized-block subscription: {e:?}");
+                    error!("❌ 🔗 Failed to start finalized-block subscription: {e:?}");
                     return Err(Error::SubscriptionConnectionLost(e));
                 }
             };
-            info!("Subscription started, streaming finalized blocks...");
+            info!("🔗 📡 Subscription started, streaming finalized blocks...");
 
             loop {
                 match blocks_sub.next().await {

--- a/common/continuity/src/archiver.rs
+++ b/common/continuity/src/archiver.rs
@@ -8,7 +8,8 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use attestor_primitives::block::Block;
 use sp_core::H256;
-use tracing::{debug, info};
+use std::time::Instant;
+use tracing::{debug, info, warn};
 
 use crate::rpc::{EthRpcProvider, SharedEthProvider};
 
@@ -45,17 +46,63 @@ impl ArchiverClient {
     /// Fetch merkle roots for an inclusive block range [from, to].
     pub async fn get_roots(&self, from: u64, to: u64) -> Result<Vec<(u64, H256)>> {
         let url = format!("{}/roots?from={}&to={}", self.base_url, from, to);
-        let entries: Vec<RootEntry> = self
+        let span = (to.saturating_sub(from)).saturating_add(1);
+        debug!(
+            archiver_url = %self.base_url,
+            from,
+            to,
+            span,
+            "📡 ➡️  archiver GET /roots"
+        );
+
+        let started = Instant::now();
+        let response = self
             .http
             .get(&url)
             .send()
             .await
-            .context("archiver request failed")?
+            .with_context(|| {
+                let elapsed_ms = started.elapsed().as_millis();
+                warn!(
+                    archiver_url = %self.base_url,
+                    from,
+                    to,
+                    span,
+                    duration_ms = elapsed_ms,
+                    "📡 ❌ archiver GET /roots transport error"
+                );
+                "archiver request failed"
+            })?
             .error_for_status()
-            .context("archiver returned error status")?
+            .with_context(|| {
+                let elapsed_ms = started.elapsed().as_millis();
+                warn!(
+                    archiver_url = %self.base_url,
+                    from,
+                    to,
+                    span,
+                    duration_ms = elapsed_ms,
+                    "📡 ❌ archiver GET /roots non-success status"
+                );
+                "archiver returned error status"
+            })?;
+
+        let status = response.status();
+        let entries: Vec<RootEntry> = response
             .json()
             .await
             .context("failed to parse archiver response")?;
+        let elapsed_ms = started.elapsed().as_millis();
+        info!(
+            archiver_url = %self.base_url,
+            from,
+            to,
+            span,
+            count = entries.len(),
+            status = %status,
+            duration_ms = elapsed_ms,
+            "📡 ✅ archiver GET /roots completed"
+        );
 
         entries
             .into_iter()
@@ -70,17 +117,32 @@ impl ArchiverClient {
     /// Get the latest archived block number.
     pub async fn get_latest_block(&self) -> Result<Option<u64>> {
         let url = format!("{}/roots/latest", self.base_url);
-        let resp: LatestResponse = self
+        debug!(
+            archiver_url = %self.base_url,
+            "📡 ➡️  archiver GET /roots/latest"
+        );
+        let started = Instant::now();
+        let response = self
             .http
             .get(&url)
             .send()
             .await
             .context("archiver request failed")?
             .error_for_status()
-            .context("archiver returned error status")?
+            .context("archiver returned error status")?;
+        let status = response.status();
+        let resp: LatestResponse = response
             .json()
             .await
             .context("failed to parse archiver response")?;
+        let elapsed_ms = started.elapsed().as_millis();
+        info!(
+            archiver_url = %self.base_url,
+            latest_block = ?resp.latest_block,
+            status = %status,
+            duration_ms = elapsed_ms,
+            "📡 ✅ archiver GET /roots/latest completed"
+        );
         Ok(resp.latest_block)
     }
 }
@@ -109,7 +171,7 @@ impl EthRpcProvider for ArchiverEthProvider {
         start: u64,
         end: u64,
     ) -> Result<Vec<Block>> {
-        debug!(start, end, "fetching roots from archiver");
+        debug!(start, end, "🔧 📡 fetching roots from archiver");
 
         let roots = self.archiver.get_roots(start, end).await.with_context(|| {
             format!("failed to get roots from archiver for range {start}..{end}")
@@ -140,7 +202,7 @@ impl EthRpcProvider for ArchiverEthProvider {
             count = blocks.len(),
             start = blocks.first().map(|b| b.n()),
             end = blocks.last().map(|b| b.n()),
-            "built continuity blocks from archiver roots"
+            "🔧 🧱 built continuity blocks from archiver roots"
         );
 
         Ok(blocks)

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -327,7 +327,7 @@ impl Client {
             }
         };
 
-        info!("Connecting to Ethereum node at {}", url);
+        info!("🚀 🌐 Connecting to Ethereum node at {}", url);
 
         let chain_id = rpc_provider
             .get_chain_id()

--- a/proof-gen-api-server/src/events/mod.rs
+++ b/proof-gen-api-server/src/events/mod.rs
@@ -70,7 +70,7 @@ pub async fn start_cc3_event_subscription(
         info!(
             ?chain_keys,
             attempt = consecutive_failures + 1,
-            "Starting CC3 event subscription (single task, multi-chain filter)"
+            "🔗 Starting CC3 event subscription (single task, multi-chain filter)"
         );
 
         let connected_at = Instant::now();
@@ -78,7 +78,7 @@ pub async fn start_cc3_event_subscription(
         match cc3_client.subscribe_events_chains(&chain_keys_vec) {
             Ok(mut subscription) => {
                 info!(
-                    "Successfully subscribed to CC3 events for chain keys: {:?}",
+                    "🔗 Successfully subscribed to CC3 events for chain keys: {:?}",
                     chain_keys
                 );
 
@@ -93,7 +93,7 @@ pub async fn start_cc3_event_subscription(
                             )
                             .await
                             {
-                                error!("Failed to process CC3 event: {e}");
+                                error!("❌ 🔗 Failed to process CC3 event: {e}");
                             }
                         }
                         None => {
@@ -106,20 +106,20 @@ pub async fn start_cc3_event_subscription(
                                     error!(
                                         connection_duration_secs =
                                             connection_duration.as_secs_f64(),
-                                        "CC3 event subscription terminated with error: {err:?}"
+                                        "❌ 🔗 CC3 event subscription terminated with error: {err:?}"
                                     );
                                 }
                                 Ok(None) => {
                                     warn!(
                                         connection_duration_secs = connection_duration.as_secs_f64(),
-                                        "CC3 event subscription closed cleanly by backend (no error reported)"
+                                        "⚠️ 🔗 CC3 event subscription closed cleanly by backend (no error reported)"
                                     );
                                 }
                                 Err(join_err) => {
                                     error!(
                                         connection_duration_secs =
                                             connection_duration.as_secs_f64(),
-                                        "CC3 event subscription task panicked: {join_err:?}"
+                                        "💥 🔗 CC3 event subscription task panicked: {join_err:?}"
                                     );
                                 }
                             }
@@ -131,7 +131,7 @@ pub async fn start_cc3_event_subscription(
             Err(e) => {
                 error!(
                     attempt = consecutive_failures + 1,
-                    "Failed to subscribe to CC3 events: {e:?}"
+                    "❌ 🔗 Failed to subscribe to CC3 events: {e:?}"
                 );
             }
         }
@@ -146,7 +146,7 @@ pub async fn start_cc3_event_subscription(
             if backoff != INITIAL_BACKOFF {
                 info!(
                     connection_duration_secs = connection_duration.as_secs_f64(),
-                    "Resetting CC3 reconnect backoff after a healthy connection"
+                    "🔄 🔗 Resetting CC3 reconnect backoff after a healthy connection"
                 );
             }
             backoff = INITIAL_BACKOFF;
@@ -157,7 +157,7 @@ pub async fn start_cc3_event_subscription(
 
         warn!(
             backoff_secs = backoff.as_secs_f64(),
-            consecutive_failures, "Reconnecting CC3 event subscription"
+            consecutive_failures, "🔄 🔗 Reconnecting CC3 event subscription"
         );
         tokio::time::sleep(backoff).await;
         backoff = (backoff * 2).min(MAX_BACKOFF);
@@ -179,12 +179,12 @@ pub async fn start_cc3_event_subscription(
         // next `subscribe_events_chains` call will fail with the same error,
         // surface that via the existing logging path, and we'll back off and
         // retry until the node comes back.
-        info!("Refreshing CC3 RPC connection before next subscribe attempt");
+        info!("🔄 🔗 Refreshing CC3 RPC connection before next subscribe attempt");
         match cc3_client.reconnect().await {
-            Ok(()) => info!("CC3 RPC connection refreshed"),
+            Ok(()) => info!("✅ 🔗 CC3 RPC connection refreshed"),
             Err(err) => warn!(
                 ?err,
-                "Failed to refresh CC3 RPC connection; will retry on next loop iteration"
+                "⚠️ 🔗 Failed to refresh CC3 RPC connection; will retry on next loop iteration"
             ),
         }
     }
@@ -206,7 +206,7 @@ async fn process_cc_event(
             let header_number = metadata.header_number;
             let digest = metadata.digest;
             info!(
-                "Processing BlockAttested event: chain_key={chain_key}, header_number={header_number}, digest={digest:?}"
+                "🔗 📜 Processing BlockAttested event: chain_key={chain_key}, header_number={header_number}, digest={digest:?}"
             );
 
             if let Ok(mut cache) = LAST_ATTESTATIONS.lock() {
@@ -229,7 +229,7 @@ async fn process_cc_event(
                 .insert_attestation(chain_key, header_number, digest)
                 .await;
 
-            info!("Cached attestation in-memory: chain_key={chain_key}, header_number={header_number}");
+            info!("🔗 📦 Cached attestation in-memory: chain_key={chain_key}, header_number={header_number}");
 
             Ok(())
         }
@@ -241,7 +241,7 @@ async fn process_cc_event(
             let block_number = checkpoint.block_number;
             let digest = checkpoint.digest;
             info!(
-                "Processing CheckpointReached event: chain_key={event_chain_key}, block_number={block_number}, digest={digest:?}"
+                "🔗 🚩 Processing CheckpointReached event: chain_key={event_chain_key}, block_number={block_number}, digest={digest:?}"
             );
 
             let mut checkpoint_blocks = last_checkpoint_blocks.write().await;
@@ -249,7 +249,7 @@ async fn process_cc_event(
             if block_number > current_last {
                 checkpoint_blocks.insert(*event_chain_key, block_number);
                 info!(
-                    "✅ Updated last checkpoint block for chain {event_chain_key} to {}",
+                    "🔗 ✅ Updated last checkpoint block for chain {event_chain_key} to {}",
                     block_number
                 );
 
@@ -279,7 +279,7 @@ async fn process_cc_event(
             }
             let interval_u64 = *new_interval;
             info!(
-                "⚙️  Checkpoint interval changed for chain {event_chain_key}: {} attestations",
+                "🔗 ⚙️  Checkpoint interval changed for chain {event_chain_key}: {} attestations",
                 interval_u64
             );
 
@@ -287,7 +287,7 @@ async fn process_cc_event(
             intervals.insert(*event_chain_key, interval_u64);
 
             info!(
-                "✅ Updated checkpoint interval for chain {event_chain_key} to {}",
+                "🔗 ✅ Updated checkpoint interval for chain {event_chain_key} to {}",
                 interval_u64
             );
 
@@ -299,7 +299,7 @@ async fn process_cc_event(
             }
             let new_genesis = *new_genesis;
             info!(
-                "⚙️  Chain genesis block changed for chain {event_chain_key}: {}",
+                "🔗 ⚙️  Chain genesis block changed for chain {event_chain_key}: {}",
                 new_genesis
             );
 
@@ -308,7 +308,7 @@ async fn process_cc_event(
                 .await;
 
             info!(
-                "✅ Updated chain genesis block for chain {event_chain_key} to {}",
+                "🔗 ✅ Updated chain genesis block for chain {event_chain_key} to {}",
                 new_genesis
             );
 
@@ -322,7 +322,7 @@ async fn process_cc_event(
 
             let revert_height = *checkpoint_height;
             warn!(
-                "⚠️  Attestation chain reversion detected for chain {chain_key}: \
+                "🔗 ⚠️  Attestation chain reversion detected for chain {chain_key}: \
                  reverting caches to height {revert_height}"
             );
 
@@ -337,7 +337,7 @@ async fn process_cc_event(
             last_checkpoint_blocks.write().await.remove(&chain_key);
 
             info!(
-                "✅ Attestation chain reversion handled for chain {chain_key} \
+                "🔗 ✅ Attestation chain reversion handled for chain {chain_key} \
                  (reverted to height {revert_height})"
             );
 

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -47,12 +47,12 @@ impl Server {
     pub async fn new(config: Config) -> Result<Self> {
         let chain_keys: Vec<u64> = config.chains.iter().map(|c| c.chain_key).collect();
         let prom_metrics = Arc::new(ProofGenMetrics::new(&chain_keys));
-        info!("📈 Prometheus metrics available at /metrics");
+        info!("🚀 📈 Prometheus metrics available at /metrics");
 
         debug!(
             cc3_rpc_url = %config.cc3_rpc_url,
             chain_count = config.chains.len(),
-            "[startup] connecting Creditcoin3 read-only client (cc3_rpc_url)"
+            "🚀 [startup] connecting Creditcoin3 read-only client (cc3_rpc_url)"
         );
         let cc3_client = Arc::<CcClient>::new(
             CcClient::new_read_only(&config.cc3_rpc_url)
@@ -65,7 +65,7 @@ impl Server {
                     )
                 })?,
         );
-        debug!("[startup] Creditcoin3 client connected");
+        debug!("🚀 ✅ [startup] Creditcoin3 client connected");
 
         let mut builders: Vec<Arc<ContinuityBuilder>> = Vec::with_capacity(config.chains.len());
         let checkpoint_intervals = Arc::new(RwLock::new(HashMap::new()));
@@ -78,7 +78,7 @@ impl Server {
                 chain_key = chain.chain_key,
                 eth_rpc_url = %redact_url_query(&chain.eth_rpc_url),
                 archiver_url = ?chain.archiver_url.as_ref().map(|u| redact_url_query(u)),
-                "[startup] configuring source chain"
+                "🚀 [startup] configuring source chain"
             );
             let builder = Self::build_continuity_for_chain(
                 &config,
@@ -131,7 +131,7 @@ impl Server {
                 redis_url = %redact_url_query(redis_url),
                 cluster_mode = global.redis_cluster_mode,
                 eth_rpc_url = %redact_url_query(&chain.eth_rpc_url),
-                "[startup] connecting source chain ETH client with Redis block cache"
+                "🚀 [startup] connecting source chain ETH client with Redis block cache"
             );
             let block_cache_metrics = prom_metrics.block_cache_metrics();
             let cache_config = eth::block_cache::BlockCacheConfig {
@@ -152,7 +152,7 @@ impl Server {
             debug!(
                 chain_key,
                 eth_rpc_url = %redact_url_query(&chain.eth_rpc_url),
-                "[startup] connecting source chain ETH client (no Redis)"
+                "🚀 [startup] connecting source chain ETH client (no Redis)"
             );
             EthClient::new(&chain.eth_rpc_url, None)
                 .await
@@ -242,7 +242,7 @@ impl Server {
                 debug!(
                     chain_key,
                     archiver_url = %redact_url_query(archiver_url),
-                    "[startup] wrapping ETH client with archiver HTTP provider"
+                    "🚀 [startup] wrapping ETH client with archiver HTTP provider"
                 );
                 Arc::new(continuity::archiver::ArchiverEthProvider::new(
                     archiver_url.clone(),
@@ -254,7 +254,7 @@ impl Server {
 
         debug!(
             chain_key,
-            "[startup] building ContinuityBuilder (continuity + CC3 + source chain providers)"
+            "🚀 [startup] building ContinuityBuilder (continuity + CC3 + source chain providers)"
         );
         let builder = Arc::new(ContinuityBuilder::new_with_providers(
             continuity_config,
@@ -298,7 +298,7 @@ impl Server {
         let server = run_http_server(app, bind_addr, http_shutdown_rx);
         tokio::pin!(server);
 
-        info!("Server listening on {bind_addr}");
+        info!("🚀 🌐 Server listening on {bind_addr}");
 
         let cc3_client_clone = self.cc3_client.clone();
         let checkpoint_intervals_clone = self.checkpoint_intervals.clone();
@@ -313,7 +313,7 @@ impl Server {
             )
             .await
             {
-                error!("CC3 event subscription failed: {e}");
+                error!("❌ 🔗 CC3 event subscription failed: {e}");
             }
         });
 
@@ -372,5 +372,5 @@ pub async fn shutdown_signal() {
         _ = terminate => {}
     }
 
-    info!("Shutdown signal received");
+    info!("🛑 Shutdown signal received");
 }

--- a/proof-gen-api-server/src/networking/mod.rs
+++ b/proof-gen-api-server/src/networking/mod.rs
@@ -111,7 +111,7 @@ pub fn build_app(
                     )
                 })
                 .on_request(|_request: &axum::http::Request<_>, _span: &tracing::Span| {
-                    tracing::event!(Level::INFO, "Incoming request");
+                    tracing::event!(Level::INFO, "🌐 ⬇️  Incoming request");
                 })
                 .on_response(
                     |_response: &axum::http::Response<_>,
@@ -121,7 +121,7 @@ pub fn build_app(
                             Level::INFO,
                             latency_ms = latency.as_millis(),
                             status = %_response.status(),
-                            "Request completed"
+                            "🌐 ✅ Request completed"
                         );
                     },
                 ),

--- a/proof-gen-api-server/src/networking/routes/continuity.rs
+++ b/proof-gen-api-server/src/networking/routes/continuity.rs
@@ -49,7 +49,7 @@ pub async fn get_proof_with_tx(
                 header_number = r.header_number,
                 tx_index = r.tx_index,
                 cached = r.cached,
-                "Request served"
+                "🌐 ✅ Request served"
             )
         })
         .map(ContinuityResponse::from)
@@ -85,7 +85,7 @@ pub async fn get_proof_by_tx_hash(
     service
         .get_proof_by_tx_hash(&chain.state, tx_hash.clone())
         .await
-        .inspect(|r| tracing::info!(chain_key = chain.key, %tx_hash, header_number = r.header_number, cached = r.cached, "Request served"))
+        .inspect(|r| tracing::info!(chain_key = chain.key, %tx_hash, header_number = r.header_number, cached = r.cached, "🌐 ✅ Request served"))
         .map(ContinuityResponse::from)
         .map(Json)
         .map_err(|e| {
@@ -166,7 +166,7 @@ pub async fn get_proof_batch(
                 from_header = r.from_header,
                 to_header = r.to_header,
                 cached = r.cached,
-                "Batch request served"
+                "🌐 ✅ 📦 Batch request served"
             )
         })
         .map(ContinuityResponse::from)
@@ -227,7 +227,7 @@ pub async fn get_proof_batch_by_tx_hash(
                 from_header = r.from_header,
                 to_header = r.to_header,
                 cached = r.cached,
-                "Batch request served"
+                "🌐 ✅ 📦 Batch request served"
             )
         })
         .map(ContinuityResponse::from)

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -57,7 +57,7 @@ impl ContinuityService {
                 max_query,
                 lower = bounds.0,
                 upper = bounds.2,
-                "resolved boundaries from attestation cache"
+                "🔧 🔍 resolved boundaries from attestation cache"
             );
             bounds
         } else if let Some(bounds) = self
@@ -69,7 +69,7 @@ impl ContinuityService {
                 max_query,
                 lower = bounds.0,
                 upper = bounds.2,
-                "resolved boundaries from checkpoint cache"
+                "🔧 🔍 resolved boundaries from checkpoint cache"
             );
             bounds
         } else if let Some(bounds) = self.get_mixed_boundaries(chain, min_query, max_query).await {
@@ -78,7 +78,7 @@ impl ContinuityService {
                 max_query,
                 lower = bounds.0,
                 upper = bounds.2,
-                "resolved boundaries from mixed cache bracket (one half per cache)"
+                "🔧 🔍 resolved boundaries from mixed cache bracket (one half per cache)"
             );
             bounds
         } else {
@@ -116,7 +116,7 @@ impl ContinuityService {
             upper_checkpoint,
             ?upper_checkpoint_digest,
             min_query,
-            "building proof from eth provider roots"
+            "🔧 🛠️  building proof from eth provider roots"
         );
 
         // Start the digest chain from the lower checkpoint's known on-chain digest.
@@ -147,7 +147,7 @@ impl ContinuityService {
                     upper_checkpoint,
                     expected = ?upper_checkpoint_digest,
                     computed = ?d,
-                    "continuity upper-boundary digest mismatch"
+                    "🔧 ❌ continuity upper-boundary digest mismatch"
                 );
                 return Err(ServiceError::Internal {
                     message: format!(
@@ -161,7 +161,7 @@ impl ContinuityService {
                     upper_checkpoint,
                     build_from,
                     n_blocks = blocks.len(),
-                    "eth provider returned no block at upper checkpoint boundary"
+                    "🔧 ❌ eth provider returned no block at upper checkpoint boundary"
                 );
                 return Err(ServiceError::Internal {
                     message: format!(

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -484,7 +484,7 @@ impl ContinuityService {
                     height,
                     removed,
                     remaining = att.len(),
-                    "🔧 🧦 pruned consumed attestations after checkpoint"
+                    "🔧 🧹 pruned consumed attestations after checkpoint"
                 );
             }
         }

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -188,7 +188,7 @@ impl ContinuityService {
             // Fetch genesis block at startup - fail fast if RPC is unavailable
             tracing::debug!(
                 chain_key,
-                "[startup] ContinuityService: fetching attestation genesis block from CC3"
+                "🚀 🔗 [startup] ContinuityService: fetching attestation genesis block from CC3"
             );
             let attestation_genesis_block = builder
                 .get_attestation_genesis_block()
@@ -202,13 +202,13 @@ impl ContinuityService {
             tracing::debug!(
                 chain_key,
                 attestation_genesis_block,
-                "ContinuityService chain initialized with attestation genesis block"
+                "🚀 ✅ ContinuityService chain initialized with attestation genesis block"
             );
 
             // Populate checkpoint cache from CC3 on startup.
             tracing::debug!(
                 chain_key,
-                "⏳ Populating checkpoint cache from CC3 (this may take a while)..."
+                "🚀 ⏳ 📝 Populating checkpoint cache from CC3 (this may take a while)..."
             );
             let checkpoints = builder
                 .cc_provider
@@ -217,7 +217,7 @@ impl ContinuityService {
                 .unwrap_or_else(|e| {
                     tracing::warn!(
                         chain_key,
-                        "Failed to fetch checkpoints on startup: {e}, starting with empty cache"
+                        "⚠️ 🔗 Failed to fetch checkpoints on startup: {e}, starting with empty cache"
                     );
                     Vec::new()
                 });
@@ -229,13 +229,13 @@ impl ContinuityService {
                 chain_key,
                 count = checkpoint_map.len(),
                 latest = ?checkpoint_map.keys().next_back(),
-                "Checkpoint cache populated from CC3"
+                "🚀 ✅ 📝 Checkpoint cache populated from CC3"
             );
 
             // Populate attestation cache from CC3 on startup.
             tracing::debug!(
                 chain_key,
-                "⏳ Populating attestation cache from CC3 (this may take a while)..."
+                "🚀 ⏳ 📜 Populating attestation cache from CC3 (this may take a while)..."
             );
             let attestations = builder
                 .cc_provider
@@ -244,7 +244,7 @@ impl ContinuityService {
                 .unwrap_or_else(|e| {
                     tracing::warn!(
                         chain_key,
-                        "Failed to fetch attestations on startup: {e}, starting with empty cache"
+                        "⚠️ 🔗 Failed to fetch attestations on startup: {e}, starting with empty cache"
                     );
                     Vec::new()
                 });
@@ -256,7 +256,7 @@ impl ContinuityService {
                 chain_key,
                 count = attestation_map.len(),
                 latest = ?attestation_map.keys().next_back(),
-                "Attestation cache populated from CC3"
+                "🚀 ✅ 📜 Attestation cache populated from CC3"
             );
 
             chains.insert(
@@ -323,7 +323,7 @@ impl ContinuityService {
                 requested_block = header_number,
                 genesis_block,
                 chain_key,
-                "Requested block is before or at attestation genesis"
+                "⚠️  Requested block is before or at attestation genesis"
             );
             return Err(ServiceError::BlockBeforeOrAtGenesis {
                 requested_block: header_number,
@@ -351,7 +351,7 @@ impl ContinuityService {
                 confirmed_block,
                 chain_key,
                 block_confirmation_depth = chain.builder.config.block_confirmation_depth,
-                "Requested block is not yet confirmed on source chain (within reorg window)"
+                "⚠️  ⛓️ Requested block is not yet confirmed on source chain (within reorg window)"
             );
             return Err(ServiceError::BlockNotOnSourceChain {
                 requested_block: header_number,
@@ -407,7 +407,12 @@ impl ContinuityService {
                 .write()
                 .await
                 .insert(block_number, digest);
-            tracing::debug!(chain_key, block_number, ?digest, "attestation cached");
+            tracing::debug!(
+                chain_key,
+                block_number,
+                ?digest,
+                "🔧 📦 📜 attestation cached"
+            );
         }
     }
 
@@ -427,7 +432,7 @@ impl ContinuityService {
                     revert_height,
                     removed,
                     remaining = att.len(),
-                    "Reverted attestation cache"
+                    "🔧 ↩️  Reverted attestation cache"
                 );
             }
 
@@ -439,7 +444,7 @@ impl ContinuityService {
                     revert_height,
                     removed,
                     remaining = cp.len(),
-                    "Reverted checkpoint cache"
+                    "🔧 ↩️  Reverted checkpoint cache"
                 );
             }
 
@@ -479,7 +484,7 @@ impl ContinuityService {
                     height,
                     removed,
                     remaining = att.len(),
-                    "pruned consumed attestations after checkpoint"
+                    "🔧 🧦 pruned consumed attestations after checkpoint"
                 );
             }
         }
@@ -493,7 +498,12 @@ impl ContinuityService {
                 .write()
                 .await
                 .insert(block_number, digest);
-            tracing::debug!(chain_key, block_number, ?digest, "checkpoint cached");
+            tracing::debug!(
+                chain_key,
+                block_number,
+                ?digest,
+                "🔧 📦 🚩 checkpoint cached"
+            );
         }
     }
 
@@ -688,7 +698,7 @@ impl ContinuityService {
                 max_query,
                 last_coverage,
                 %ops,
-                "boundary miss: returning BlockNotReady to client"
+                "🔧 ⚠️  boundary miss: returning BlockNotReady to client"
             );
             return ServiceError::BlockNotReady {
                 block_number: max_query,
@@ -715,7 +725,7 @@ impl ContinuityService {
             tracing::info!(
                 chain_key,
                 attestation_genesis_block = new_genesis_block,
-                "Updated attestation genesis block"
+                "🔗 ✅ Updated attestation genesis block"
             );
         }
     }
@@ -744,7 +754,7 @@ impl ContinuityService {
                 tracing::info!(
                     proof_block_count = proof.roots.len(),
                     lower_endpoint_digest = ?proof.lower_endpoint_digest,
-                    "Generated continuity proof for API response"
+                    "🔧 ✨ Generated continuity proof for API response"
                 );
             })
     }

--- a/proof-gen-api-server/src/services/errors.rs
+++ b/proof-gen-api-server/src/services/errors.rs
@@ -185,7 +185,7 @@ impl ServiceError {
                 retriable = response.retriable,
                 block_number = ?response.block_number,
                 last_attested_block = ?response.last_attested_block,
-                "proof API returning server error"
+                "🌐 ❌ proof API returning server error"
             );
         } else {
             tracing::warn!(
@@ -195,7 +195,7 @@ impl ServiceError {
                 retriable = response.retriable,
                 block_number = ?response.block_number,
                 last_attested_block = ?response.last_attested_block,
-                "proof API returning client error"
+                "🌐 ⚠️  proof API returning client error"
             );
         }
 


### PR DESCRIPTION
Adds emoji prefixes to log lines in `proof-gen-api-server` so categories are easy to spot when scanning the log stream.

**Categories:**
- 🔗 CC3 chain events + subscription lifecycle
- 🌐 HTTP requests / responses (incoming + served)
- 🔧 Internal service calls (cache ops, boundary lookup, proof build)
- 🚀 startup, 🛑 shutdown, ❌ errors, ⚠️ warnings

A few combined prefixes are used where a line crosses categories, e.g. `🔗 📜 Processing BlockAttested`, `🌐 ✅ 📦 Batch request served`, `🔧 📦 📜 attestation cached`.

**No behavior change** — only log message prefixes. Tests + clippy clean.