### PR TITLE
test(attestor): mint attest-coin to stash so withdraw-unbonded register succeeds

### DIFF
--- a/cli/src/test/integration-tests/attestor/withdraw-unbonded.test.ts
+++ b/cli/src/test/integration-tests/attestor/withdraw-unbonded.test.ts
@@ -5,6 +5,15 @@ import { chain_Anvil1_Key } from '../../blockchain-tests/pallets/supported-chain
 import { parseAmount } from '../../../commands/options';
 import { signSendAndWatchCcKeyring } from '../../../lib/tx';
 import { CallerKeyring } from '../../../lib/account/keyring';
+import { evmAddressToSubstrateAddress } from '../../../lib/evm/address';
+
+// pallet_attestation now denominates bonds in `attest-coin` (`pallet_assets` asset id 1)
+// instead of native CTC. Its issuer/admin is the attest-coin precompile account
+// (`HashedAddressMapping` of EVM `0x0...fd5`). For tests we use `sudo.sudoAs` to mint
+// directly as the precompile so the stash has enough attest-coin to register.
+const ATTEST_COIN_ASSET_ID = 1;
+const ATTEST_COIN_PRECOMPILE_EVM = '0x0000000000000000000000000000000000000fd5';
+const ATTEST_COIN_PRECOMPILE_ACCOUNT = evmAddressToSubstrateAddress(ATTEST_COIN_PRECOMPILE_EVM);
 
 // NOTE: The attestor-stash precompile uses the EVM `msg.sender` as the origin
 // of the dispatched pallet call. Proxy-signed attestor operations are not
@@ -37,6 +46,17 @@ describe('withdraw-unbonded', () => {
         // Create and fund the test account (sr25519 + EVM stash)
         caller = await randomFundedAccount(api, sudoSigner);
         await fundFromSudo(api, caller.evmStashAddress, parseAmount('1000'));
+        // Mint attest-coin to the EVM-mapped stash address so `register_attestor` (which now
+        // checks `BondFungibles::balance(BondAssetId=1)`, not native CTC) sees enough bond.
+        await signSendAndWatchCcKeyring(
+            api.tx.sudo.sudoAs(
+                ATTEST_COIN_PRECOMPILE_ACCOUNT,
+                api.tx.assets.mint(ATTEST_COIN_ASSET_ID, caller.evmStashAddress, minBondForTest),
+            ),
+            api,
+            sudoKeyring,
+        );
+        await forElapsedBlocks(api, { minBlocks: 1 });
         CLI = CLIBuilder({ CC_SECRET: caller.secret });
 
         attestor = await randomFundedAccount(api, sudoSigner);


### PR DESCRIPTION
## Why

CI on #825 fails in `cli/src/test/integration-tests/attestor/withdraw-unbonded.test.ts`:

```
Command failed with exit code 1: node dist/cli.js attestor register --chain 2 --attestor 5DczBNmnkYGTAEA6UnC7dEgzoJ2YR1iNzGhSheVANjDQphSS
Transaction failed with error: "InsufficientBalance"
```

for all three tests in the suite.

## Root cause

`pallet_attestation` now denominates bonds in **attest-coin** (`pallet_assets` asset id `1`) instead of native CTC. `register_attestor` checks the stash's attest-coin balance:

```rust
// pallets/attestation/src/impls.rs:705
pub fn get_free_balance(account_id: &T::AccountId) -> BalanceOf<T> {
    T::BondFungibles::balance(T::BondAssetId::get(), account_id)
}
```

The test sets `MinBondRequirement(Anvil1) = 100 CTC` in `beforeAll`, but only funds the EVM-mapped stash with **native CTC** via `fundFromSudo` (`balances.forceSetBalance`). The stash therefore has `0` attest-coin and `register` aborts with `InsufficientBalance` (`pallets/attestation/src/impls.rs:194-195`).

`register.test.ts` keeps passing because it does not change `MinBondRequirement` and the default is `0`.

## Fix

Mint enough attest-coin to the EVM-mapped stash in `beforeAll`. Asset `1`'s issuer/admin is `attest_coin_precompile_account()`, so the test dispatches `assets.mint` as the precompile account via `sudo.sudoAs`:

```ts
api.tx.sudo.sudoAs(
    ATTEST_COIN_PRECOMPILE_ACCOUNT,
    api.tx.assets.mint(ATTEST_COIN_ASSET_ID, caller.evmStashAddress, minBondForTest),
)
```

No runtime / pallet changes.

## Scope

- `cli/src/test/integration-tests/attestor/withdraw-unbonded.test.ts` only.
- Targets `attest_coin` so it rolls up into #825.

## Validation

- `yarn build` (cli) — clean.
- `yarn lint` (cli) — clean.
- Local zombienet not available in sandbox; CI on this PR will exercise the integration test.

## Notes on the other PR-825 failure

The parallel `validator/withdraw-unbonded.test.ts` flake (iteration #8/200, `nextUnbondingInMs` diff ~980000ms vs ≤10000ms) and the cascade `validator/bond.test.ts` `WebSocket is not connected` come from the **same node restart** — `bond.test.ts` opens its WS right after the validator-cli node restart at `08:34:35Z`. That's in the validator (staking) flow, unrelated to attest-coin, and is not addressed here.
