### PR TITLE
Make prover-check.ts capable of inspecting proofs at checkpoint boundaries

### DIFF
--- a/.github/workflows/check-prover.yml
+++ b/.github/workflows/check-prover.yml
@@ -17,26 +17,31 @@ jobs:
           # CC3 Devnet, Sepolia Full Archive
           - creditcoinUrl: "wss://rpc.cc3-devnet.creditcoin.network/ws"
             proverUrl: "https://prover.cc3-devnet.creditcoin.network"
+            indexerUrl: "https://graphql-usc.cc3-devnet.creditcoin.network"
             chainKey: 1
 
           # CC3 Devnet, Ethereum Mainnet Full Archive
           - creditcoinUrl: "wss://rpc.cc3-devnet.creditcoin.network/ws"
             proverUrl: "https://prover.cc3-devnet.creditcoin.network"
+            indexerUrl: "https://graphql-usc.cc3-devnet.creditcoin.network"
             chainKey: 2
 
           # CC3 Devnet, Sepolia Full Archive w/recreated checkpoints
           - creditcoinUrl: "wss://rpc.cc3-devnet.creditcoin.network/ws"
             proverUrl: "https://prover.cc3-devnet.creditcoin.network"
+            indexerUrl: "https://graphql-usc.cc3-devnet.creditcoin.network"
             chainKey: 3
 
           # CC3 Testnet, Sepolia Full Archive
           - creditcoinUrl: "wss://rpc.cc3-testnet.creditcoin.network/ws"
             proverUrl: "https://prover.cc3-testnet.creditcoin.network"
+            indexerUrl: "https://graphql-usc.cc3-testnet.creditcoin.network"
             chainKey: 1
 
           # USC Testnet v2, Sepolia from 10,050,300
           - creditcoinUrl: "wss://rpc.usc-testnet2.creditcoin.network/ws"
             proverUrl: "https://proof-gen-api.usc-testnet2.creditcoin.network"
+            indexerUrl: "https://attestations-graphql.usc-testnet2.creditcoin.network"
             chainKey: 1
 
     name: CK ${{ matrix.chainKey }} / ${{ matrix.proverUrl }}
@@ -62,7 +67,20 @@ jobs:
           solc --version
           ./abi-creator.sh
 
-      - name: Execute prover-check.ts
+      - name: Install & build
+        working-directory: ./cli
+        run: |
+          yarn install
+          yarn build
+
+      - name: Execute prover-check.ts on checkpoint boundaries
+        working-directory: ./cli
+        env:
+          GO_BACK_BLOCKS: '3600'
+        run: |
+          node dist/scripts/prover-check.js ${{ matrix.creditcoinUrl }} ${{ matrix.chainKey }} ${{ matrix.proverUrl }} ${{ matrix.indexerUrl }}
+
+      - name: Execute prover-check.ts on random blocks
         working-directory: ./cli
         env:
           # LAST_SOURCE_BLOCK: '1000000'
@@ -70,8 +88,6 @@ jobs:
           GO_BACK_BLOCKS: '4000'
           STEP_THROUGH_BLOCKS: '7'
         run: |
-          yarn install
-          yarn build
           node dist/scripts/prover-check.js ${{ matrix.creditcoinUrl }} ${{ matrix.chainKey }} ${{ matrix.proverUrl }}
 
       - name: Report result to Slack

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -25,6 +25,7 @@ https://sepolia.infura.io/v3/(.*)
 https://registry.npmjs.org/-/npm/v1/(.*)
 https://github.com/request/request/issues/(.*)
 https://blockscout(.*)creditcoin.network/
+https://attestations-graphql(.*)creditcoin.network/
 https://graphql-usc(.*)creditcoin.network/
 https://prover(.*)creditcoin.network/
 https://proof-gen-api(.*)creditcoin.network/

--- a/cli/src/scripts/prover-check.ts
+++ b/cli/src/scripts/prover-check.ts
@@ -1,16 +1,63 @@
 import { blockProver, chainInfo, proofGenerator } from '@gluwa/usc-sdk';
 import { WebSocketProvider } from 'ethers';
