### PR TITLE
fix(attestation): gate checkpoint trust anchors while revert pruning is in flight

### DIFF
--- a/pallets/attestation/src/impls.rs
+++ b/pallets/attestation/src/impls.rs
@@ -781,6 +781,30 @@ impl<T: Config> Pallet<T> {
             || Checkpoints::<T>::get(chain_key, block_number) == Some(digest)
     }
 
+    /// Return the checkpoint digest at `(chain_key, block_number)` **only** when no
+    /// chain reversion is currently in flight for `chain_key`.
+    ///
+    /// `revert_to` synchronously purges checkpoints above the revert height **only**
+    /// inside the bucket containing `checkpoint_height`. Buckets at higher pivots are
+    /// pruned asynchronously by `on_init_prune_checkpoints` at
+    /// [`MAX_CHECKPOINTS_CLEARED_PER_BLOCK`](crate::clear_or_revert::MAX_CHECKPOINTS_CLEARED_PER_BLOCK)
+    /// entries per block. During that window [`Checkpoints`] still contains stale
+    /// post-revert digests that consumers using checkpoints as a trust anchor (e.g.
+    /// the `block-prover` precompile) must not accept.
+    ///
+    /// Fail-closed semantics: while [`CheckpointPruningStates`] has an entry for
+    /// `chain_key`, this returns `None` for **every** height on that chain, including
+    /// the revert anchor itself. Callers that need a stable trust anchor must wait
+    /// for async pruning to drain before relying on checkpoint storage again.
+    /// Informational readers that do not gate consensus may keep using the raw
+    /// [`Checkpoints`] storage directly.
+    pub fn checkpoint_if_stable(chain_key: ChainKey, block_number: u64) -> Option<Digest> {
+        if CheckpointPruningStates::<T>::contains_key(chain_key) {
+            return None;
+        }
+        Checkpoints::<T>::get(chain_key, block_number)
+    }
+
     pub fn attestor_bls_pubkey(
         chain_key: ChainKey,
         address: &T::AccountId,

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -19,7 +19,7 @@ mod continuity_dev;
 mod benchmarking;
 
 mod asset;
-mod clear_or_revert;
+pub mod clear_or_revert;
 mod continuity;
 pub mod extensions;
 mod impls;

--- a/pallets/attestation/src/tests.rs
+++ b/pallets/attestation/src/tests.rs
@@ -6366,6 +6366,131 @@ mod revert_to {
                 );
             })
     }
