### PR TITLE
Execute Check Prover Mon-Fri only

### DIFF
--- a/.github/workflows/check-prover.yml
+++ b/.github/workflows/check-prover.yml
@@ -3,7 +3,7 @@ name: Check Prover
 
 "on":
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 */12 * * 1-5"
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
to minimize the likelyhood of Infura keys going out of credits when there's noone to see. 