+import { createClient } from 'graphqurl';
 import axios from 'axios';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-async function getProofForBlock(apiUrl: string, chainKey: number, blockNumber: number) {
+const graphQLQuery = (serverUrl: string, queryString: string) => {
+    return createClient({
+        endpoint: serverUrl,
+        headers: {
+            /* eslint-disable @typescript-eslint/naming-convention */
+            'content-type': 'application/json',
+        },
+    }).query({
+        query: queryString,
+    });
+};
+
+async function getProofForBlock(apiUrl: string, chainKey: number, blockNumber: bigint) {
     const url = `${apiUrl}/api/v1/proof/${chainKey}/${blockNumber}/0`;
     // NOTE: throws an exception in case of errors
     return axios.get(url);
 }
 
-async function main(creditcoinWsUrl: string, chainKey: number, proverBaseUrl: string): Promise<void> {
+const fetchCheckpoints = (
+    indexerUrl: string,
+    chainKey: number,
+    startBlock: number,
+    lastBlock: number,
+    afterCursor: string | null,
+) => {
+    return graphQLQuery(
+        indexerUrl,
+        `query {
+            checkpoints(
+                filter: {
+                    chainKey: { equalTo: "${chainKey}" },
+                    blockNumber: {
+                        greaterThanOrEqualTo: "${startBlock}",
+                        lessThanOrEqualTo: "${lastBlock}"
+                    },
+                },
+                orderBy: BLOCK_NUMBER_ASC,
+                first: 100,
+                after: ${afterCursor},
+            ) {
+                nodes { blockNumber },
+                pageInfo { endCursor, hasNextPage },
+            }
+        }`,
+    );
+};
+
+async function main(
+    creditcoinWsUrl: string,
+    chainKey: number,
+    proverBaseUrl: string,
+    indexerUrl: string | undefined,
+): Promise<void> {
     const creditcoinWs = new WebSocketProvider(creditcoinWsUrl);
     const prover = new blockProver.PrecompileBlockProver(creditcoinWs);
     const chainInfoPrecompile = new chainInfo.PrecompileChainInfoProvider(creditcoinWs);
@@ -24,10 +71,47 @@ async function main(creditcoinWsUrl: string, chainKey: number, proverBaseUrl: st
     const startFrom = lastSourceBlock - goBack;
     const stepThrough = parseInt(process.env.STEP_THROUGH_BLOCKS || '5', 10); // how many blocks to step through
 
-    const howMany = Math.ceil(goBack / stepThrough);
-    console.log(`**** INFO: will check ${howMany} blocks: ${startFrom}..${lastSourceBlock}, step ${stepThrough}`);
+    // NOTE: the default is to query random blocks by iterating over them
+    const blocksToInspect = Array.from({ length: goBack / stepThrough + 1 }, (value, index) =>
+        BigInt(startFrom + index * stepThrough),
+    );
+    if (indexerUrl === undefined) {
+        console.log(
+            `**** INFO: will check ${blocksToInspect.length} random blocks: ${startFrom}..${lastSourceBlock}, step ${stepThrough}`,
+        );
+    } else {
+        // NOTE: if indexerUrl is defined will inspect blocks at checkpoint boundaries instead
 
-    for (let blockNumber = startFrom; blockNumber < lastSourceBlock; blockNumber += stepThrough) {
+        // reset which blocks we should inspect
+        blocksToInspect.splice(0, blocksToInspect.length);
+
+        let hasNextPage = true;
+        let afterCursor = null;
+        do {
+            // WARNING: this returns max 100 records
+            const response = await fetchCheckpoints(indexerUrl, chainKey, startFrom, lastSourceBlock, afterCursor);
+            hasNextPage = response.data.checkpoints.pageInfo.hasNextPage;
+            afterCursor = `"${response.data.checkpoints.pageInfo.endCursor}"`;
+
+            for (const node of response.data.checkpoints.nodes) {
+                // upper boundary of current checkpoint
+                blocksToInspect.push(BigInt(node.blockNumber));
+                // lower boundary of next checkpoint
+                if (BigInt(node.blockNumber) + 1n <= lastAttestation.height) {
+                    blocksToInspect.push(BigInt(node.blockNumber) + 1n);
+                }
+            }
+        } while (hasNextPage);
+        console.log(
+            `**** INFO: will check ${blocksToInspect.length} blocks at checkpoint boundaries: ${startFrom}..${lastSourceBlock}`,
+        );
+    }
+
+    if (blocksToInspect.length === 0) {
+        throw new Error('no blocks to inspect. Something is wrong! Investigate!');
+    }
+
+    for (const blockNumber of blocksToInspect) {
         console.log(`... get proof for source chain block ${blockNumber}`);
         await sleep(500); // rate-limit
         const response = await getProofForBlock(proverBaseUrl, chainKey, blockNumber);
@@ -56,15 +140,18 @@ async function main(creditcoinWsUrl: string, chainKey: number, proverBaseUrl: st
 }
 
 if (process.argv.length < 5) {
-    console.error('prover-check.js <creditcoinWssUrl> <chainKey> <proverBaseUrl>');
+    console.error('prover-check.js <creditcoinWssUrl> <chainKey> <proverBaseUrl> [<indexerUrl>]');
     process.exit(1);
 }
 
 const creditcoinWsRpcUrl = process.argv[2];
 const sourceChainKey = Number(process.argv[3]);
 const proverUrl = process.argv[4];
+// when defined will query proofs at checkpoint boundaries
+// otherwise will query random blocks by iterating over them
+const cc3IndexerUrl = process.argv[5];
 
-main(creditcoinWsRpcUrl, sourceChainKey, proverUrl).catch((reason) => {
+main(creditcoinWsRpcUrl, sourceChainKey, proverUrl, cc3IndexerUrl).catch((reason) => {
     console.error(reason);
     process.exit(1);
 });


### PR DESCRIPTION
only when indexerUrl is supplied as argument. If it isn't the default behavior is to inspect random blocks by looping over them

Example: https://github.com/gluwa/creditcoin3/actions/runs/25657500174/job/75309419181