+
+    #[test]
+    fn checkpoint_if_stable_fails_closed_during_revert_pruning_window() {
+        // Repro: `do_revert_to` only synchronously prunes the bucket containing
+        // `checkpoint_height`. Buckets at higher pivots stay populated until
+        // `on_init_prune_checkpoints` drains them, MAX_CHECKPOINTS_CLEARED_PER_BLOCK
+        // entries at a time. Consumers using `Checkpoints` as a trust anchor
+        // (block-prover precompile) must not see those stale digests.
+        //
+        // `checkpoint_if_stable` fails closed on the whole chain while a
+        // CheckpointPruningStates entry exists, then returns the valid post-revert
+        // checkpoint once pruning drains.
+        let revert_height: u64 = 0;
+        let added_checkpoints = MAX_CHECKPOINTS_CLEARED_PER_BLOCK * 2 + 10;
+        let mut test_ext = ExtBuilder.build();
+        test_ext
+            .then_run(|| {
+                // Revert target checkpoint at the anchor height.
+                let revert_digest =
+                    H256::from(&sp_io::hashing::blake2_256(&revert_height.to_be_bytes()));
+                insert_checkpoint_and_bucket_entry::<Test>(
+                    SUPPORTED_CHAIN_KEY,
+                    revert_height,
+                    revert_digest,
+                );
+
+                // Stash post-revert checkpoints in *higher* buckets so the
+                // synchronous prune in `do_revert_to` does not touch them. This
+                // models the bad-data window: these digests live in storage but
+                // must not be trusted while async pruning is in flight.
+                let start_height = revert_height + CHECKPOINT_BUCKET_SIZE;
+                for i in 0..added_checkpoints {
+                    let stale_digest = H256::from(&sp_io::hashing::blake2_256(&[i]));
+                    let stale_height = start_height + (i as u64) * 100;
+                    insert_checkpoint_and_bucket_entry::<Test>(
+                        SUPPORTED_CHAIN_KEY,
+                        stale_height,
+                        stale_digest,
+                    );
+                    if i == added_checkpoints - 1 {
+                        LastCheckpoint::<Test>::insert(
+                            SUPPORTED_CHAIN_KEY,
+                            AttestationCheckpoint {
+                                block_number: stale_height,
+                                digest: stale_digest,
+                            },
+                        );
+                    }
+                }
+                System::set_block_number(1);
+                Timestamp::set_timestamp(1);
+
+                // Pre-revert: helper agrees with raw storage.
+                assert_eq!(
+                    Pallet::<Test>::checkpoint_if_stable(SUPPORTED_CHAIN_KEY, revert_height),
+                    Some(revert_digest)
+                );
+                let sample_stale_height = start_height + 100;
+                assert!(
+                    Checkpoints::<Test>::get(SUPPORTED_CHAIN_KEY, sample_stale_height).is_some()
+                );
+            })
+            .then_run(|| {
+                // Initiate reversion. Buckets above the revert pivot are NOT yet pruned.
+                assert_ok!(Attestation::revert_to(
+                    RuntimeOrigin::root(),
+                    SUPPORTED_CHAIN_KEY,
+                    revert_height
+                ));
+                assert!(CheckpointPruningStates::<Test>::contains_key(
+                    SUPPORTED_CHAIN_KEY
+                ));
+
+                // Stale digests are still physically present in `Checkpoints`...
+                let stale_height_above_revert = revert_height + CHECKPOINT_BUCKET_SIZE + 100;
+                assert!(
+                    Checkpoints::<Test>::get(SUPPORTED_CHAIN_KEY, stale_height_above_revert,)
+                        .is_some(),
+                    "sanity: stale checkpoint must still be in storage during pruning window",
+                );
+
+                // ...but the helper fails closed for every height on this chain,
+                // including the revert anchor itself. This is the documented
+                // semantics: callers needing a trust anchor must wait for async
+                // pruning to drain before relying on checkpoint storage again.
+                assert_eq!(
+                    Pallet::<Test>::checkpoint_if_stable(
+                        SUPPORTED_CHAIN_KEY,
+                        stale_height_above_revert,
+                    ),
+                    None,
+                    "stale post-revert checkpoint must not be returned as a trust anchor",
+                );
+                assert_eq!(
+                    Pallet::<Test>::checkpoint_if_stable(SUPPORTED_CHAIN_KEY, revert_height),
+                    None,
+                    "fail-closed: even the revert anchor is gated until pruning drains",
+                );
+            })
+            .then_run(|| {
+                // Drain the pruning queue. Walk on_initialize until the state clears.
+                let mut guard = 0u64;
+                while CheckpointPruningStates::<Test>::contains_key(SUPPORTED_CHAIN_KEY) {
+                    progress_to_block(System::block_number() + 1);
+                    guard += 1;
+                    assert!(guard < 256, "pruning did not drain in a reasonable window");
+                }
+            })
+            .run(|| {
+                // After pruning drains, the helper unblocks and surfaces the valid
+                // post-revert checkpoint.
+                let revert_digest =
+                    H256::from(&sp_io::hashing::blake2_256(&revert_height.to_be_bytes()));
+                assert_eq!(
+                    Pallet::<Test>::checkpoint_if_stable(SUPPORTED_CHAIN_KEY, revert_height),
+                    Some(revert_digest),
+                );
+                // And the stale entries are gone from raw storage too.
+                let stale_height_above_revert = revert_height + CHECKPOINT_BUCKET_SIZE + 100;
+                assert_eq!(
+                    Checkpoints::<Test>::get(SUPPORTED_CHAIN_KEY, stale_height_above_revert,),
+                    None,
+                );
+            })
+    }
 }
 
 #[test]

--- a/precompiles/block-prover/src/continuity.rs
+++ b/precompiles/block-prover/src/continuity.rs
@@ -75,7 +75,8 @@ where
     /// # Gas Costs
     /// - `CONTINUITY_BLOCK_HASH_COST` (48) per block in the chain (charged upfront)
     /// - `GAS_STORAGE_LOOKUP` (2600) for attestation lookup
