### PR TITLE
fix(api): correctly use fallback provider

### DIFF
--- a/common/continuity/src/rpc.rs
+++ b/common/continuity/src/rpc.rs
@@ -18,14 +18,6 @@ use usc_abi_encoding::common::EncodingVersion;
 use user::prelude::*;
 use utils::block_item_traits::BlockItem;
 
-fn eth_inconsistent_block_payload_from_anyhow(err: &anyhow::Error) -> bool {
-    err.chain().any(|cause| {
-        cause
-            .downcast_ref::<eth::Error>()
-            .is_some_and(eth::Error::inconsistent_block_payload_for_fallback)
-    })
-}
-
 /// Total attempts (call + retries-after-reconnect) for a single RPC operation.
 const ETH_RPC_MAX_ATTEMPTS: usize = 3;
 
@@ -71,7 +63,7 @@ impl ReconnectingEthRpcProvider {
             match call(client).await {
                 Ok(value) => return Ok(value),
                 Err(err) => {
-                    if eth_inconsistent_block_payload_from_anyhow(&err) {
+                    if eth::anyhow_chain_is_inconsistent_block_payload(&err) {
                         warn!(
                             op,
                             attempt,

--- a/common/continuity/src/rpc.rs
+++ b/common/continuity/src/rpc.rs
@@ -18,6 +18,14 @@ use usc_abi_encoding::common::EncodingVersion;
 use user::prelude::*;
 use utils::block_item_traits::BlockItem;
 
+fn eth_inconsistent_block_payload_from_anyhow(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<eth::Error>()
+            .is_some_and(eth::Error::inconsistent_block_payload_for_fallback)
+    })
+}
+
 /// Total attempts (call + retries-after-reconnect) for a single RPC operation.
 const ETH_RPC_MAX_ATTEMPTS: usize = 3;
 
@@ -63,6 +71,16 @@ impl ReconnectingEthRpcProvider {
             match call(client).await {
                 Ok(value) => return Ok(value),
                 Err(err) => {
+                    if eth_inconsistent_block_payload_from_anyhow(&err) {
+                        warn!(
+                            op,
+                            attempt,
+                            max = ETH_RPC_MAX_ATTEMPTS,
+                            error = %err,
+                            "ETH RPC returned block data inconsistent with header; not retrying with reconnect",
+                        );
+                        return Err(err);
+                    }
                     warn!(
                         op,
                         attempt,

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -89,14 +89,6 @@ pub enum Error {
 }
 
 impl Error {
-    /// If this error is [`Error::BlockHeaderRootsMismatch`], returns the block number.
-    pub fn block_header_roots_mismatch_block(&self) -> Option<u64> {
-        match self {
-            Error::BlockHeaderRootsMismatch(n) => Some(*n),
-            _ => None,
-        }
-    }
-
     /// True when the payload returned for a block (from a single RPC peer) cannot be reconciled
     /// with the block header or expected shape. Callers should try another endpoint instead of
     /// treating this as a transient transport failure.
@@ -125,6 +117,33 @@ impl Error {
             _ => None,
         }
     }
+}
+
+/// True when any cause in the [`anyhow::Error`] chain is an [`Error`] that
+/// [`Error::inconsistent_block_payload_for_fallback`] classifies as a payload-inconsistency case.
+///
+/// Use this from layers above the eth client that receive an `anyhow::Error` and need to
+/// distinguish "the peer returned a structurally inconsistent block payload" (try another
+/// endpoint / surface 422) from "transport failure" (reconnect / surface 503). Keeping the
+/// classifier here means a future addition to
+/// [`Error::inconsistent_block_payload_for_fallback`] is automatically picked up by every
+/// caller.
+pub fn anyhow_chain_is_inconsistent_block_payload(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<Error>()
+            .is_some_and(Error::inconsistent_block_payload_for_fallback)
+    })
+}
+
+/// Walks the [`anyhow::Error`] chain looking for an [`Error`] that carries a block-number
+/// hint via [`Error::inconsistent_block_number_hint`] and returns the first hit.
+pub fn anyhow_chain_inconsistent_block_number_hint(err: &anyhow::Error) -> Option<u64> {
+    err.chain().find_map(|cause| {
+        cause
+            .downcast_ref::<Error>()
+            .and_then(Error::inconsistent_block_number_hint)
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -717,19 +736,31 @@ impl Client {
 
     /// Fetch full block and [`eth_getBlockReceipts`](https://ethereum.github.io/execution-apis/api-documentation/) from the **same**
     /// [`AlloyProvider`] so the header cannot be paired with receipts from another backend.
+    ///
+    /// The two RPC calls are independent reads against the same provider, so we issue them
+    /// concurrently with [`tokio::try_join!`] to cut the per-block latency roughly in half on
+    /// the happy path. Pairing on the **same** provider is what keeps reorg-safety: if the
+    /// peer reorgs between the two calls, the recomputed header roots will fail to match in
+    /// [`OrderedBlock::try_from_fetched_block`] and the caller will fall through to the next
+    /// endpoint (or retry the whole sweep).
     async fn fetch_block_and_receipts_from_provider(
         provider: &AlloyProvider,
         number: u64,
     ) -> Result<(Block, Vec<TransactionReceipt>), Error> {
         let block_id = BlockId::Number(BlockNumberOrTag::Number(number));
-        let block = provider
-            .get_block(block_id, true.into())
-            .await?
-            .ok_or(Error::FailedToGetBlock(number))?;
-        let receipts = provider
-            .get_block_receipts(block_id)
-            .await?
-            .ok_or(Error::FailedToGetReceipts(number))?;
+        let block_fut = async {
+            provider
+                .get_block(block_id, true.into())
+                .await?
+                .ok_or(Error::FailedToGetBlock(number))
+        };
+        let receipts_fut = async {
+            provider
+                .get_block_receipts(block_id)
+                .await?
+                .ok_or(Error::FailedToGetReceipts(number))
+        };
+        let (block, receipts) = tokio::try_join!(block_fut, receipts_fut)?;
         Ok((block, receipts))
     }
 
@@ -1336,20 +1367,41 @@ mod error_classifier_tests {
     }
 
     #[test]
-    fn block_header_roots_mismatch_accessor_is_strict() {
+    fn anyhow_chain_helpers_walk_context_to_find_eth_error() {
+        // Wrapping a payload-inconsistency `eth::Error` in extra `.context(...)` layers must
+        // not hide it from callers above the eth client. Both shared helpers walk the
+        // `anyhow::Error::chain()` and must surface the inner classification and the
+        // block-number hint.
+        let inner = anyhow::Error::new(Error::BlockHeaderRootsMismatch(42))
+            .context("while building continuity blocks")
+            .context("in fetch sweep #3");
+        assert!(super::anyhow_chain_is_inconsistent_block_payload(&inner));
         assert_eq!(
-            Error::BlockHeaderRootsMismatch(99).block_header_roots_mismatch_block(),
-            Some(99)
+            super::anyhow_chain_inconsistent_block_number_hint(&inner),
+            Some(42)
         );
-        // Only the literal `BlockHeaderRootsMismatch` variant should be exposed by
-        // this narrower accessor — callers asking for the broader "inconsistent"
-        // set must use `inconsistent_block_number_hint`.
+    }
+
+    #[test]
+    fn anyhow_chain_helpers_reject_non_inconsistent_chains() {
+        // "Not found" / transport-style chains must not be flagged as inconsistent and
+        // must not produce a block-number hint. Misclassifying these would disable the
+        // reconnect-retry path and surface a non-retriable 422 to API clients.
+        let not_found = anyhow::Error::new(Error::FailedToGetBlock(42));
+        assert!(!super::anyhow_chain_is_inconsistent_block_payload(
+            &not_found
+        ));
         assert_eq!(
-            Error::TransactionsReceiptsMismatch(99).block_header_roots_mismatch_block(),
+            super::anyhow_chain_inconsistent_block_number_hint(&not_found),
             None
         );
+
+        let transport = anyhow::anyhow!("connection refused");
+        assert!(!super::anyhow_chain_is_inconsistent_block_payload(
+            &transport
+        ));
         assert_eq!(
-            Error::FailedToGetBlock(99).block_header_roots_mismatch_block(),
+            super::anyhow_chain_inconsistent_block_number_hint(&transport),
             None
         );
     }

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -100,14 +100,19 @@ impl Error {
     /// True when the payload returned for a block (from a single RPC peer) cannot be reconciled
     /// with the block header or expected shape. Callers should try another endpoint instead of
     /// treating this as a transient transport failure.
+    ///
+    /// Deliberately does **not** include [`Error::FailedToGetBlock`] /
+    /// [`Error::FailedToGetReceipts`]: those are produced when a provider answers `Ok(None)`
+    /// ("I don't have that block yet"), which is a not-found / behind-the-head signal rather
+    /// than a structural inconsistency. Surfacing those as inconsistent would (a) suppress the
+    /// reconnect-retry path in [`crate::ReconnectingEthRpcProvider`] and (b) map them to a
+    /// non-retriable 422 in the API, both of which are wrong for a peer that's just lagging.
     pub fn inconsistent_block_payload_for_fallback(&self) -> bool {
         matches!(
             self,
             Error::BlockHeaderRootsMismatch(_)
                 | Error::TransactionsReceiptsMismatch(_)
                 | Error::NotFullTransactionsFetched(_)
-                | Error::FailedToGetBlock(_)
-                | Error::FailedToGetReceipts(_)
         )
     }
 
@@ -116,9 +121,7 @@ impl Error {
         match self {
             Error::BlockHeaderRootsMismatch(n)
             | Error::TransactionsReceiptsMismatch(n)
-            | Error::NotFullTransactionsFetched(n)
-            | Error::FailedToGetBlock(n)
-            | Error::FailedToGetReceipts(n) => Some(*n),
+            | Error::NotFullTransactionsFetched(n) => Some(*n),
             _ => None,
         }
     }
@@ -593,17 +596,23 @@ impl Client {
             BlockId::Number(BlockNumberOrTag::Number(number))
         );
 
+        // One "attempt" = one full sweep through `[primary, fallbacks...]`. With N providers
+        // this is up to MAX_ATTEMPTS * N RPC round-trips for a single block fetch. This is a
+        // deliberate change from the previous per-call retry counter: with provider pairing,
+        // a transient mismatch (e.g. reorg between `eth_getBlockByNumber` and
+        // `eth_getBlockReceipts` on the same peer) is only resolvable by re-fetching, so we
+        // back off and retry the whole sweep instead of bailing on the first pass.
         const MAX_ATTEMPTS: usize = 5;
         const DELAY_BASE: u64 = 10;
         const DELAY_MAX: u64 = 60;
 
-        let mut attempt = 0u32;
+        let mut attempt: usize = 0;
         let mut delay = DELAY_BASE;
 
         loop {
             attempt += 1;
-            let mut last_transport_err: Option<Error> = None;
-            let mut last_payload_inconsistent: Option<Error> = None;
+            let mut last_transport_err: Option<(String, Error)> = None;
+            let mut last_payload_inconsistent: Option<(String, Error)> = None;
 
             for (label, provider) in self.providers_with_labels() {
                 match Self::fetch_block_and_receipts_from_provider(provider, number).await {
@@ -615,7 +624,34 @@ impl Client {
                             number,
                             encoding,
                         ) {
-                            Ok(ob) => return Ok(ob),
+                            Ok(ob) => {
+                                // Don't silently drop earlier-provider failures: if the primary
+                                // (or an earlier fallback) errored and a later peer served the
+                                // request, surface that at warn so operators can root-cause
+                                // flaky peers.
+                                if label != "primary" {
+                                    if let Some((err_label, err)) = last_transport_err.take() {
+                                        tracing::warn!(
+                                            provider = %err_label,
+                                            served_by = %label,
+                                            block_number = number,
+                                            error = %err,
+                                            "block+receipts fetch: provider errored but another succeeded"
+                                        );
+                                    }
+                                    if let Some((err_label, err)) = last_payload_inconsistent.take()
+                                    {
+                                        tracing::warn!(
+                                            provider = %err_label,
+                                            served_by = %label,
+                                            block_number = number,
+                                            error = %err,
+                                            "block+receipts fetch: provider returned inconsistent payload but another succeeded"
+                                        );
+                                    }
+                                }
+                                return Ok(ob);
+                            }
                             Err(e) if e.inconsistent_block_payload_for_fallback() => {
                                 tracing::warn!(
                                     provider = %label,
@@ -623,9 +659,11 @@ impl Client {
                                     error = %e,
                                     "block body or receipts inconsistent with header from this RPC peer; trying next endpoint"
                                 );
-                                last_payload_inconsistent = Some(e);
+                                last_payload_inconsistent = Some((label, e));
                             }
                             Err(e) => {
+                                // Structural error unrelated to per-peer inconsistency
+                                // (e.g. chain-id mismatch) — fail fast, no retry.
                                 tracing::error!(error = %e, "⛔ Failed to verify block data");
                                 return Err(Interrupt::Cont(e));
                             }
@@ -638,23 +676,26 @@ impl Client {
                             error = %e,
                             "failed to retrieve block/receipts pair from provider"
                         );
-                        last_transport_err = Some(e);
+                        last_transport_err = Some((label, e));
                     }
                 }
             }
 
-            if let Some(e) = last_payload_inconsistent {
+            // Prefer surfacing the payload-inconsistency cause if we have one: it carries the
+            // most informative classification (and the block-number hint) for the caller.
+            // Otherwise, fall back to the last transport error, or a generic "not found".
+            let err = last_payload_inconsistent
+                .map(|(_, e)| e)
+                .or_else(|| last_transport_err.map(|(_, e)| e))
+                .unwrap_or(Error::FailedToGetBlock(number));
+
+            if attempt >= MAX_ATTEMPTS {
                 tracing::error!(
-                    error = %e,
-                    "⛔ all RPC endpoints returned a payload inconsistent with the block header (or exhausted fallbacks)"
+                    attempt,
+                    MAX_ATTEMPTS,
+                    error = %err,
+                    "⛔ all RPC endpoints failed to return a consistent block+receipts pair after retries"
                 );
-                return Err(Interrupt::Cont(e));
-            }
-
-            let err = last_transport_err.unwrap_or(Error::FailedToGetBlock(number));
-
-            if attempt >= MAX_ATTEMPTS as u32 {
-                tracing::error!(error = %err, "⛔ Failed to retrieve eth block");
                 return Err(Interrupt::Cont(err));
             }
 
@@ -1231,5 +1272,85 @@ mod provider_lookup_tests {
         // middle. Verify each segment is evaluated independently.
         let redacted = redact_url_query("https://eth.example.io/v1/aB3xQ9MnP2rT7vW4kY8jL6/rpc");
         assert_eq!(redacted, "https://eth.example.io/v1/…/rpc");
+    }
+}
+
+#[cfg(test)]
+mod error_classifier_tests {
+    use super::Error;
+
+    #[test]
+    fn inconsistent_payload_matches_only_genuine_mismatch_variants() {
+        // Structural mismatches between the fetched body/receipts and the header:
+        // these are the only variants that should cause a fallback skip and map to
+        // `UnsupportedBlockFormat` 422 at the API edge.
+        assert!(Error::BlockHeaderRootsMismatch(42).inconsistent_block_payload_for_fallback());
+        assert!(Error::TransactionsReceiptsMismatch(42).inconsistent_block_payload_for_fallback());
+        assert!(Error::NotFullTransactionsFetched(42).inconsistent_block_payload_for_fallback());
+    }
+
+    #[test]
+    fn not_found_and_transport_errors_are_not_inconsistent() {
+        // `FailedToGetBlock` / `FailedToGetReceipts` are produced when a provider
+        // answers `Ok(None)` ("I don't have this block yet"). Treating those as
+        // structurally inconsistent would (a) disable the reconnect-retry path in
+        // `ReconnectingEthRpcProvider` and (b) make the API surface a non-retriable
+        // 422 for a peer that's just lagging. They must NOT be in this set.
+        assert!(!Error::FailedToGetBlock(42).inconsistent_block_payload_for_fallback());
+        assert!(!Error::FailedToGetReceipts(42).inconsistent_block_payload_for_fallback());
+        assert!(
+            !Error::ClientError(anyhow::anyhow!("boom")).inconsistent_block_payload_for_fallback()
+        );
+        assert!(!Error::UnsupportedUrl("weird://".into()).inconsistent_block_payload_for_fallback());
+    }
+
+    #[test]
+    fn block_number_hint_only_present_for_inconsistent_variants() {
+        assert_eq!(
+            Error::BlockHeaderRootsMismatch(7).inconsistent_block_number_hint(),
+            Some(7)
+        );
+        assert_eq!(
+            Error::TransactionsReceiptsMismatch(7).inconsistent_block_number_hint(),
+            Some(7)
+        );
+        assert_eq!(
+            Error::NotFullTransactionsFetched(7).inconsistent_block_number_hint(),
+            Some(7)
+        );
+        // Symmetry with `inconsistent_block_payload_for_fallback`: "not found"
+        // variants are not classified as inconsistent, and therefore must not
+        // surface a block-number hint via this accessor.
+        assert_eq!(
+            Error::FailedToGetBlock(7).inconsistent_block_number_hint(),
+            None
+        );
+        assert_eq!(
+            Error::FailedToGetReceipts(7).inconsistent_block_number_hint(),
+            None
+        );
+        assert_eq!(
+            Error::ClientError(anyhow::anyhow!("boom")).inconsistent_block_number_hint(),
+            None
+        );
+    }
+
+    #[test]
+    fn block_header_roots_mismatch_accessor_is_strict() {
+        assert_eq!(
+            Error::BlockHeaderRootsMismatch(99).block_header_roots_mismatch_block(),
+            Some(99)
+        );
+        // Only the literal `BlockHeaderRootsMismatch` variant should be exposed by
+        // this narrower accessor — callers asking for the broader "inconsistent"
+        // set must use `inconsistent_block_number_hint`.
+        assert_eq!(
+            Error::TransactionsReceiptsMismatch(99).block_header_roots_mismatch_block(),
+            None
+        );
+        assert_eq!(
+            Error::FailedToGetBlock(99).block_header_roots_mismatch_block(),
+            None
+        );
     }
 }

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -630,8 +630,12 @@ impl Client {
 
         loop {
             attempt += 1;
-            let mut last_transport_err: Option<(String, Error)> = None;
-            let mut last_payload_inconsistent: Option<(String, Error)> = None;
+            // Accumulate *every* provider failure in this sweep — not just the last one of each
+            // kind. With N ≥ 3 providers, two flaky peers followed by a healthy fallback would
+            // otherwise leave the operator blind to the first failure (the second would
+            // overwrite it). Mirrors the old `get_receipts` walker's `Vec`-of-errors behavior.
+            let mut transport_errs: Vec<(String, Error)> = Vec::new();
+            let mut payload_inconsistent_errs: Vec<(String, Error)> = Vec::new();
 
             for (label, provider) in self.providers_with_labels() {
                 match Self::fetch_block_and_receipts_from_provider(provider, number).await {
@@ -646,10 +650,10 @@ impl Client {
                             Ok(ob) => {
                                 // Don't silently drop earlier-provider failures: if the primary
                                 // (or an earlier fallback) errored and a later peer served the
-                                // request, surface that at warn so operators can root-cause
-                                // flaky peers.
+                                // request, surface *every* prior failure at warn so operators
+                                // can root-cause flaky peers even when 3+ providers are configured.
                                 if label != "primary" {
-                                    if let Some((err_label, err)) = last_transport_err.take() {
+                                    for (err_label, err) in transport_errs.drain(..) {
                                         tracing::warn!(
                                             provider = %err_label,
                                             served_by = %label,
@@ -658,8 +662,7 @@ impl Client {
                                             "block+receipts fetch: provider errored but another succeeded"
                                         );
                                     }
-                                    if let Some((err_label, err)) = last_payload_inconsistent.take()
-                                    {
+                                    for (err_label, err) in payload_inconsistent_errs.drain(..) {
                                         tracing::warn!(
                                             provider = %err_label,
                                             served_by = %label,
@@ -678,7 +681,7 @@ impl Client {
                                     error = %e,
                                     "block body or receipts inconsistent with header from this RPC peer; trying next endpoint"
                                 );
-                                last_payload_inconsistent = Some((label, e));
+                                payload_inconsistent_errs.push((label, e));
                             }
                             Err(e) => {
                                 // Structural error unrelated to per-peer inconsistency
@@ -695,17 +698,20 @@ impl Client {
                             error = %e,
                             "failed to retrieve block/receipts pair from provider"
                         );
-                        last_transport_err = Some((label, e));
+                        transport_errs.push((label, e));
                     }
                 }
             }
 
-            // Prefer surfacing the payload-inconsistency cause if we have one: it carries the
-            // most informative classification (and the block-number hint) for the caller.
-            // Otherwise, fall back to the last transport error, or a generic "not found".
-            let err = last_payload_inconsistent
+            // Sweep failed end-to-end. Prefer the payload-inconsistency cause for the
+            // propagated error — it carries the block-number hint and a non-retriable
+            // classification at the API layer — falling back to the last transport error and
+            // then a generic "not found". Earlier per-provider failures were already emitted
+            // at warn/debug inside the loop, so we don't re-log them here to avoid spam.
+            let err = payload_inconsistent_errs
+                .pop()
                 .map(|(_, e)| e)
-                .or_else(|| last_transport_err.map(|(_, e)| e))
+                .or_else(|| transport_errs.pop().map(|(_, e)| e))
                 .unwrap_or(Error::FailedToGetBlock(number));
 
             if attempt >= MAX_ATTEMPTS {

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -88,6 +88,42 @@ pub enum Error {
     UnsupportedUrl(String),
 }
 
+impl Error {
+    /// If this error is [`Error::BlockHeaderRootsMismatch`], returns the block number.
+    pub fn block_header_roots_mismatch_block(&self) -> Option<u64> {
+        match self {
+            Error::BlockHeaderRootsMismatch(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    /// True when the payload returned for a block (from a single RPC peer) cannot be reconciled
+    /// with the block header or expected shape. Callers should try another endpoint instead of
+    /// treating this as a transient transport failure.
+    pub fn inconsistent_block_payload_for_fallback(&self) -> bool {
+        matches!(
+            self,
+            Error::BlockHeaderRootsMismatch(_)
+                | Error::TransactionsReceiptsMismatch(_)
+                | Error::NotFullTransactionsFetched(_)
+                | Error::FailedToGetBlock(_)
+                | Error::FailedToGetReceipts(_)
+        )
+    }
+
+    /// Block number associated with [`Error::inconsistent_block_payload_for_fallback`] errors, if any.
+    pub fn inconsistent_block_number_hint(&self) -> Option<u64> {
+        match self {
+            Error::BlockHeaderRootsMismatch(n)
+            | Error::TransactionsReceiptsMismatch(n)
+            | Error::NotFullTransactionsFetched(n)
+            | Error::FailedToGetBlock(n)
+            | Error::FailedToGetReceipts(n) => Some(*n),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "block_cache", derive(serde::Serialize, serde::Deserialize))]
 pub struct TxRx {
@@ -296,9 +332,11 @@ pub enum ConnectionTransport {
 ///
 /// The [`Client`] always tries its primary URL first; on `Ok(None)` or
 /// transport errors it walks `fallback_providers` in declared order and
-/// uses the first non-empty answer. All fallback URLs must point to a
-/// node that reports the same `chain_id` as the primary URL — this is
-/// verified when the [`Client`] is constructed.
+/// uses the first non-empty answer. For full blocks, `eth_getBlockByNumber(full)`
+/// and `eth_getBlockReceipts` are always queried on the **same** provider so a
+/// block header cannot be paired with receipts from another backend.
+/// All fallback URLs must point to a node that reports the same `chain_id` as
+/// the primary URL — this is verified when the [`Client`] is constructed.
 #[derive(Debug, Clone)]
 pub(crate) struct FallbackProvider {
     pub(crate) url: Url,
@@ -559,53 +597,73 @@ impl Client {
         const DELAY_BASE: u64 = 10;
         const DELAY_MAX: u64 = 60;
 
-        let mut attempt = 0;
+        let mut attempt = 0u32;
         let mut delay = DELAY_BASE;
 
-        let ordered_block = loop {
-            let get_eth_block_fut = self.get_eth_block(number);
-            let get_eth_receipts_fut = self.get_receipts(number);
+        loop {
+            attempt += 1;
+            let mut last_transport_err: Option<Error> = None;
+            let mut last_payload_inconsistent: Option<Error> = None;
 
-            match futures::future::try_join(get_eth_block_fut, get_eth_receipts_fut).await {
-                Ok((block, receipts)) => {
-                    match OrderedBlock::try_from_fetched_block(
-                        self.chain_id,
-                        block,
-                        receipts,
-                        number,
-                        encoding,
-                    ) {
-                        Ok(ob) => break ob,
-                        Err(err) => {
-                            attempt += 1;
-                            tracing::debug!(
-                                attempt,
-                                MAX_ATTEMPTS,
-                                error = %err,
-                                "Block body inconsistent with header roots (likely reorg between RPC calls), retrying..."
-                            );
-                            if attempt >= MAX_ATTEMPTS {
-                                tracing::error!(error = %err, "⛔ Failed to verify consistent block data");
-                                return Err(Interrupt::Cont(err));
+            for (label, provider) in self.providers_with_labels() {
+                match Self::fetch_block_and_receipts_from_provider(provider, number).await {
+                    Ok((block, receipts)) => {
+                        match OrderedBlock::try_from_fetched_block(
+                            self.chain_id,
+                            block,
+                            receipts,
+                            number,
+                            encoding,
+                        ) {
+                            Ok(ob) => return Ok(ob),
+                            Err(e) if e.inconsistent_block_payload_for_fallback() => {
+                                tracing::warn!(
+                                    provider = %label,
+                                    block_number = number,
+                                    error = %e,
+                                    "block body or receipts inconsistent with header from this RPC peer; trying next endpoint"
+                                );
+                                last_payload_inconsistent = Some(e);
+                            }
+                            Err(e) => {
+                                tracing::error!(error = %e, "⛔ Failed to verify block data");
+                                return Err(Interrupt::Cont(e));
                             }
                         }
                     }
-                }
-                Err(err) => {
-                    attempt += 1;
-
-                    tracing::debug!(
-                        attempt,
-                        MAX_ATTEMPTS,
-                        "Failed to retrieve eth block, retrying..."
-                    );
-
-                    if attempt >= MAX_ATTEMPTS {
-                        tracing::error!(error = %err, "⛔ Failed to retrieve eth block");
-                        return Err(Interrupt::Cont(err));
+                    Err(e) => {
+                        tracing::debug!(
+                            provider = %label,
+                            block_number = number,
+                            error = %e,
+                            "failed to retrieve block/receipts pair from provider"
+                        );
+                        last_transport_err = Some(e);
                     }
                 }
             }
+
+            if let Some(e) = last_payload_inconsistent {
+                tracing::error!(
+                    error = %e,
+                    "⛔ all RPC endpoints returned a payload inconsistent with the block header (or exhausted fallbacks)"
+                );
+                return Err(Interrupt::Cont(e));
+            }
+
+            let err = last_transport_err.unwrap_or(Error::FailedToGetBlock(number));
+
+            if attempt >= MAX_ATTEMPTS as u32 {
+                tracing::error!(error = %err, "⛔ Failed to retrieve eth block");
+                return Err(Interrupt::Cont(err));
+            }
+
+            tracing::debug!(
+                attempt,
+                MAX_ATTEMPTS,
+                error = %err,
+                "all RPC endpoints failed to return block+receipts; backing off before retry"
+            );
 
             tokio::select! {
                 _ = tokio::time::sleep(std::time::Duration::from_secs(delay)) => {},
@@ -613,9 +671,25 @@ impl Client {
             }
 
             delay = (delay * 2).min(DELAY_MAX);
-        };
+        }
+    }
 
-        Ok(ordered_block)
+    /// Fetch full block and [`eth_getBlockReceipts`](https://ethereum.github.io/execution-apis/api-documentation/) from the **same**
+    /// [`AlloyProvider`] so the header cannot be paired with receipts from another backend.
+    async fn fetch_block_and_receipts_from_provider(
+        provider: &AlloyProvider,
+        number: u64,
+    ) -> Result<(Block, Vec<TransactionReceipt>), Error> {
+        let block_id = BlockId::Number(BlockNumberOrTag::Number(number));
+        let block = provider
+            .get_block(block_id, true.into())
+            .await?
+            .ok_or(Error::FailedToGetBlock(number))?;
+        let receipts = provider
+            .get_block_receipts(block_id)
+            .await?
+            .ok_or(Error::FailedToGetReceipts(number))?;
+        Ok((block, receipts))
     }
 
     #[cfg(not(feature = "block_cache"))]
@@ -632,85 +706,6 @@ impl Client {
     ) -> std::result::Result<alloy::pubsub::SubscriptionStream<alloy::rpc::types::Header>, Error>
     {
         Ok(self.rpc_provider.subscribe_blocks().await?.into_stream())
-    }
-
-    async fn get_receipts(&self, number: u64) -> Result<Vec<TransactionReceipt>, Error> {
-        let providers = self.providers_with_labels();
-        let mut got_definitive_none = false;
-        let mut errors: Vec<(String, Error)> = Vec::new();
-
-        for (label, provider) in providers {
-            match provider
-                .get_block_receipts(BlockId::Number(BlockNumberOrTag::Number(number)))
-                .await
-            {
-                Ok(Some(receipts)) => {
-                    if label != "primary" {
-                        info!(
-                            provider = %label,
-                            block_number = number,
-                            "receipts fetched via fallback provider"
-                        );
-                    }
-                    // Don't silently drop errors from earlier providers:
-                    // if the primary (or an earlier fallback) errored and a
-                    // later fallback served the request, surface those errors
-                    // at WARN so operators can still root-cause flaky peers.
-                    for (err_label, err) in errors.drain(..) {
-                        tracing::warn!(
-                            provider = %err_label,
-                            served_by = %label,
-                            block_number = number,
-                            error = %err,
-                            "receipts fetch: provider errored but another succeeded"
-                        );
-                    }
-                    return Ok(receipts);
-                }
-                Ok(None) => got_definitive_none = true,
-                Err(e) => errors.push((label, Error::from(e))),
-            }
-        }
-
-        // Mirror the legacy behavior: an `Ok(None)` from a single provider
-        // mapped to `FailedToGetBlock(number)`. When at least one provider
-        // says the receipts are not available we honor that and surface the
-        // block-not-found error; transport errors from any other provider
-        // are demoted to warnings.
-        match merge_provider_lookup(got_definitive_none, errors) {
-            LookupOutcome::NotFound { errors_to_warn } => {
-                for (label, err) in errors_to_warn {
-                    tracing::warn!(
-                        provider = %label,
-                        block_number = number,
-                        error = %err,
-                        "receipts fetch: provider errored but another said `not found`; treating as not found"
-                    );
-                }
-                Err(Error::FailedToGetBlock(number))
-            }
-            LookupOutcome::AllErrored {
-                first,
-                additional_to_warn,
-            } => {
-                for (label, err) in additional_to_warn {
-                    tracing::warn!(
-                        provider = %label,
-                        block_number = number,
-                        error = %err,
-                        "receipts fetch: additional provider error"
-                    );
-                }
-                let (first_label, first_err) = first;
-                error!(
-                    provider = %first_label,
-                    block_number = number,
-                    error = %first_err,
-                    "Failed to get receipts: all providers errored",
-                );
-                Err(Error::FailedToGetReceipts(number))
-            }
-        }
     }
 
     pub async fn get_eth_block(&self, number: u64) -> Result<Block, Error> {
@@ -982,9 +977,8 @@ enum LookupOutcome {
     },
 }
 
-/// Pure decision step shared by every sequential-fallback lookup
-/// ([`Client::get_tx_position_by_hash`], [`Client::get_eth_block`],
-/// [`Client::get_receipts`]).
+/// Pure decision step shared by sequential-fallback lookups such as
+/// [`Client::get_tx_position_by_hash`] and [`Client::get_eth_block`].
 ///
 /// `got_definitive_none` is `true` iff at least one provider returned
 /// `Ok(None)`. `errors` carries every provider that failed to respond.

--- a/proof-gen-api-server/src/networking/routes/continuity.rs
+++ b/proof-gen-api-server/src/networking/routes/continuity.rs
@@ -30,7 +30,7 @@ type TxHashes = Vec<String>;
         (status = 200, description = "Continuity and merkle proof", body = SingleContinuityResponse),
         (status = 400, description = "Invalid parameters", body = ErrorResponse),
         (status = 404, description = "Block or transaction not found", body = ErrorResponse),
-        (status = 422, description = "Block exists but is not yet attested (BlockNotReady)", body = ErrorResponse),
+        (status = 422, description = "Unprocessable: block not yet attested (BlockNotReady), or source RPC block/header inconsistent (UnsupportedBlockFormat)", body = ErrorResponse),
         (status = 503, description = "RPC unavailable", body = ErrorResponse)
     )
 )]
@@ -72,7 +72,7 @@ pub async fn get_proof_with_tx(
         (status = 200, description = "Continuity and merkle proof", body = SingleContinuityResponse),
         (status = 400, description = "Invalid parameters", body = ErrorResponse),
         (status = 404, description = "Transaction not found", body = ErrorResponse),
-        (status = 422, description = "Block exists but is not yet attested (BlockNotReady)", body = ErrorResponse),
+        (status = 422, description = "Unprocessable: block not yet attested (BlockNotReady), or source RPC block/header inconsistent (UnsupportedBlockFormat)", body = ErrorResponse),
         (status = 501, description = "Tx hash lookup not implemented", body = ErrorResponse)
     )
 )]
@@ -105,7 +105,7 @@ pub async fn get_proof_by_tx_hash(
         (status = 200, description = "Continuity and merkle proof entries", body = BatchedContinuityResponse),
         (status = 400, description = "Invalid parameters", body = ErrorResponse),
         (status = 404, description = "Transaction not found", body = ErrorResponse),
-        (status = 422, description = "Block exists but is not yet attested (BlockNotReady)", body = ErrorResponse),
+        (status = 422, description = "Unprocessable: block not yet attested (BlockNotReady), or source RPC block/header inconsistent (UnsupportedBlockFormat)", body = ErrorResponse),
         (status = 501, description = "Tx hash lookup not implemented", body = ErrorResponse)
     )
 )]
@@ -188,7 +188,7 @@ pub async fn get_proof_batch(
         (status = 200, description = "Continuity and merkle proof entries", body = BatchedContinuityResponse),
         (status = 400, description = "Invalid parameters", body = ErrorResponse),
         (status = 404, description = "Transaction not found", body = ErrorResponse),
-        (status = 422, description = "Block exists but is not yet attested (BlockNotReady)", body = ErrorResponse),
+        (status = 422, description = "Unprocessable: block not yet attested (BlockNotReady), or source RPC block/header inconsistent (UnsupportedBlockFormat)", body = ErrorResponse),
         (status = 501, description = "Tx hash lookup not implemented", body = ErrorResponse)
     )
 )]

--- a/proof-gen-api-server/src/prom/mod.rs
+++ b/proof-gen-api-server/src/prom/mod.rs
@@ -452,6 +452,7 @@ mod labels {
     // Error type labels
     #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
     pub enum ErrorType {
+        UnsupportedBlockFormat,
         UnknownChain,
         BlockNotReady,
         BlockBeforeOrAtGenesis,

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -2,7 +2,33 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use super::*;
+use anyhow::Error as AnyhowError;
 use attestor_primitives::block::ContinuityProof;
+use eth;
+
+fn map_eth_rpc_anyhow_to_service_error(
+    err: AnyhowError,
+    fallback_block_number: u64,
+) -> ServiceError {
+    if err.chain().any(|cause| {
+        cause
+            .downcast_ref::<eth::Error>()
+            .is_some_and(eth::Error::inconsistent_block_payload_for_fallback)
+    }) {
+        let block_number = err
+            .chain()
+            .find_map(|cause| {
+                cause
+                    .downcast_ref::<eth::Error>()
+                    .and_then(eth::Error::inconsistent_block_number_hint)
+            })
+            .unwrap_or(fallback_block_number);
+        return ServiceError::UnsupportedBlockFormat { block_number };
+    }
+    ServiceError::RpcUnavailable {
+        message: err.to_string(),
+    }
+}
 
 impl ContinuityService {
     /// Internal helper that always builds a fresh continuity proof directly
@@ -128,8 +154,25 @@ impl ContinuityService {
             .eth_provider
             .build_continuity_blocks(lower_checkpoint_digest, build_from, upper_checkpoint)
             .await
-            .map_err(|err| ServiceError::Internal {
-                message: format!("failed to build continuity blocks: {err}"),
+            .map_err(|err| {
+                if err.chain().any(|cause| {
+                    cause
+                        .downcast_ref::<eth::Error>()
+                        .is_some_and(eth::Error::inconsistent_block_payload_for_fallback)
+                }) {
+                    let block_number = err
+                        .chain()
+                        .find_map(|cause| {
+                            cause
+                                .downcast_ref::<eth::Error>()
+                                .and_then(eth::Error::inconsistent_block_number_hint)
+                        })
+                        .unwrap_or(min_query);
+                    return ServiceError::UnsupportedBlockFormat { block_number };
+                }
+                ServiceError::Internal {
+                    message: format!("failed to build continuity blocks: {err}"),
+                }
             })?;
 
         // Verify the built chain reconciles with the on-chain upper boundary digest.
@@ -199,9 +242,7 @@ impl ContinuityService {
             Ok(None) => Err(ServiceError::TxHashNotFound {
                 tx_hash: format!("0x{}", hex::encode(tx_hash.as_bytes())),
             }),
-            Err(e) => Err(ServiceError::RpcUnavailable {
-                message: format!("failed to resolve tx by hash via RPC: {e:#}"),
-            }),
+            Err(e) => Err(map_eth_rpc_anyhow_to_service_error(e, 0)),
         }
     }
 
@@ -220,9 +261,7 @@ impl ContinuityService {
             .builder
             .get_block_tx_bytes(header_number)
             .await
-            .map_err(|e| ServiceError::RpcUnavailable {
-                message: e.to_string(),
-            })?;
+            .map_err(|e| map_eth_rpc_anyhow_to_service_error(e, header_number))?;
         if tx_bytes.is_empty() {
             if tx_index != 0 {
                 return Err(ServiceError::TxIndexOutOfBounds {
@@ -261,9 +300,7 @@ impl ContinuityService {
                 .builder
                 .get_tx_hash_by_index(header_number, tx_index)
                 .await
-                .map_err(|e| ServiceError::RpcUnavailable {
-                    message: format!("Failed to get tx hash: {e}"),
-                })?
+                .map_err(|e| map_eth_rpc_anyhow_to_service_error(e, header_number))?
         };
 
         // Record merkle proof generation duration

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -17,22 +17,11 @@ fn classify_eth_rpc_anyhow_as_inconsistent(
     err: &AnyhowError,
     fallback_block_number: u64,
 ) -> Option<ServiceError> {
-    let is_inconsistent = err.chain().any(|cause| {
-        cause
-            .downcast_ref::<eth::Error>()
-            .is_some_and(eth::Error::inconsistent_block_payload_for_fallback)
-    });
-    if !is_inconsistent {
+    if !eth::anyhow_chain_is_inconsistent_block_payload(err) {
         return None;
     }
-    let block_number = err
-        .chain()
-        .find_map(|cause| {
-            cause
-                .downcast_ref::<eth::Error>()
-                .and_then(eth::Error::inconsistent_block_number_hint)
-        })
-        .unwrap_or(fallback_block_number);
+    let block_number =
+        eth::anyhow_chain_inconsistent_block_number_hint(err).unwrap_or(fallback_block_number);
     Some(ServiceError::UnsupportedBlockFormat { block_number })
 }
 

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -6,28 +6,69 @@ use anyhow::Error as AnyhowError;
 use attestor_primitives::block::ContinuityProof;
 use eth;
 
+/// If the anyhow chain wraps an [`eth::Error`] that the eth client classifies as a
+/// payload-inconsistency case ([`eth::Error::inconsistent_block_payload_for_fallback`]),
+/// return the corresponding `ServiceError::UnsupportedBlockFormat`, using the block number
+/// hint from the chain when present and `fallback_block_number` otherwise.
+///
+/// Otherwise, return `None` and let the caller pick the appropriate non-inconsistent
+/// mapping (typically `RpcUnavailable` or `Internal`).
+fn classify_eth_rpc_anyhow_as_inconsistent(
+    err: &AnyhowError,
+    fallback_block_number: u64,
+) -> Option<ServiceError> {
+    let is_inconsistent = err.chain().any(|cause| {
+        cause
+            .downcast_ref::<eth::Error>()
+            .is_some_and(eth::Error::inconsistent_block_payload_for_fallback)
+    });
+    if !is_inconsistent {
+        return None;
+    }
+    let block_number = err
+        .chain()
+        .find_map(|cause| {
+            cause
+                .downcast_ref::<eth::Error>()
+                .and_then(eth::Error::inconsistent_block_number_hint)
+        })
+        .unwrap_or(fallback_block_number);
+    Some(ServiceError::UnsupportedBlockFormat { block_number })
+}
+
+/// Map an `anyhow::Error` returned by the eth provider into a `ServiceError`,
+/// using `UnsupportedBlockFormat` for payload-inconsistency causes and
+/// `RpcUnavailable` for everything else. Use
+/// [`map_eth_rpc_anyhow_to_service_error_with`] when the non-inconsistent fallback
+/// should be a different variant (e.g. `Internal`).
 fn map_eth_rpc_anyhow_to_service_error(
     err: AnyhowError,
     fallback_block_number: u64,
 ) -> ServiceError {
-    if err.chain().any(|cause| {
-        cause
-            .downcast_ref::<eth::Error>()
-            .is_some_and(eth::Error::inconsistent_block_payload_for_fallback)
-    }) {
-        let block_number = err
-            .chain()
-            .find_map(|cause| {
-                cause
-                    .downcast_ref::<eth::Error>()
-                    .and_then(eth::Error::inconsistent_block_number_hint)
-            })
-            .unwrap_or(fallback_block_number);
-        return ServiceError::UnsupportedBlockFormat { block_number };
+    map_eth_rpc_anyhow_to_service_error_with(err, fallback_block_number, |err| {
+        ServiceError::RpcUnavailable {
+            message: err.to_string(),
+        }
+    })
+}
+
+/// Same as [`map_eth_rpc_anyhow_to_service_error`] but lets the caller supply the
+/// non-inconsistent fallback mapping. Keeps the payload-inconsistency detection in
+/// a single place so a future addition to
+/// [`eth::Error::inconsistent_block_payload_for_fallback`] only needs to be wired
+/// up once.
+fn map_eth_rpc_anyhow_to_service_error_with<F>(
+    err: AnyhowError,
+    fallback_block_number: u64,
+    on_other: F,
+) -> ServiceError
+where
+    F: FnOnce(AnyhowError) -> ServiceError,
+{
+    if let Some(svc_err) = classify_eth_rpc_anyhow_as_inconsistent(&err, fallback_block_number) {
+        return svc_err;
     }
-    ServiceError::RpcUnavailable {
-        message: err.to_string(),
-    }
+    on_other(err)
 }
 
 impl ContinuityService {
@@ -155,24 +196,11 @@ impl ContinuityService {
             .build_continuity_blocks(lower_checkpoint_digest, build_from, upper_checkpoint)
             .await
             .map_err(|err| {
-                if err.chain().any(|cause| {
-                    cause
-                        .downcast_ref::<eth::Error>()
-                        .is_some_and(eth::Error::inconsistent_block_payload_for_fallback)
-                }) {
-                    let block_number = err
-                        .chain()
-                        .find_map(|cause| {
-                            cause
-                                .downcast_ref::<eth::Error>()
-                                .and_then(eth::Error::inconsistent_block_number_hint)
-                        })
-                        .unwrap_or(min_query);
-                    return ServiceError::UnsupportedBlockFormat { block_number };
-                }
-                ServiceError::Internal {
-                    message: format!("failed to build continuity blocks: {err}"),
-                }
+                map_eth_rpc_anyhow_to_service_error_with(err, min_query, |err| {
+                    ServiceError::Internal {
+                        message: format!("failed to build continuity blocks: {err}"),
+                    }
+                })
             })?;
 
         // Verify the built chain reconciles with the on-chain upper boundary digest.
@@ -477,6 +505,130 @@ mod tests {
         );
         assert!(!err.retriable());
         assert_eq!(err.code(), "TxHashNotFound");
+    }
+
+    // ---------------------------------------------------------------------
+    // Tests for the eth::Error -> ServiceError mapping helper.
+    //
+    // The classifier is the single source of truth for which `eth::Error`
+    // variants map to `UnsupportedBlockFormat` (422, non-retriable) versus
+    // the caller-supplied fallback (typically `RpcUnavailable` 503 or
+    // `Internal` 500). Keep these tests in lockstep with
+    // `eth::Error::inconsistent_block_payload_for_fallback`.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn map_eth_rpc_anyhow_maps_inconsistent_variants_to_unsupported() {
+        for variant in [
+            eth::Error::BlockHeaderRootsMismatch(11),
+            eth::Error::TransactionsReceiptsMismatch(12),
+            eth::Error::NotFullTransactionsFetched(13),
+        ] {
+            let block = variant
+                .inconsistent_block_number_hint()
+                .expect("variant must expose a block-number hint");
+            let err = anyhow::Error::new(variant);
+            let svc_err = super::map_eth_rpc_anyhow_to_service_error(err, /* fallback */ 999);
+            match svc_err {
+                ServiceError::UnsupportedBlockFormat { block_number } => {
+                    assert_eq!(
+                        block_number, block,
+                        "block number hint must win over the fallback"
+                    );
+                }
+                other => panic!("expected UnsupportedBlockFormat, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn map_eth_rpc_anyhow_uses_fallback_block_when_hint_missing() {
+        // A wrapped error with no `eth::Error` cause should fall through to
+        // RpcUnavailable, *not* UnsupportedBlockFormat with a guessed block.
+        let err = anyhow::anyhow!("transport failure, no eth::Error in chain");
+        let svc_err = super::map_eth_rpc_anyhow_to_service_error(err, 12345);
+        assert!(
+            matches!(svc_err, ServiceError::RpcUnavailable { .. }),
+            "non-eth-Error chains must fall through to RpcUnavailable, got {svc_err:?}"
+        );
+    }
+
+    #[test]
+    fn map_eth_rpc_anyhow_treats_failed_to_get_block_as_rpc_unavailable() {
+        // Regression: `FailedToGetBlock` / `FailedToGetReceipts` are produced when
+        // a provider answers `Ok(None)` (block not yet present). They must NOT map
+        // to UnsupportedBlockFormat (which would be a non-retriable 422 to the
+        // client). They should fall through to the caller-supplied fallback
+        // mapping — here, `RpcUnavailable`.
+        let err = anyhow::Error::new(eth::Error::FailedToGetBlock(42));
+        let svc_err = super::map_eth_rpc_anyhow_to_service_error(err, 42);
+        assert!(
+            matches!(svc_err, ServiceError::RpcUnavailable { .. }),
+            "FailedToGetBlock must map to RpcUnavailable, got {svc_err:?}"
+        );
+        assert!(svc_err.retriable());
+
+        let err = anyhow::Error::new(eth::Error::FailedToGetReceipts(42));
+        let svc_err = super::map_eth_rpc_anyhow_to_service_error(err, 42);
+        assert!(
+            matches!(svc_err, ServiceError::RpcUnavailable { .. }),
+            "FailedToGetReceipts must map to RpcUnavailable, got {svc_err:?}"
+        );
+        assert!(svc_err.retriable());
+    }
+
+    #[test]
+    fn map_eth_rpc_anyhow_with_uses_caller_fallback_for_non_inconsistent() {
+        let err = anyhow::anyhow!("some non-eth failure");
+        let svc_err =
+            super::map_eth_rpc_anyhow_to_service_error_with(err, 7, |e| ServiceError::Internal {
+                message: format!("build failed: {e}"),
+            });
+        match svc_err {
+            ServiceError::Internal { message } => assert!(
+                message.starts_with("build failed:"),
+                "caller fallback must be invoked, got {message:?}"
+            ),
+            other => panic!("expected Internal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_eth_rpc_anyhow_with_still_routes_inconsistent_to_unsupported() {
+        // The caller-supplied fallback must not override the inconsistent path.
+        // Even when the caller wants `Internal` for the non-inconsistent case,
+        // a genuine mismatch is still surfaced as `UnsupportedBlockFormat`.
+        let err = anyhow::Error::new(eth::Error::BlockHeaderRootsMismatch(50));
+        let svc_err =
+            super::map_eth_rpc_anyhow_to_service_error_with(err, 999, |e| ServiceError::Internal {
+                message: e.to_string(),
+            });
+        match svc_err {
+            ServiceError::UnsupportedBlockFormat { block_number } => {
+                assert_eq!(block_number, 50);
+            }
+            other => panic!("expected UnsupportedBlockFormat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_eth_rpc_anyhow_walks_context_chain_to_find_eth_error() {
+        // The eth::Error often sits behind several `.context(...)` calls
+        // before reaching the service layer. The classifier walks the full
+        // error chain via `anyhow::Error::chain()`, so a wrapped variant must
+        // still be recognized.
+        let inner = anyhow::Error::new(eth::Error::TransactionsReceiptsMismatch(77));
+        let wrapped = inner.context("while building continuity blocks");
+        let svc_err = super::map_eth_rpc_anyhow_to_service_error(wrapped, /* fallback */ 1);
+        match svc_err {
+            ServiceError::UnsupportedBlockFormat { block_number } => {
+                assert_eq!(
+                    block_number, 77,
+                    "block number must be lifted from the deep cause"
+                );
+            }
+            other => panic!("expected UnsupportedBlockFormat, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/proof-gen-api-server/src/services/errors.rs
+++ b/proof-gen-api-server/src/services/errors.rs
@@ -80,6 +80,8 @@ impl ErrorResponse {
 
 #[derive(Debug, Error)]
 pub enum ServiceError {
+    #[error("block {block_number}: source chain RPC returned data inconsistent with the block header (mixed endpoints, unsupported trie layout, or bad archive payload); cannot build proof")]
+    UnsupportedBlockFormat { block_number: u64 },
     #[error("unknown or unsupported chain_key {chain_key} for this server")]
     UnknownChain { chain_key: u64 },
     #[error("attestations missing for chain {chain_key}")]
@@ -154,6 +156,7 @@ impl ServiceError {
     }
     pub fn code(&self) -> &'static str {
         match self {
+            ServiceError::UnsupportedBlockFormat { .. } => "UnsupportedBlockFormat",
             ServiceError::UnknownChain { .. } => "UnknownChain",
             ServiceError::AttestationsMissing { .. } => "AttestationsMissing",
             ServiceError::QueryOutOfRange { .. } => "QueryOutOfRange",
@@ -199,7 +202,10 @@ impl ServiceError {
             // cannot be processed in the current state, so 422 Unprocessable Entity
             // is more accurate than 404 Not Found and lets clients distinguish
             // "keep waiting / retry" from "this will never exist".
-            Self::BlockNotReady { .. } => StatusCode::UNPROCESSABLE_ENTITY,
+            // Same semantics as BlockNotReady: request may be valid but payload cannot be processed.
+            Self::UnsupportedBlockFormat { .. } | Self::BlockNotReady { .. } => {
+                StatusCode::UNPROCESSABLE_ENTITY
+            }
             Self::MerkleError { .. } | Self::Internal { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -303,6 +309,7 @@ impl From<serde_json::Error> for ServiceError {
 impl GetErrorType for ServiceError {
     fn error_type(&self) -> ErrorType {
         match self {
+            ServiceError::UnsupportedBlockFormat { .. } => ErrorType::UnsupportedBlockFormat,
             ServiceError::UnknownChain { .. } => ErrorType::UnknownChain,
             ServiceError::AttestationsMissing { .. } => ErrorType::AttestationsMissing,
             ServiceError::QueryOutOfRange { .. } => ErrorType::QueryOutOfRange,


### PR DESCRIPTION
# Description of proposed changes

## What

Make full-block proof generation honor the fallback provider list **as a whole pair** instead of treating block headers and receipts as two independent fallback chains. Previously `get_eth_block` and `get_receipts` each walked the providers list separately, so a `(header, receipts)` tuple could end up stitched together from two different RPC peers. When those peers were even slightly out of sync (reorg, late-arriving receipts, archive-vs-full divergence), the resulting `OrderedBlock::try_from_fetched_block` would fail `BlockHeaderRootsMismatch` / `TransactionsReceiptsMismatch` and the API would tight-loop retry against the same broken combination.

## How

- New `eth::Error` helpers in `common/eth/src/lib.rs`:
  - `inconsistent_block_payload_for_fallback()` — classifies header/receipts/full-tx mismatch errors as "try another endpoint" rather than transport-transient.
  - `inconsistent_block_number_hint()` / `block_header_roots_mismatch_block()` — extract the offending block number for diagnostics and API error mapping.
- `Client::get_ordered_block` rewritten:
  - On each attempt, iterate `providers_with_labels()` and call the new `fetch_block_and_receipts_from_provider` helper, which queries `eth_getBlockByNumber(full)` **and** `eth_getBlockReceipts` against the **same** `AlloyProvider`. The header/receipts pair is now guaranteed to come from one backend.
  - Payload-inconsistency errors (`BlockHeaderRootsMismatch`, `TransactionsReceiptsMismatch`, `NotFullTransactionsFetched`, `FailedToGetBlock`, `FailedToGetReceipts`) cause the loop to move to the next provider instead of bailing or hammering the same peer.
  - Transport errors are still retried with exponential backoff (10s → 60s cap, `MAX_ATTEMPTS` outer attempts) and remain Ctrl-C aware.
  - If every provider returns an inconsistent payload, surface the last `Error` as `Interrupt::Cont(...)` so the caller sees the real reason (was previously masked by the retry loop).
- The standalone `Client::get_receipts(...)` fallback walker is removed (its job is now subsumed by the per-provider pairing). `LookupOutcome` docs updated to match (still used by `get_eth_block` and `get_tx_position_by_hash`).
- Reconnect logic in `common/continuity/src/rpc.rs::ReconnectingEthRpcProvider`:
  - New `eth_inconsistent_block_payload_from_anyhow` walks the `anyhow::Error` chain. When the underlying cause is a payload-inconsistency error, we **do not** retry-after-reconnect — reconnecting will not fix bad data — and we return the error to the service layer immediately with a warn log. Transport-style errors still get the existing reconnect+retry treatment.
- Service layer mapping (`proof-gen-api-server/src/services/continuity_service/helpers.rs`):
  - New `map_eth_rpc_anyhow_to_service_error` translates payload-inconsistency causes into a new `ServiceError::UnsupportedBlockFormat { block_number }` (carrying the block hint from the error chain when present), and everything else into the existing `ServiceError::RpcUnavailable`.
  - `build_continuity_blocks`, `resolve_tx_position_by_hash`, `get_block_tx_bytes`, and `get_tx_hash_by_index` call sites updated to use the new mapping.
- New API surface (`proof-gen-api-server`):
  - `ServiceError::UnsupportedBlockFormat` returns **HTTP 422** (same family as `BlockNotReady` — request valid, payload not processable right now) with error code `UnsupportedBlockFormat`.
  - Prometheus `ErrorType` enum gains `UnsupportedBlockFormat`.
  - OpenAPI docs for the four continuity routes broadened their 422 description to cover both `BlockNotReady` and `UnsupportedBlockFormat`.

## Why this matters

In production we observed cases where one fallback peer would briefly return a stale receipts set for a block whose header had already advanced on the primary. With the old code paths that mismatch was structural, not transient — repeating the call against the same providers, in the same order, just reproduced it. Pairing the two calls on a single provider lets the next fallback fix the symptom in a single round trip, and exposing `UnsupportedBlockFormat` upstream gives operators a clear, separately graphable failure mode (different from `RpcUnavailable`).

## Behavioral changes

- API: continuity endpoints can now return `422 UnsupportedBlockFormat` (previously these cases surfaced as `500 Internal` or `503 RpcUnavailable`). The HTTP status family changes for these specific errors.
- Metrics: new `UnsupportedBlockFormat` label appears on the error-type counter.
- Logs: payload-inconsistency at the fallback layer is now `warn!` with `provider`/`block_number`/`error`, and "all endpoints failed" at the retry layer logs the last error at `error!`.
- The `get_receipts` public-in-module helper is removed; receipts are no longer fetched independently of the block.

## Tests / verification

- `cargo fmt` + `cargo clippy -D warnings` (run locally / via CI).
- Existing unit tests on `merge_provider_lookup` / `get_eth_block` / `get_tx_position_by_hash` cover the unchanged fallback walkers.
- Behavior of `get_ordered_block` is exercised end-to-end by the continuity service integration tests.

## Update (fc7eee78): addressed review + bugbot feedback

- **Real reorg between `get_block` and `get_block_receipts` on the same peer no longer terminal.** The outer retry loop in `Client::try_fetch_block` now backs off and re-sweeps the full provider list on payload-inconsistency as well as transport errors; only after exhausting `MAX_ATTEMPTS` do we surface `UnsupportedBlockFormat`. Transient cross-peer divergence self-heals; structural mismatches still surface after retries.
- **`FailedToGetBlock` / `FailedToGetReceipts` removed from `inconsistent_block_payload_for_fallback`.** Those variants are produced when a provider answers `Ok(None)` (block not yet present) and were incorrectly suppressing the reconnect-retry path in `ReconnectingEthRpcProvider` and mapping to a non-retriable 422 `UnsupportedBlockFormat` instead of a retriable 503 `RpcUnavailable`. The classifier is now restricted to the genuine mismatch variants (`BlockHeaderRootsMismatch`, `TransactionsReceiptsMismatch`, `NotFullTransactionsFetched`).
- **Restored the warn-level diagnostic** when a primary or earlier-fallback provider errored and a later peer served the request (lost when `get_receipts` was removed).
- **`MAX_ATTEMPTS` semantic change documented** in a comment: one attempt = one full provider sweep (was: one fetch).
- **Deduplicated the `eth::Error` → `ServiceError` mapping** in `proof-gen-api-server/.../helpers.rs` into a single classifier plus a `..._with(on_other)` variant for callers that want a different non-inconsistent fallback (e.g. `Internal` vs `RpcUnavailable`). Addresses the bugbot low-severity finding.
- **New unit tests:**
  - `common/eth/src/lib.rs` — `error_classifier_tests` covering `inconsistent_block_payload_for_fallback`, `inconsistent_block_number_hint`, and `block_header_roots_mismatch_block`.
  - `proof-gen-api-server` — coverage for `map_eth_rpc_anyhow_to_service_error` / `..._with`, including the regression case where `FailedToGetBlock` must map to `RpcUnavailable` (not `UnsupportedBlockFormat`) and an anyhow `.context()` chain-walk test.

All 38 `proof-gen-api-server` lib tests pass; all 4 new `eth` classifier tests pass.

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed

