### PR TITLE
Account for Maturity Strategy in Checkpoint Audit Alert Threshold

### DIFF
--- a/scripts/usc-audit-automation/src/main.ts
+++ b/scripts/usc-audit-automation/src/main.ts
@@ -222,29 +222,26 @@ async function runChecksForChain(
   const checkpointInterval = await getCheckpointInterval(chainKey);
   const attestationInterval = await getAttestationInterval(chainKey);
   const checkpointWidth = checkpointInterval * attestationInterval;
-  // Pallet creates checkpoint when attestation_block_span >= (checkpoint_width * 2) + 1
-  // Extra attestation intervals cover submission/timing variance plus eth RPC vs chain head lag
-  const checkpointLagBufferIntervals = 3;
-  const maxAllowed = checkpointWidth * 2 + 1 +
-    (attestationInterval * checkpointLagBufferIntervals);
-  const diff = ethBlock - lastCheckpoint.blockNumber;
-  const checkpointRangeOk = diff >= 0 && diff <= maxAllowed;
-
-  if (config.verbose && !checkpointRangeOk) {
-    console.log(
-      `[${chainLabel}] Checkpoint range: diff=${diff}, maxAllowed=${maxAllowed} ` +
-        `(checkpointWidth*2+1+attestationInterval*${checkpointLagBufferIntervals}: ` +
-        `${checkpointWidth}*2+1+${attestationInterval}*${checkpointLagBufferIntervals})`,
-    );
-  }
-
-  const blockDiff = ethBlock - attBlock;
-  const maxBlockDiff = getMaxBlockDiff(
+  const maxAttBlockDiff = getMaxBlockDiff(
     chainName,
     maturityStrategy,
     attestationInterval,
   );
-  const blockDiffOk = blockDiff >= 0 && blockDiff <= maxBlockDiff;
+  // maxCheckpointBlockDiff = maxAttBlockDiff + (lag bettween attestation creation and checkpoint creation)
+  // Checkpoints are created when total_width_of_stored_attestations >= (checkpoint_width * 2) + 1
+  const gapFromAttToCheck = checkpointWidth * 2 + 1;
+  const maxCheckpointBlockDiff = maxAttBlockDiff + gapFromAttToCheck;
+  const diff = ethBlock - lastCheckpoint.blockNumber;
+  const checkpointRangeOk = diff >= 0 && diff <= maxCheckpointBlockDiff;
+
+  if (config.verbose && !checkpointRangeOk) {
+    console.log(
+      `[${chainLabel}] Checkpoint range: diff=${diff}, maxAllowed=${maxCheckpointBlockDiff}`,
+    );
+  }
+
+  const blockDiff = ethBlock - attBlock;
+  const blockDiffOk = blockDiff >= 0 && blockDiff <= maxAttBlockDiff;
 
   const graphqlResult = await queryAttestation(
     config.graphqlUrl,
@@ -260,7 +257,7 @@ async function runChecksForChain(
     maturityStrategy,
     ethBlock,
     attBlock,
-    maxBlockDiff,
+    maxAttBlockDiff,
     lastCheckpoint.blockNumber,
     fetchedBlockByHash,
     blockDiffOk,


### PR DESCRIPTION
We were getting false positives for this alert:

❌ Last checkpoint creation is outside checkpoint range: (10,851,135|10,850,900)

This is because the alert didn't account for longer delay maturity strategies such as `EvmSafe`