-    /// - Additional `GAS_STORAGE_LOOKUP` for checkpoint lookup (only if attestation doesn't match)
+    /// - Additional `GAS_STORAGE_LOOKUP` * 2 for checkpoint lookup (only if attestation doesn't match):
+    ///   one for the revert-pruning guard read, one for the checkpoint storage read.
     ///
     /// # Optimization
     /// Instead of comparing each intermediate digest, we hash through the entire chain

--- a/precompiles/block-prover/src/lib.rs
+++ b/precompiles/block-prover/src/lib.rs
@@ -361,11 +361,19 @@ where
         pallet_attestation::Pallet::<Runtime>::last_checkpoint(chain_key)
     }
 
-    /// Check if a digest corresponds to a checkpoint
+    /// Check if a digest corresponds to a checkpoint that is currently safe to use
+    /// as a continuity-proof trust anchor.
     ///
-    /// Returns the digest if the block number matches a checkpoint,
-    /// None otherwise. Used as a fallback when attestation lookup fails.
-    /// Charges gas for the storage lookup.
+    /// Delegates to [`pallet_attestation::Pallet::checkpoint_if_stable`], which
+    /// fails closed (returns `None`) while a chain reversion is in flight for the
+    /// given `chain_key`. This closes a soundness gap where `do_revert_to` only
+    /// synchronously purges the bucket containing `checkpoint_height`, leaving
+    /// stale checkpoints at higher pivots readable until `on_init_prune_checkpoints`
+    /// finishes draining them at `MAX_CHECKPOINTS_CLEARED_PER_BLOCK` per block.
+    ///
+    /// Gas: charges `GAS_STORAGE_LOOKUP` twice, once for the `CheckpointPruningStates`
+    /// guard read and once for the `Checkpoints` read itself. Both reads happen
+    /// unconditionally so the pessimistic cost matches the worst case.
     ///
     /// Returns `Ok(Some(..))` / `Ok(None)` on success; gas recording failures surface as `EvmResult` errors.
     fn get_checkpoint(
@@ -373,9 +381,9 @@ where
         chain_key: u64,
         block_number: u64,
     ) -> EvmResult<Option<H256>> {
-        // Charge for checkpoint storage lookup only if we need to check it
-        handle.record_cost(GAS_STORAGE_LOOKUP)?;
-        Ok(pallet_attestation::Pallet::<Runtime>::checkpoints(
+        // Charge for the pruning-state guard read plus the checkpoint storage lookup.
+        handle.record_cost(GAS_STORAGE_LOOKUP.saturating_mul(2))?;
+        Ok(pallet_attestation::Pallet::<Runtime>::checkpoint_if_stable(
             chain_key,
             block_number,
         ))

--- a/precompiles/block-prover/src/tests.rs
+++ b/precompiles/block-prover/src/tests.rs
@@ -889,6 +889,96 @@ fn test_continuity_chain_with_checkpoint() {
 }
 
 #[test]
+// Regression: while a chain reversion is in flight, the precompile must not
+// accept a continuity proof that terminates at a checkpoint. `do_revert_to`
+// only synchronously prunes the bucket containing `checkpoint_height`, so
+// checkpoints at higher pivots remain in storage until `on_init_prune_checkpoints`
+// drains them. The precompile previously read `Checkpoints` directly and would
+// accept these stale digests as a trust anchor.
+fn test_continuity_chain_checkpoint_gated_during_revert_pruning_window() {
+    ExtBuilder::default().build().execute_with(|| {
+        // Model `test_continuity_chain_at_checkpoint_height`: a continuity chain
+        // that terminates at a checkpoint (NOT an attestation). The query height
+        // is the first block in the chain; the last block's digest must match a
+        // checkpoint for verification to succeed.
+        let query_height = 100;
+        let chain_key = 1u64;
+        let test_block = create_test_block(query_height, 4);
+        let tx_data = test_block.transactions[0].data.clone();
+        let merkle_proof = create_valid_merkle_proof_for_block(&test_block, 0);
+
+        let prev_digest = H256::zero();
+        let root = test_block.merkle_root;
+        let digest = compute_test_digest(query_height, &root, &prev_digest);
+
+        let next_root = H256::from([0x99; 32]);
+        let next_digest = compute_test_digest(query_height + 1, &next_root, &digest);
+
+        let continuity_blocks = vec![
+            Block {
+                block_number: query_height,
+                root,
+                prev_digest,
+                digest,
+            },
+            Block {
+                block_number: query_height + 1,
+                root: next_root,
+                prev_digest: digest,
+                digest: next_digest,
+            },
+        ];
+
+        // Checkpoint anchors the end of the continuity chain. No attestation at
+        // that height, so the checkpoint is the only possible trust anchor.
+        setup_checkpoint(chain_key, query_height + 1, next_digest);
+
+        // Simulate a chain reversion in flight: any non-empty pruning state for
+        // this chain key must make the precompile fail closed.
+        pallet_attestation::CheckpointPruningStates::<Runtime>::insert(
+            chain_key,
+            pallet_attestation::clear_or_revert::CheckpointPruningState {
+                stop_height: u64::MAX,
+                next_pivot: 0,
+            },
+        );
+
+        precompiles()
+            .prepare_test(
+                Account::Alice,
+                Account::Precompile,
+                PCall::verify {
+                    chain_key,
+                    height: query_height,
+                    encoded_transaction: tx_data.clone().into(),
+                    merkle_proof: merkle_proof.clone(),
+                    continuity_proof: ContinuityProof::from_blocks(continuity_blocks.clone()),
+                },
+            )
+            .execute_reverts(|output| {
+                output == b"Continuity proof does not match attestation or checkpoint"
+            });
+
+        // Once async pruning drains and the pruning state clears, the same
+        // request succeeds again. This proves the gate is the only thing blocking.
+        pallet_attestation::CheckpointPruningStates::<Runtime>::remove(chain_key);
+        precompiles()
+            .prepare_test(
+                Account::Alice,
+                Account::Precompile,
+                PCall::verify {
+                    chain_key,
+                    height: query_height,
+                    encoded_transaction: tx_data.into(),
+                    merkle_proof,
+                    continuity_proof: ContinuityProof::from_blocks(continuity_blocks),
+                },
+            )
+            .execute_returns(true);
+    });
+}
+
+#[test]
 fn test_continuity_chain_invalid_prev_digest_succeeds() {
     ExtBuilder::default().build().execute_with(|| {
         // Use deterministic test scenario


### PR DESCRIPTION
## Summary

External bounty Submission #2 
This PR fixes a soundness gap in the `block-prover` precompile's continuity-proof
verification path during a chain-reversion pruning window.

## Bug

`pallet_attestation::do_revert_to` only **synchronously** prunes the single
`CheckpointBuckets` pivot that contains `checkpoint_height` (removes entries
with `block_number > checkpoint_height` from that one pivot). Checkpoints
stored at higher pivots are pruned **asynchronously** by
`on_init_prune_checkpoints` at `MAX_CHECKPOINTS_CLEARED_PER_BLOCK = 40`
entries per block.

During that async-pruning window, the `Checkpoints` storage map still
contains stale post-revert checkpoint digests. The `block-prover`
precompile read those digests directly via
`pallet_attestation::Pallet::<Runtime>::checkpoints(chain_key, block_number)`
in `precompiles/block-prover/src/lib.rs::get_checkpoint` and accepted any
match as a valid continuity-proof trust anchor (see
`precompiles/block-prover/src/continuity.rs` around lines 121–153).

Net effect: after a legitimate operator-initiated `revert_to` — the
`OperatorsOrigin`-gated call triggered to handle a source-chain reorg or
bad data — the precompile could still validate continuity proofs anchored
at exactly the checkpoints the revert was meant to invalidate. That is
the scenario the revert exists to handle, so accepting those proofs is
unsafe.

`revert_to` is `OperatorsOrigin`-gated, so this is **not** a permissionless
theft path. The concrete failure mode is: a legitimate operator revert
during a source-chain reorg would otherwise leave the precompile
accepting proofs anchored at exactly the bad checkpoints the revert is
purging, for up to `ceil(stale_buckets * entries_per_bucket / 40)` blocks.

## Fix

Introduce a small helper on the pallet that the precompile (and any
other consensus-critical reader) must use instead of touching
`Checkpoints` storage directly:

```rust
pub fn checkpoint_if_stable(chain_key: ChainKey, block_number: u64) -> Option<Digest> {
    if CheckpointPruningStates::<T>::contains_key(chain_key) {
        return None;
    }
    Checkpoints::<T>::get(chain_key, block_number)
}
```

Semantics, documented in rustdoc on the helper:

- **Fail-closed.** While `CheckpointPruningStates::<T>` has an entry for
  `chain_key`, the helper returns `None` for **every** height on that
  chain, including the revert anchor itself. Callers needing a stable
  trust anchor must wait for async pruning to drain before relying on
  checkpoint storage again.
- The synchronous purge inside `do_revert_to` is intentionally left
  alone (forcing a large synchronous walk over `CheckpointBuckets` would
  bloat `revert_to` weight). The helper closes the exposure without
  changing block-time bounds.

The `block-prover` precompile now goes through the helper. Gas
accounting on `get_checkpoint` is bumped to `GAS_STORAGE_LOOKUP * 2` to
cover the additional `CheckpointPruningStates::contains_key` read.

## Other readers of `Checkpoints`

Audited via `grep`:

- `pallet_attestation::Pallet::contains_digest` (used by the offchain
  attestor worker as a duplicate-attestation check via runtime API):
  liveness-only. At worst, post-revert heights are briefly treated as
  "already known" during the pruning window, which is the safer
  direction. Left as-is.
- `precompiles/chain-info/src/lib.rs` (`get_checkpoint_for_height`,
  `find_highest_attested_below`, `find_lowest_attested_after`):
  informational view functions for EVM consumers. Not part of the
  consensus-critical continuity-proof trust anchor. Left as-is per the
  brief; flagged here in case a follow-up wants to route them through
  the same helper.
- `CheckpointProvider` trait impl: only `use`d inside `pallet-attestation`
  itself; no external consumers in this repo.

## Tests

- `pallets/attestation/src/tests.rs::revert_to::checkpoint_if_stable_fails_closed_during_revert_pruning_window`
  - Seeds stale post-revert checkpoints in pivots **above** the revert
    anchor so the synchronous prune does not touch them.
  - Calls `revert_to`. Asserts the raw `Checkpoints` storage still
    contains the stale digest, **and** that `checkpoint_if_stable`
    returns `None` for that height **and** for the revert anchor itself.
  - Walks `on_initialize` blocks until `CheckpointPruningStates` is
    empty, then asserts `checkpoint_if_stable` returns the valid
    post-revert checkpoint and the stale entries are gone from raw
    storage.
- `precompiles/block-prover/src/tests.rs::test_continuity_chain_checkpoint_gated_during_revert_pruning_window`
  - Same scenario via the EVM precompile path: a continuity proof that
    terminates at a checkpoint (no attestation at the upper bound) is
    rejected with `Continuity proof does not match attestation or
    checkpoint` while `CheckpointPruningStates` has an entry, and
    succeeds again once the entry is removed.

Test results locally:
- `pallet-attestation` lib tests: 234 passed (+1 new).
- `pallet-evm-precompile-block-prover` lib tests: 113 passed (+1 new).
- `cargo fmt --all` clean.
- `cargo clippy -p pallet-attestation -p pallet-evm-precompile-block-prover --all-targets` clean.

## Diff overview

| File | Change |
| --- | --- |
| `pallets/attestation/src/lib.rs` | `mod clear_or_revert` → `pub mod clear_or_revert` so consumers can name `CheckpointPruningState` in tests. |
| `pallets/attestation/src/impls.rs` | New `checkpoint_if_stable` helper with rustdoc documenting fail-closed semantics. |
| `pallets/attestation/src/tests.rs` | New regression test for the pruning-window gate. |
| `precompiles/block-prover/src/lib.rs` | `get_checkpoint` now goes through the helper; gas bumped to `GAS_STORAGE_LOOKUP * 2`. |
| `precompiles/block-prover/src/continuity.rs` | Updated rustdoc on gas costs. |
| `precompiles/block-prover/src/tests.rs` | New EVM-path regression test. |