### PR TITLE
fix(audit): direct-link attestations

### DIFF
--- a/attestor/attestor/src/lib.rs
+++ b/attestor/attestor/src/lib.rs
@@ -373,12 +373,17 @@ impl Attestor {
         tracing::info!("⏳ [2/4] Starting attestation validation worker");
 
         let can_attest = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let attestation_latest_cc3 = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(
+            start_attestation.map(|info| info.height).unwrap_or(genesis),
+        ));
+
         let config = worker::validation::ConfigBuilder::new()
             .with_stream_cc3(stream_cc3_validation)
             .with_cc3(client_cc3.clone())
             .with_signer(signer)
             .with_validation_receiver(receiver_validation)
             .with_validation_sender(sender_validation.clone())
+            .with_attestation_latest_cc3(std::sync::Arc::clone(&attestation_latest_cc3))
             .with_can_attest(std::sync::Arc::clone(&can_attest))
             .with_api_calls(cc_client::Client::runtime_api())
             .with_start_height(start_height)
@@ -409,34 +414,33 @@ impl Attestor {
 
         // --------------------------------------* Genesis *------------------------------------ //
 
-        let attestation_latest_cc3 = match start_attestation {
-            Some(info) => info,
-            None => {
-                tracing::info!(genesis, "👶 Generating genesis attestation");
+        if start_attestation.is_none() {
+            tracing::info!(genesis, "👶 Generating genesis attestation");
 
-                match wait_for_genesis(
-                    genesis,
-                    &client_eth,
-                    &account_id,
-                    &mut stream_cc3_genesis,
-                    &mut stream_attestation,
-                    &mut sender_validation,
-                    &sender_p2p,
-                )
-                .await
-                {
-                    Ok(info) => info,
-                    Err(Interrupt::Stop) => {
-                        tracing::info!("🔌 Received shutdown signal");
-                        return Ok(());
-                    }
-                    Err(Interrupt::Cont(err)) => {
-                        tracing::error!(%err, "⛔ Failed to submit genesis attestation");
-                        return Err(err);
-                    }
+            match wait_for_genesis(
+                genesis,
+                &client_eth,
+                &account_id,
+                &mut stream_cc3_genesis,
+                &mut stream_attestation,
+                &mut sender_validation,
+                &sender_p2p,
+            )
+            .await
+            {
+                Ok(info) => {
+                    attestation_latest_cc3.store(info.height, std::sync::atomic::Ordering::Release);
                 }
-            }
-        };
+                Err(Interrupt::Stop) => {
+                    tracing::info!("🔌 Received shutdown signal");
+                    return Ok(());
+                }
+                Err(Interrupt::Cont(err)) => {
+                    tracing::error!(%err, "⛔ Failed to submit genesis attestation");
+                    return Err(err);
+                }
+            };
+        }
 
         // ------------------------------------* Production *----------------------------------- //
 

--- a/attestor/attestor/src/main.rs
+++ b/attestor/attestor/src/main.rs
@@ -418,7 +418,7 @@ async fn main() -> anyhow::Result<()> {
         .map(|_| tracing_subscriber::EnvFilter::from_default_env())
         .unwrap_or_else(|| {
             tracing_subscriber::EnvFilter::new(
-                "attestor=info,stream_attestation=info,stream_eth=info,alloy=warn,subxt=warn",
+                "attestor=info,stream_attestation=info,attestation_pool=info,stream_eth=info,alloy=warn,subxt=warn",
             )
         });
 
@@ -439,6 +439,7 @@ async fn main() -> anyhow::Result<()> {
         .with_default(tracing_subscriber::filter::LevelFilter::OFF)
         .with_target("attestor", tracing::Level::TRACE)
         .with_target("stream_attestation", tracing::Level::TRACE)
+        .with_target("attestation_pool", tracing::Level::TRACE)
         .with_target("stream_eth", tracing::Level::TRACE)
         .with_target("alloy", tracing::Level::WARN)
         .with_target("subxt", tracing::Level::DEBUG);

--- a/attestor/attestor/src/worker/production/mod.rs
+++ b/attestor/attestor/src/worker/production/mod.rs
@@ -106,7 +106,7 @@ pub struct Config {
     sender_validation: attestation_pool::AttestationPoolSender,
 
     interval_attestation: std::num::NonZero<attestor_primitives::Height>,
-    attestation_latest_cc3: stream::util::AttestationInfo,
+    attestation_latest_cc3: std::sync::Arc<std::sync::atomic::AtomicU64>,
     can_attest: std::sync::Arc<std::sync::atomic::AtomicBool>,
 
     start_height: attestor_primitives::Height,
@@ -129,7 +129,7 @@ pub(crate) struct WorkerAttestationProduction {
 
     // ATTESTATION DATA
     attestation_local: attestor_primitives::Height,
-    attestation_latest_cc3: stream::util::AttestationInfo,
+    attestation_latest_cc3: std::sync::Arc<std::sync::atomic::AtomicU64>,
     attestation_interval: std::num::NonZero<attestor_primitives::Height>,
 
     // METRICS
@@ -223,8 +223,6 @@ impl WorkerAttestationProduction {
             "📡 Generated attestation"
         );
 
-        let attestation_latest_cc3 = self.attestation_latest_cc3.height;
-
         self.metrics
             .update_attestation_delay_production(now.elapsed());
 
@@ -237,7 +235,8 @@ impl WorkerAttestationProduction {
         );
         self.metrics.update_attestation_lag_cc3(
             attestation.header_number(),
-            attestation_latest_cc3,
+            self.attestation_latest_cc3
+                .load(std::sync::atomic::Ordering::Acquire),
             self.attestation_interval,
         );
 
@@ -283,8 +282,13 @@ impl WorkerAttestationProduction {
 
                     tracing::info!(height, ?digest, "💾 New execution chain attestation");
 
-                    if attestation_latest_cc3.height > self.attestation_latest_cc3.height {
-                        self.attestation_latest_cc3 = attestation_latest_cc3;
+                    if attestation_latest_cc3.height
+                        > self
+                            .attestation_latest_cc3
+                            .load(std::sync::atomic::Ordering::Acquire)
+                    {
+                        self.attestation_latest_cc3
+                            .store(height, std::sync::atomic::Ordering::Release);
 
                         // 1. Chain Listener - Eth
                         //
@@ -345,7 +349,9 @@ impl WorkerAttestationProduction {
                         return Ok(());
                     };
 
-                    let attestation_latest_cc3 = self.attestation_latest_cc3.height;
+                    let attestation_latest_cc3 = self
+                        .attestation_latest_cc3
+                        .load(std::sync::atomic::Ordering::Acquire);
 
                     // 1. Chain listener - Eth
                     //
@@ -492,7 +498,8 @@ impl WorkerAttestationProduction {
 
                     tracing::info!(height, ?digest, "💾 Attestation chain reversion detected!");
 
-                    self.attestation_latest_cc3 = attestation_latest_cc3;
+                    self.attestation_latest_cc3
+                        .store(height, std::sync::atomic::Ordering::Release);
                     self.attestation_local = height;
 
                     // 1. Update the attestation pool

--- a/attestor/attestor/src/worker/validation/mod.rs
+++ b/attestor/attestor/src/worker/validation/mod.rs
@@ -106,6 +106,7 @@ pub struct Config {
 
     validation_sender: attestation_pool::AttestationPoolSender,
     validation_receiver: attestation_pool::AttestationPoolReceiver,
+    attestation_latest_cc3: std::sync::Arc<std::sync::atomic::AtomicU64>,
     can_attest: std::sync::Arc<std::sync::atomic::AtomicBool>,
 
     api_calls: cc_client::cc3::runtime_apis::RuntimeApi,
@@ -127,6 +128,7 @@ pub(crate) struct WorkerAttestationValidation {
     watch_submission: future::OptionFuture<(AttestationSubmission, attestor_primitives::Height)>,
     validation_sender: attestation_pool::AttestationPoolSender,
     validation_receiver: attestation_pool::AttestationPoolReceiver,
+    attestation_latest_cc3: std::sync::Arc<std::sync::atomic::AtomicU64>,
     can_attest: std::sync::Arc<std::sync::atomic::AtomicBool>,
 
     // CHAIN DATA
@@ -148,6 +150,7 @@ impl WorkerAttestationValidation {
             watch_submission: future::OptionFuture::default(),
             validation_receiver: config.validation_receiver,
             validation_sender: config.validation_sender,
+            attestation_latest_cc3: config.attestation_latest_cc3,
             can_attest: config.can_attest,
 
             api_calls: config.api_calls,
@@ -560,9 +563,16 @@ impl WorkerAttestationValidation {
             .first()
             .expect("Invariant violated: quorum must always contain at least one vote");
 
+        let attestation_latest_cc3 = self
+            .attestation_latest_cc3
+            .load(std::sync::atomic::Ordering::Acquire);
+
         // Every attestation must have a continuity proof except for the first attestation in the
         // chain
-        if attestation.continuity_proof.is_empty() && height != self.start_height {
+        if attestation.continuity_proof.is_empty()
+            && height != attestation_latest_cc3.saturating_add(1)
+            && height != self.start_height
+        {
             tracing::error!(?digest, height, "⛔ Empty continuity proof");
             return Err(Interrupt::Cont(Error::InvalidAttestation(
                 InvalidCause::EmptyContinuityProof,

--- a/attestor/pool/src/lib.rs
+++ b/attestor/pool/src/lib.rs
@@ -674,7 +674,11 @@ impl AttestationPoolForks {
 
         tracing::debug!("Validating tail prev digest");
 
-        let prev_digest_tail = attestation.continuity_proof.tail_prev_digest();
+        let prev_digest_tail = if self.validate_quorum.attestation_interval.get() == 1 {
+            attestation.prev_digest()
+        } else {
+            attestation.continuity_proof.tail_prev_digest()
+        };
 
         let key_vote = KeyVote {
             height,
@@ -700,7 +704,7 @@ impl AttestationPoolForks {
         if prev_digest_tail != self.last_finalized_digest {
             tracing::warn!(
                 last_finalized_digest = ?self.last_finalized_digest,
-                 prev_digest_tail = ?prev_digest_tail,
+                prev_digest_tail = ?prev_digest_tail,
                 "🏎️ Received pending attestation"
             );
 

--- a/common/streams/attestation/src/lib.rs
+++ b/common/streams/attestation/src/lib.rs
@@ -267,9 +267,11 @@ impl StreamAttestation {
         );
 
         let continuity_proof = attestor_primitives::block::ContinuityProof::from_blocks(blocks);
-
-        let prev_digest = (!continuity_proof.is_empty())
-            .then(|| continuity_proof.compute_continuity_digest(block_first));
+        let prev_digest = if self.attestation_interval.get() == 1 {
+            Some(self.attestation_prev.digest)
+        } else {
+            Some(continuity_proof.compute_continuity_digest(block_first))
+        };
 
         let attestation_data = attestor_primitives::AttestationData::new(
             self.chain_key,


### PR DESCRIPTION
# Description of proposed changes

<describe what this PR is about and why we want it>

Local attestation validation now supports attestation intervals of 1.

## Fixes

- [audit item 6](https://github.com/chainlight-io/2026-q1-ctc-usc-phase2-audit-issues/issues/6)
