### PR TITLE
ci(check-prover): add BSC testnet on CC3 devnet (chain key 5)

### DIFF
--- a/.github/workflows/check-prover.yml
+++ b/.github/workflows/check-prover.yml
@@ -26,6 +26,12 @@ jobs:
             indexerUrl: "https://graphql-usc.cc3-devnet.creditcoin.network"
             chainKey: 4
 
+          # CC3 Devnet, BSC Testnet
+          - creditcoinUrl: "wss://rpc.cc3-devnet.creditcoin.network/ws"
+            proverUrl: "https://prover.cc3-devnet.creditcoin.network"
+            indexerUrl: "https://graphql-usc.cc3-devnet.creditcoin.network"
+            chainKey: 5
+
           # CC3 Testnet, Sepolia Full Archive
           - creditcoinUrl: "wss://rpc.cc3-testnet.creditcoin.network/ws"
             proverUrl: "https://prover.cc3-testnet.creditcoin.network"


### PR DESCRIPTION
Adds a new matrix entry to `check-prover.yml` for BSC testnet deployed on CC3 devnet (chain key 5), per Alex in the snapshots channel.