### PR TITLE
feat:Add new `attested_height` endpoint

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -34,7 +34,7 @@
         "test:archiver": "jest --config src/test/archiver-tests.config.ts --silent --verbose --runInBand --forceExit src/test/archiver-tests"
     },
     "devDependencies": {
-        "@gluwa/usc-sdk": "0.12.1",
+        "@gluwa/usc-sdk": "0.12.2",
         "@polkadot/typegen": "16.5.2",
         "@types/graphqurl": "^1.0.3",
         "@types/jest": "29.5.14",

--- a/proof-gen-api-server/src/networking/middleware.rs
+++ b/proof-gen-api-server/src/networking/middleware.rs
@@ -92,7 +92,7 @@ fn parse_api_path(path: &str) -> (Option<&str>, Option<u64>, usize) {
     let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
     // parts[0] = "api"
     // parts[1] = "v1"
-    // parts[2] = "proof" or "proof-by-tx" or "proof-batch" or "proof-batch-by-tx"
+    // parts[2] = "proof" or "proof-by-tx" or "proof-batch" or "proof-batch-by-tx" or "attested-height"
     // parts[3] = chain_key
     // parts[4+] = additional path segments
 
@@ -119,6 +119,7 @@ fn extract_endpoint_from_matched_path(matched_path: &str) -> Option<Endpoint> {
         "/api/v1/proof-by-tx/{chain_key}/{tx_hash}" => Some(Endpoint::ProofByTxHash),
         "/api/v1/proof-batch/{chain_key}" => Some(Endpoint::ProofBatch),
         "/api/v1/proof-batch-by-tx/{chain_key}" => Some(Endpoint::ProofBatchByTxHash),
+        "/api/v1/attested-height/{chain_key}" => Some(Endpoint::AttestedHeight),
         "/metrics" => None, // Metrics endpoint doesn't need endpoint classification
         _ => None,
     }
@@ -147,6 +148,14 @@ fn extract_endpoint_from_path(uri: &Uri) -> Option<Endpoint> {
             // parts_count includes: "api", "v1", "proof-batch", "chain_key"
             if parts_count == 4 {
                 Some(Endpoint::ProofBatch)
+            } else {
+                None
+            }
+        }
+        Some("attested-height") => {
+            // parts_count includes: "api", "v1", "attested-height", "chain_key"
+            if parts_count == 4 {
+                Some(Endpoint::AttestedHeight)
             } else {
                 None
             }

--- a/proof-gen-api-server/src/networking/middleware.rs
+++ b/proof-gen-api-server/src/networking/middleware.rs
@@ -167,6 +167,7 @@ pub async fn chain_key_validator_middleware(
     // Extract chain_key from path
     // Paths are: /api/v1/proof/{chain_key}/{header_number}/{tx_index}
     //            /api/v1/proof-by-tx/{chain_key}/{tx_hash}
+    //.           /api/v1/attested-height/{chain_key}
     // Note: extract_chain_key_from_path returns None for health endpoints, so validation
     // automatically skips them without needing an explicit check.
     if let Some(request_chain_key) = extract_chain_key_from_path(&uri) {
@@ -198,10 +199,13 @@ pub(crate) fn extract_chain_key_from_path(uri: &Uri) -> Option<u64> {
     let path = uri.path();
     let (endpoint_type, chain_key, _parts_count) = parse_api_path(path);
 
-    // Only extract chain_key for proof endpoints
     if matches!(
         endpoint_type,
-        Some("proof") | Some("proof-by-tx") | Some("proof-batch") | Some("proof-batch-by-tx")
+        Some("proof")
+            | Some("proof-by-tx")
+            | Some("proof-batch")
+            | Some("proof-batch-by-tx")
+            | Some("attested-height")
     ) {
         chain_key
     } else {
@@ -246,6 +250,10 @@ mod tests {
         assert_eq!(
             extract_chain_key_from_path(&"/invalid/path".parse().unwrap()),
             None
+        );
+        assert_eq!(
+            extract_chain_key_from_path(&"/api/v1/attested-height/123".parse().unwrap()),
+            Some(123)
         );
     }
 

--- a/proof-gen-api-server/src/networking/mod.rs
+++ b/proof-gen-api-server/src/networking/mod.rs
@@ -17,7 +17,7 @@ use tracing::Level;
 
 use crate::prom::{handle_metrics_response, Metrics, ProofGenMetrics};
 use crate::services::continuity_service::ContinuityService;
-use routes::{continuity, health};
+use routes::{attested_height, continuity, health};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -42,6 +42,10 @@ pub fn build_app(
     let router = Router::new()
         .route("/", get(|| async { Redirect::permanent("/api/swagger") }))
         .route("/api/v1/health", get(health::health_check))
+        .route(
+            "/api/v1/attested-height/{chain_key}",
+            get(attested_height::attested_height),
+        )
         .route(
             "/api/v1/proof/{chain_key}/{header_number}/{tx_index}",
             get(continuity::get_proof_with_tx),

--- a/proof-gen-api-server/src/networking/openapi.rs
+++ b/proof-gen-api-server/src/networking/openapi.rs
@@ -3,6 +3,7 @@
 use utoipa::OpenApi;
 use utoipa_swagger_ui::Config;
 
+use crate::networking::routes::attested_height;
 use crate::services::continuity_service::{
     ContinuityProofSchema, ContinuityResponse, MerkleProofEntrySchema, ProofQuery,
     TransactionMerkleProofSchema,
@@ -24,6 +25,7 @@ use super::routes::{continuity, health};
         continuity::get_proof_by_tx_hash,
         continuity::get_proof_batch,
         continuity::get_proof_batch_by_tx_hash,
+        attested_height::attested_height,
     ),
     components(schemas(
         ContinuityResponse,
@@ -33,6 +35,7 @@ use super::routes::{continuity, health};
         ErrorResponse,
         ProofQuery,
         health::HealthCheckResponse,
+        attested_height::AttestedHeightResponse,
     ))
 )]
 pub struct ApiDoc;

--- a/proof-gen-api-server/src/networking/routes/attested_height.rs
+++ b/proof-gen-api-server/src/networking/routes/attested_height.rs
@@ -11,6 +11,7 @@ use crate::services::continuity_service::ContinuityService;
 
 /// Health check response schema for OpenAPI
 #[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct AttestedHeightResponse {
     attested_height: Option<u64>,
 }

--- a/proof-gen-api-server/src/networking/routes/attested_height.rs
+++ b/proof-gen-api-server/src/networking/routes/attested_height.rs
@@ -1,4 +1,7 @@
 use crate::networking::extract::Chain;
+use crate::services::errors::ErrorResponse;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
 use axum::{Extension, Json};
 use serde::Serialize;
 use std::sync::Arc;
@@ -23,39 +26,67 @@ pub struct AttestedHeightResponse {
     params(
         ("chain_key" = u64, Path, description = "Chain identifier"),
     ),
-    responses((status = 200, description = "Height of last finalized attestation in cache", body = AttestedHeightResponse))
+    responses(
+        (status = 200, description = "Height of last finalized attestation in cache", body = AttestedHeightResponse),
+        (status = 500, description = "Error retrieving last attestation from cache", body = ErrorResponse)
+
+    )
 )]
 pub async fn attested_height(
     chain: Chain,
     Extension(service): Extension<Arc<ContinuityService>>,
-) -> Json<AttestedHeightResponse> {
+) -> impl IntoResponse {
     let chain_key = chain.key;
-    let height = service.attested_height(chain_key).await;
 
-    let height = match height {
+    match service.attested_height(chain_key).await {
         Ok(Some(height)) => {
             tracing::debug!(
                 chain_key = chain_key,
                 attested_height = height,
                 "✅ Latest attested height fetched"
             );
-            Some(height)
+
+            (
+                StatusCode::OK,
+                Json(AttestedHeightResponse {
+                    attested_height: Some(height),
+                }),
+            )
+                .into_response()
         }
+
         Ok(None) => {
             tracing::warn!(chain_key = chain_key, "⚠️ No attestations found in cache");
-            None
+
+            (
+                StatusCode::OK,
+                Json(AttestedHeightResponse {
+                    attested_height: None,
+                }),
+            )
+                .into_response()
         }
+
         Err(e) => {
             tracing::error!(
                 chain_key = chain_key,
                 error = %e,
                 "❌ Failed to fetch attested height"
             );
-            None
-        }
-    };
 
-    Json(AttestedHeightResponse {
-        attested_height: height,
-    })
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    code: "Internal".to_string(),
+                    message: format!(
+                        "Failed to fetch attested height for chain key {chain_key}: {e}"
+                    ),
+                    retriable: true,
+                    block_number: None,
+                    last_attested_block: None,
+                }),
+            )
+                .into_response()
+        }
+    }
 }

--- a/proof-gen-api-server/src/networking/routes/attested_height.rs
+++ b/proof-gen-api-server/src/networking/routes/attested_height.rs
@@ -17,9 +17,6 @@ pub struct AttestedHeightResponse {
 /// proof request timing. (Independently having each service
 /// listen for new finalized attestations was resulting in
 /// timing deltas and failed proving jobs.)
-///
-/// For simplicity, if there are no attestations in storage
-/// we return an attested height of 0.
 #[utoipa::path(
     get,
     path = "/api/v1/attested-height/{chain_key}",

--- a/proof-gen-api-server/src/networking/routes/attested_height.rs
+++ b/proof-gen-api-server/src/networking/routes/attested_height.rs
@@ -1,0 +1,67 @@
+use axum::{Extension, Json};
+use serde::Serialize;
+use std::sync::Arc;
+use utoipa::ToSchema;
+use crate::networking::extract::Chain;
+
+use crate::services::continuity_service::ContinuityService;
+
+/// Health check response schema for OpenAPI
+#[derive(Serialize, ToSchema)]
+pub struct AttestedHeightResponse {
+    attested_height: Option<u64>,
+}
+
+/// Queries the last attested height in the proof gen server
+/// Used by USC SDK `waitUntilHeightAttested` to coordinate 
+/// proof request timing. (Independently having each service
+/// listen for new finalized attestations was resulting in 
+/// timing deltas and failed proving jobs.)
+/// 
+/// For simplicity, if there are no attestations in storage
+/// we return an attested height of 0.
+#[utoipa::path(
+    get,
+    path = "/api/v1/attested-height/{chain_key}",
+    params(
+        ("chain_key" = u64, Path, description = "Chain identifier"),
+    ),
+    responses((status = 200, description = "Height of last finalized attestation in cache", body = AttestedHeightResponse))
+)]
+pub async fn attested_height(
+    chain: Chain,
+    Extension(service): Extension<Arc<ContinuityService>>,
+) -> Json<AttestedHeightResponse> {
+    let chain_key = chain.key;
+    let height = service.attested_height(chain_key).await;
+
+    let height = match height {
+        Ok(Some(height)) => {
+            tracing::debug!(
+                chain_key = chain_key,
+                attested_height = height,
+                "✅ Latest attested height fetched"
+            );
+            Some(height)
+        }
+        Ok(None) => {
+            tracing::warn!(
+                chain_key = chain_key,
+                "⚠️ No attestations found in cache"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::error!(
+                chain_key = chain_key,
+                error = %e,
+                "❌ Failed to fetch attested height"
+            );
+            None
+        }
+    };
+
+    Json(AttestedHeightResponse {
+        attested_height: height
+    })
+}

--- a/proof-gen-api-server/src/networking/routes/attested_height.rs
+++ b/proof-gen-api-server/src/networking/routes/attested_height.rs
@@ -1,8 +1,8 @@
+use crate::networking::extract::Chain;
 use axum::{Extension, Json};
 use serde::Serialize;
 use std::sync::Arc;
 use utoipa::ToSchema;
-use crate::networking::extract::Chain;
 
 use crate::services::continuity_service::ContinuityService;
 
@@ -13,11 +13,11 @@ pub struct AttestedHeightResponse {
 }
 
 /// Queries the last attested height in the proof gen server
-/// Used by USC SDK `waitUntilHeightAttested` to coordinate 
+/// Used by USC SDK `waitUntilHeightAttested` to coordinate
 /// proof request timing. (Independently having each service
-/// listen for new finalized attestations was resulting in 
+/// listen for new finalized attestations was resulting in
 /// timing deltas and failed proving jobs.)
-/// 
+///
 /// For simplicity, if there are no attestations in storage
 /// we return an attested height of 0.
 #[utoipa::path(
@@ -45,10 +45,7 @@ pub async fn attested_height(
             Some(height)
         }
         Ok(None) => {
-            tracing::warn!(
-                chain_key = chain_key,
-                "⚠️ No attestations found in cache"
-            );
+            tracing::warn!(chain_key = chain_key, "⚠️ No attestations found in cache");
             None
         }
         Err(e) => {
@@ -62,6 +59,6 @@ pub async fn attested_height(
     };
 
     Json(AttestedHeightResponse {
-        attested_height: height
+        attested_height: height,
     })
 }

--- a/proof-gen-api-server/src/networking/routes/mod.rs
+++ b/proof-gen-api-server/src/networking/routes/mod.rs
@@ -1,3 +1,3 @@
+pub mod attested_height;
 pub mod continuity;
 pub mod health;
-pub mod attested_height;

--- a/proof-gen-api-server/src/networking/routes/mod.rs
+++ b/proof-gen-api-server/src/networking/routes/mod.rs
@@ -1,2 +1,3 @@
 pub mod continuity;
 pub mod health;
+pub mod attested_height;

--- a/proof-gen-api-server/src/prom/mod.rs
+++ b/proof-gen-api-server/src/prom/mod.rs
@@ -415,6 +415,7 @@ mod labels {
         ProofBatch,
         ProofBatchByTxHash,
         Health,
+        AttestedHeight,
     }
 
     #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -407,10 +407,11 @@ impl ContinuityService {
     pub async fn attested_height(&self, chain_key: u64) -> ServiceResult<Option<u64>> {
         let chain = self.chain_state(chain_key)?;
 
-        let cache = chain.attestation_cache.read().await;
+        let mut last_height = {
+            let cache = chain.attestation_cache.read().await;
+            cache.keys().next_back().copied()
+        };
 
-        let mut last_height = cache.keys().next_back().copied();
-        // If no attestations, then we check for the height of the latest checkpoint, if any
         if last_height.is_none() {
             let checkpoint_cache = chain.checkpoint_cache.read().await;
             last_height = checkpoint_cache.keys().next_back().copied();

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -403,6 +403,22 @@ impl ContinuityService {
         Ok(())
     }
 
+    /// Returns the latest attested height in the in-memory cache for a chain.
+    pub async fn attested_height(&self, chain_key: u64) -> ServiceResult<Option<u64>> {
+        let chain = self.chain_state(chain_key)?;
+
+        let cache = chain.attestation_cache.read().await;
+
+        let mut last_height = cache.keys().next_back().copied();
+        // If no attestations, then we check for the height of the latest checkpoint, if any
+        if last_height.is_none() {
+            let checkpoint_cache = chain.checkpoint_cache.read().await;
+            last_height = checkpoint_cache.keys().next_back().copied();
+        }
+
+        Ok(last_height)
+    }
+
     /// Insert an attestation into the in-memory cache (called from event handler).
     pub async fn insert_attestation(&self, chain_key: u64, block_number: u64, digest: H256) {
         if let Some(chain) = self.chains.get(&chain_key) {

--- a/scripts/TransferWaitAndSubmit.js
+++ b/scripts/TransferWaitAndSubmit.js
@@ -18,6 +18,7 @@
  *   --devnet               Use devnet provider URL for source chain
  */
 
+const { proofGenerator } = require('@gluwa/usc-sdk');
 const { ethers } = require('ethers');
 const { ApiPromise, WsProvider } = require('@polkadot/api');
 const {
@@ -163,19 +164,21 @@ async function main() {
         // Step 2: Wait for attestation
         console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
         console.log('STEP 2: Wait for Attestation');
-        console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-        console.log(`\n🔗 Connecting to Creditcoin3 at ${options.cc3WsUrl}...`);
-        const wsProvider = new WsProvider(options.cc3WsUrl);
-        const api = await ApiPromise.create({ provider: wsProvider });
-        await api.isReady;
-        console.log('✅ Connected to Creditcoin3\n');
+        console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
 
-        const attestationResult = await waitForAttestation(api, chainKey, blockNumber);
+        const proofGenApi = new proofGenerator.api.ProverAPIProofGenerator(
+            chainKey,
+            options.apiUrl
+        );
 
-        // Wait for at least 2 Creditcoin3 blocks to ensure attestation is indexed
-        await waitForCreditcoin3Blocks(api, 2);
+        console.log(`⏳ Waiting for attestation of block ${blockNumber}...`);
 
-        await api.disconnect();
+        await proofGenApi.waitUntilHeightAttested(
+            chainKey,
+            blockNumber
+        );
+
+        console.log('✅ Attestation observed in proof server');
 
         // Step 3: Fetch proof and submit
         console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');

--- a/scripts/TransferWaitAndSubmit.js
+++ b/scripts/TransferWaitAndSubmit.js
@@ -232,8 +232,6 @@ async function main() {
         console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
         console.log(`   Transaction: ${txHash}`);
         console.log(`   Block: ${blockNumber}`);
-        console.log(`   Attested at block: ${attestationResult.attestedBlock}`);
-        console.log(`   Attestation wait time: ${attestationResult.elapsed.toFixed(2)}s`);
         console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
 
         process.exit(0);

--- a/scripts/TransferWaitAndSubmit.js
+++ b/scripts/TransferWaitAndSubmit.js
@@ -20,7 +20,6 @@
 
 const { proofGenerator } = require('@gluwa/usc-sdk');
 const { ethers } = require('ethers');
-const { ApiPromise, WsProvider } = require('@polkadot/api');
 const {
     DEFAULT_SOURCE_RPC_URL,
     DEVNET_SOURCE_RPC_URL,
@@ -31,8 +30,6 @@ const {
     DEFAULT_API_URL,
     getChainKeyFromChainId,
     sendTransfer,
-    waitForAttestation,
-    waitForCreditcoin3Blocks,
     fetchProof,
     convertProofFormat,
     submitToPrecompile,

--- a/scripts/TransferWaitAndSubmit.js
+++ b/scripts/TransferWaitAndSubmit.js
@@ -163,17 +163,11 @@ async function main() {
         console.log('STEP 2: Wait for Attestation');
         console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
 
-        const proofGenApi = new proofGenerator.api.ProverAPIProofGenerator(
-            chainKey,
-            options.apiUrl
-        );
+        const proofGenApi = new proofGenerator.api.ProverAPIProofGenerator(chainKey, options.apiUrl);
 
         console.log(`⏳ Waiting for attestation of block ${blockNumber}...`);
 
-        await proofGenApi.waitUntilHeightAttested(
-            chainKey,
-            blockNumber
-        );
+        await proofGenApi.waitUntilHeightAttested(chainKey, blockNumber);
 
         console.log('✅ Attestation observed in proof server');
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -12,8 +12,9 @@
         "typecheck": "echo"
     },
     "dependencies": {
-        "ethers": "^6.16.0",
-        "@polkadot/api": "16.5.2"
+        "@gluwa/usc-sdk": "0.12.2",
+        "@polkadot/api": "16.5.2",
+        "ethers": "^6.16.0"
     },
     "devDependencies": {
         "eslint": "^8.57.0",

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -39,6 +39,16 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
+"@gluwa/usc-sdk@0.12.2":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@gluwa/usc-sdk/-/usc-sdk-0.12.2.tgz#cd9dae18de2147b1f26fb439cc5b323112b979bc"
+  integrity sha512-gFpqEYqAk3y65K0DgwljtoDmQMYYmIq2jZvDpKk2H3uGtpx9Y3PaCJ484IWcc6ANCIUGsg8GXRBgJ56lkQEaLg==
+  dependencies:
+    axios "^1.13.2"
+    dotenv "^17.2.3"
+    ethers "^6.15.0"
+    exponential-backoff "^3.1.3"
+
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.13.0.tgz#fb907624df3256d04b9aa2df50d7aa97ec648748"
@@ -562,6 +572,13 @@ aes-js@4.0.0-beta.5:
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-4.0.0-beta.5.tgz#8d2452c52adedebc3a3e28465d858c11ca315873"
   integrity sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 ajv@^6.12.4:
   version "6.14.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.14.0.tgz#fd067713e228210636ebb08c60bd3765d6dbe73a"
@@ -589,6 +606,21 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios@^1.13.2:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.1.tgz#517e29291d19d6e8cf919ff264f4fe157261ba12"
+  integrity sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==
+  dependencies:
+    follow-redirects "^1.16.0"
+    form-data "^4.0.5"
+    https-proxy-agent "^5.0.1"
+    proxy-from-env "^2.1.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -606,6 +638,14 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -632,6 +672,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -651,7 +698,7 @@ data-uri-to-buffer@^4.0.0:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
   integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
-debug@^4.1.0, debug@^4.3.1, debug@^4.3.2:
+debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -663,12 +710,58 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dotenv@^17.2.3:
+  version "17.4.2"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.4.2.tgz#c07e54a746e11eba021dd9e1047ced5afdc1c034"
+  integrity sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==
+
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
+
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  dependencies:
+    es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -770,7 +863,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-ethers@^6.16.0:
+ethers@^6.15.0, ethers@^6.16.0:
   version "6.16.0"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.16.0.tgz#fff9b4f05d7a359c774ad6e91085a800f7fccf65"
   integrity sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==
@@ -787,6 +880,11 @@ eventemitter3@^5.0.1:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.4.tgz#a86d66170433712dde814707ac52b5271ceb1feb"
   integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
+
+exponential-backoff@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.3.tgz#51cf92c1c0493c766053f9d3abee4434c244d2f6"
+  integrity sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -847,6 +945,22 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
   integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
+
+form-data@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
+
 formdata-polyfill@^4.0.10:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
@@ -858,6 +972,35 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+get-intrinsic@^1.2.6:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 glob-parent@^6.0.2:
   version "6.0.2"
@@ -885,6 +1028,11 @@ globals@^13.19.0:
   dependencies:
     type-fest "^0.20.2"
 
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
 graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
@@ -894,6 +1042,33 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-symbols@^1.0.3, has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
+
+hasown@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.3.tgz#5e5c2b15b60370a4c7930c383dfb76bf17bc403c"
+  integrity sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==
+  dependencies:
+    function-bind "^1.1.2"
+
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 ignore@^5.2.0:
   version "5.3.2"
@@ -1001,6 +1176,23 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.5"
@@ -1116,6 +1308,11 @@ propagate@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
   integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
+
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 punycode@^2.1.0:
   version "2.3.1"


### PR DESCRIPTION
More precisely determines when we can submit a proving request. Previously in Hello Bridge we were waiting an extra 2 minutes to ensure this.

This was the resolution of a conversation with David here: https://gluwa.slack.com/archives/C03MQ532BGA/p1778101216154199?thread_ts=1778020679.915329&cid=C03MQ532BGA 

Companion PR using the new endpoint in USC SDK: https://github.com/gluwa/cc-next-query-builder/pull/85 
