### PR TITLE
fix(proof-gen-api-server): gate startup checkpoint cache during revert pruning

### DIFF
--- a/common/cc-client/src/lib.rs
+++ b/common/cc-client/src/lib.rs
@@ -27,9 +27,9 @@ use cc3::runtime_types::{
 };
 
 use attestor_primitives::{
-    block::ContinuityProof, Attestation as RpcAttestation, AttestationCheckpoint, AttestationData,
-    AttestorId, AttestorStatus, BlsPublicKey, BlsSignature, ChainEncodingVersion, ChainKey, Digest,
-    SignedAttestation,
+    block::ContinuityProof, checkpoint_pivot, Attestation as RpcAttestation, AttestationCheckpoint,
+    AttestationData, AttestorId, AttestorStatus, BlsPublicKey, BlsSignature, ChainEncodingVersion,
+    ChainKey, Digest, SignedAttestation,
 };
 use supported_chains_primitives::SupportedChain;
 use vrf::{make_proof_of_inclusion, Error as VrfError, ProofOfInclusion};
@@ -819,6 +819,105 @@ impl Client {
                     chain_key, kv
                 );
             }
+        }
+
+        checkpoints.sort_by(|a: &AttestationCheckpoint, b: &AttestationCheckpoint| {
+            // Highest to lowest by comparing b to a
+            b.block_number.cmp(&a.block_number)
+        });
+
+        Ok(checkpoints)
+    }
+
+    /// Like [`Self::get_checkpoints_for_chain`], but filters out heights whose
+    /// bucket pivot is still pending async pruning during a chain reversion.
+    /// Mirrors the bucket-granular gating implemented on-chain by
+    /// `pallet_attestation::Pallet::checkpoint_if_stable`.
+    ///
+    /// `do_revert_to` synchronously cleans the bucket containing
+    /// `checkpoint_height`, but buckets at higher pivots are drained
+    /// asynchronously by `on_init_prune_checkpoints` at
+    /// `MAX_CHECKPOINTS_CLEARED_PER_BLOCK` entries per block. During that
+    /// window the raw `Checkpoints` storage map still contains stale
+    /// post-revert digests. Off-chain consumers (notably the prover API
+    /// startup cache load) that read raw storage would otherwise seed their
+    /// caches with those stale digests, then serve continuity-proof anchors
+    /// the on-chain verifier would reject after the async pruning settles.
+    ///
+    /// This method:
+    ///
+    /// 1. Pins a single best-known block hash for both reads.
+    /// 2. Fetches the chain's [`CheckpointPruningState`] at that hash.
+    /// 3. Iterates [`Checkpoints`] at the same hash and drops any entry whose
+    ///    pivot is `>= state.next_pivot`. Heights in the revert bucket itself
+    ///    (sync-cleaned) and in already-drained buckets stay readable, so a
+    ///    consumer warming its cache during a reversion gets exactly the
+    ///    on-chain stable set instead of an inconsistent snapshot.
+    pub async fn get_stable_checkpoints_for_chain(
+        &self,
+        chain_key: ChainKey,
+    ) -> Result<Vec<AttestationCheckpoint>, Error> {
+        // Pin a block ref so the pruning state and the checkpoint iterator
+        // are read against the same chain state. Without this, a revert event
+        // landing between the two reads could leave us with a pruning state
+        // from block N and checkpoints from block N+k.
+        let block = self.api().blocks().at_latest().await?;
+        let storage = block.storage();
+
+        let pruning_state = storage
+            .fetch(
+                &cc3::storage()
+                    .attestation()
+                    .checkpoint_pruning_states(chain_key),
+            )
+            .await?;
+        let next_pivot = pruning_state.as_ref().map(|s| s.next_pivot);
+
+        let address = cc3::storage().attestation().checkpoints_iter1(chain_key);
+        let mut iter = storage.iter(address).await?;
+
+        let mut checkpoints = Vec::new();
+        let mut filtered = 0usize;
+        while let Some(Ok(kv)) = iter.next().await {
+            if kv.key_bytes.len() < 8 {
+                error!(
+                    "Storage key for chainkey {} is less than 8 bytes, checkpoint: {:?}",
+                    chain_key, kv
+                );
+                continue;
+            }
+            let last_8: Result<[u8; 8], _> = kv.key_bytes[kv.key_bytes.len() - 8..].try_into();
+            let Ok(block_number_bytes) = last_8 else {
+                error!(
+                    "Failed to get last 8 bytes of storage key for chainkey {}, checkpoint: {:?}",
+                    chain_key, kv
+                );
+                continue;
+            };
+            // Substrate encodes u64 as little-endian when using Identity hasher
+            let block_number = u64::from_le_bytes(block_number_bytes);
+
+            if let Some(next_pivot) = next_pivot {
+                if checkpoint_pivot(block_number) >= next_pivot {
+                    filtered += 1;
+                    continue;
+                }
+            }
+
+            checkpoints.push(AttestationCheckpoint {
+                block_number,
+                digest: sp_core::H256::from(kv.value.0),
+            });
+        }
+
+        if let Some(next_pivot) = next_pivot {
+            debug!(
+                chain_key,
+                next_pivot,
+                filtered,
+                kept = checkpoints.len(),
+                "get_stable_checkpoints_for_chain: chain reversion in flight, filtered stale checkpoints"
+            );
         }
 
         checkpoints.sort_by(|a: &AttestationCheckpoint, b: &AttestationCheckpoint| {

--- a/common/continuity/src/mocks.rs
+++ b/common/continuity/src/mocks.rs
@@ -148,6 +148,16 @@ impl CcRpcProvider for MockCcRpcProvider {
             .collect())
     }
 
+    async fn get_stable_checkpoints_for_chain(
+        &self,
+        chain_key: u64,
+    ) -> Result<Vec<AttestationCheckpoint>> {
+        // Default mock: no reversion in flight, identical to the unfiltered set.
+        // Tests that need to model an active revert pruning window should use a
+        // bespoke provider that overrides this method.
+        self.get_checkpoints_for_chain(chain_key).await
+    }
+
     async fn get_checkpoint_by_height(
         &self,
         _chain_key: u64,

--- a/common/continuity/src/rpc.rs
+++ b/common/continuity/src/rpc.rs
@@ -150,6 +150,28 @@ pub trait CcRpcProvider: Send + Sync {
     async fn get_checkpoints_for_chain(&self, chain_key: u64)
         -> Result<Vec<AttestationCheckpoint>>;
 
+    /// Fetch all checkpoints for a chain, dropping any entry whose bucket is
+    /// still pending async pruning during an in-flight chain reversion.
+    ///
+    /// Mirrors the bucket-granular gate implemented on-chain by
+    /// `pallet_attestation::Pallet::checkpoint_if_stable`: heights whose pivot
+    /// is `>= state.next_pivot` of the current
+    /// `pallet_attestation::CheckpointPruningStates` entry are filtered out.
+    /// Heights in the sync-cleaned revert bucket and in already-drained
+    /// buckets stay readable. When no reversion is in flight this returns the
+    /// same set as [`Self::get_checkpoints_for_chain`].
+    ///
+    /// Off-chain consumers that cache checkpoints for use as continuity-proof
+    /// trust anchors (notably the prover API startup cache load) should call
+    /// this instead of [`Self::get_checkpoints_for_chain`]. Otherwise a
+    /// startup that races a reversion can seed the cache with stale
+    /// post-revert digests that the on-chain verifier will reject once the
+    /// async pruning settles.
+    async fn get_stable_checkpoints_for_chain(
+        &self,
+        chain_key: u64,
+    ) -> Result<Vec<AttestationCheckpoint>>;
+
     /// Get a specific checkpoint by block height.
     async fn get_checkpoint_by_height(
         &self,
@@ -277,6 +299,15 @@ impl CcRpcProvider for CcClient {
         self.get_checkpoints_for_chain(chain_key)
             .await
             .context("Failed to fetch checkpoints")
+    }
+
+    async fn get_stable_checkpoints_for_chain(
+        &self,
+        chain_key: u64,
+    ) -> Result<Vec<AttestationCheckpoint>> {
+        self.get_stable_checkpoints_for_chain(chain_key)
+            .await
+            .context("Failed to fetch stable checkpoints")
     }
 
     async fn get_checkpoint_by_height(

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -56,8 +56,11 @@ pub mod pallet {
     use sp_std::{fmt::Debug, vec::Vec};
     use supported_chains_primitives::provider::{OnRegisterChainProvider, SupportedChainsProvider};
 
-    // Amount of blocks tracked in a single checkpoint bucket
-    pub const CHECKPOINT_BUCKET_SIZE: u64 = 1000;
+    // Amount of blocks tracked in a single checkpoint bucket. Defined in
+    // [`attestor_primitives::CHECKPOINT_BUCKET_SIZE`] so off-chain consumers
+    // (cc-client, prover API) can mirror the bucket-granular gating used by
+    // [`Pallet::checkpoint_if_stable`] without depending on this pallet.
+    pub use attestor_primitives::CHECKPOINT_BUCKET_SIZE;
 
     /// The balance type of this pallet.
     pub type BalanceOf<T> = <T as Config>::CurrencyBalance;

--- a/primitives/attestor/src/lib.rs
+++ b/primitives/attestor/src/lib.rs
@@ -17,6 +17,21 @@ pub mod provider;
 // Re-export block types for convenience
 pub use block::{Block, ContinuityBlock, ContinuityProof};
 
+/// Number of source-chain blocks covered by a single `CheckpointBuckets` pivot
+/// in `pallet-attestation`. Off-chain consumers (cc-client, prover API) need
+/// this to mirror the on-chain `checkpoint_if_stable` bucket-granular gating
+/// when reading checkpoints during a revert pruning window; see
+/// `pallets/attestation/src/impls.rs::checkpoint_if_stable`.
+///
+/// Must stay in sync with `pallet_attestation::CHECKPOINT_BUCKET_SIZE`.
+pub const CHECKPOINT_BUCKET_SIZE: u64 = 1000;
+
+/// Pivot (bucket lower bound) for `block_number` under [`CHECKPOINT_BUCKET_SIZE`].
+#[must_use]
+pub const fn checkpoint_pivot(block_number: u64) -> u64 {
+    block_number - (block_number % CHECKPOINT_BUCKET_SIZE)
+}
+
 use crate::bls::{Bls, CryptoScheme};
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -823,6 +823,131 @@ mod tests {
         assert!(cp.contains_key(&0));
     }
 
+    /// `CcRpcProvider` that returns a different set from
+    /// `get_stable_checkpoints_for_chain` than from
+    /// `get_checkpoints_for_chain`. Models an in-flight chain reversion where
+    /// the on-chain bucket-granular gate (`Pallet::checkpoint_if_stable`)
+    /// would filter out some heights still physically present in raw storage.
+    struct ReversionInFlightCcProvider {
+        delegate: Arc<continuity::mocks::MockCcRpcProvider>,
+        stable_block_numbers: std::collections::BTreeSet<u64>,
+    }
+
+    #[async_trait]
+    impl continuity::rpc::CcRpcProvider for ReversionInFlightCcProvider {
+        async fn get_attestations_for_chain(
+            &self,
+            chain_key: u64,
+        ) -> Result<Vec<attestor_primitives::SignedAttestation<H256, cc_client::AccountId32>>>
+        {
+            self.delegate.get_attestations_for_chain(chain_key).await
+        }
+        async fn get_last_checkpoint(
+            &self,
+            chain_key: u64,
+        ) -> Result<Option<attestor_primitives::AttestationCheckpoint>> {
+            self.delegate.get_last_checkpoint(chain_key).await
+        }
+        async fn get_checkpoints_for_chain(
+            &self,
+            chain_key: u64,
+        ) -> Result<Vec<attestor_primitives::AttestationCheckpoint>> {
+            // Unfiltered: includes stale post-revert digests. Startup must NOT
+            // call this path; if it does, the test fails because the stale
+            // entries end up in the cache.
+            self.delegate.get_checkpoints_for_chain(chain_key).await
+        }
+        async fn get_stable_checkpoints_for_chain(
+            &self,
+            chain_key: u64,
+        ) -> Result<Vec<attestor_primitives::AttestationCheckpoint>> {
+            // Filtered: the on-chain gate has dropped stale-pivot digests.
+            let all = self.delegate.get_checkpoints_for_chain(chain_key).await?;
+            Ok(all
+                .into_iter()
+                .filter(|cp| self.stable_block_numbers.contains(&cp.block_number))
+                .collect())
+        }
+        async fn get_checkpoint_by_height(
+            &self,
+            chain_key: u64,
+            block_number: u64,
+        ) -> Result<Option<attestor_primitives::AttestationCheckpoint>> {
+            self.delegate
+                .get_checkpoint_by_height(chain_key, block_number)
+                .await
+        }
+        async fn get_attestation_chain_genesis_block_number(&self, chain_key: u64) -> Result<u64> {
+            self.delegate
+                .get_attestation_chain_genesis_block_number(chain_key)
+                .await
+        }
+        async fn fetch_last_digest(&self, chain_key: u64) -> Result<Option<H256>> {
+            self.delegate.fetch_last_digest(chain_key).await
+        }
+        async fn get_attestation_by_digest(
+            &self,
+            chain_key: u64,
+            digest: H256,
+        ) -> Result<Option<attestor_primitives::SignedAttestation<H256, cc_client::AccountId32>>>
+        {
+            self.delegate
+                .get_attestation_by_digest(chain_key, digest)
+                .await
+        }
+        async fn get_attestation_interval(&self, chain_key: u64) -> Result<Option<u64>> {
+            self.delegate.get_attestation_interval(chain_key).await
+        }
+        async fn get_checkpoint_interval(&self, chain_key: u64) -> Result<Option<u64>> {
+            self.delegate.get_checkpoint_interval(chain_key).await
+        }
+    }
+
+    #[tokio::test]
+    async fn startup_uses_stable_checkpoints_and_drops_stale_pivots() {
+        // Regression for the prover-API companion to the on-chain
+        // `checkpoint_if_stable` gate: when the prover API boots while a
+        // chain reversion is in flight, the checkpoint cache must be seeded
+        // from the gated read so we never cache a stale post-revert digest.
+        //
+        // The mock produces checkpoints at 0, 100, 200, ..., 1000. We model
+        // a reversion where heights > 500 still live in raw storage but the
+        // on-chain gate has dropped them. The stable set therefore contains
+        // only {0, 100, ..., 500}; the prover API cache must match exactly.
+        let chain_key = 2;
+        let (mock_cc, eth_provider) = continuity::mocks::make_mock_providers(chain_key);
+        let stable: std::collections::BTreeSet<u64> = (0..=5).map(|i| i * 100).collect();
+        let cc_provider = Arc::new(ReversionInFlightCcProvider {
+            delegate: mock_cc,
+            stable_block_numbers: stable.clone(),
+        });
+
+        let builder = Arc::new(ContinuityBuilder::new_with_providers(
+            mock_config(chain_key),
+            cc_provider,
+            eth_provider,
+        ));
+        let svc = ContinuityService::new(vec![builder], NoopMetrics::new(), 10, 1_000)
+            .await
+            .expect("service init should succeed");
+
+        let chain = svc.chain_state(chain_key).unwrap();
+        let cp = chain.checkpoint_cache.read().await;
+
+        let cached: std::collections::BTreeSet<u64> = cp.keys().copied().collect();
+        assert_eq!(
+            cached, stable,
+            "checkpoint cache must contain exactly the stable set from the gated read; \
+             stale post-revert digests must not be present"
+        );
+        for stale_height in [600u64, 700, 800, 900, 1000] {
+            assert!(
+                !cp.contains_key(&stale_height),
+                "stale checkpoint at {stale_height} must not be cached on startup during a reversion",
+            );
+        }
+    }
+
     #[tokio::test]
     async fn batch_span_exceeding_limit_is_rejected() {
         // Set a tight max_batch_span of 50 blocks

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -205,14 +205,25 @@ impl ContinuityService {
                 "🚀 ✅ ContinuityService chain initialized with attestation genesis block"
             );
 
-            // Populate checkpoint cache from CC3 on startup.
+            // Populate checkpoint cache from CC3 on startup. We deliberately
+            // use the bucket-granular gated variant so a startup that races a
+            // chain reversion does not seed the cache with stale post-revert
+            // checkpoint digests. Those digests are still physically present
+            // in raw `pallet_attestation::Checkpoints` storage until
+            // `on_init_prune_checkpoints` finishes draining higher pivots
+            // asynchronously; if we cached them the prover API would happily
+            // serve continuity proofs anchored at exactly the checkpoints the
+            // revert was meant to invalidate, until the next `BlockAttested` /
+            // `CheckpointReached` / `RevertedAttestationChainTo` event
+            // rewrites the cache. Mirrors the on-chain gate added in
+            // `pallet_attestation::Pallet::checkpoint_if_stable`.
             tracing::debug!(
                 chain_key,
                 "🚀 ⏳ 📝 Populating checkpoint cache from CC3 (this may take a while)..."
             );
             let checkpoints = builder
                 .cc_provider
-                .get_checkpoints_for_chain(chain_key)
+                .get_stable_checkpoints_for_chain(chain_key)
                 .await
                 .unwrap_or_else(|e| {
                     tracing::warn!(


### PR DESCRIPTION
## Summary

Companion to #975. That PR added a bucket-granular gate on `pallet_attestation::Pallet::checkpoint_if_stable` so the `block-prover` precompile cannot trust checkpoint digests in pivots still pending async prune after a `revert_to`. The off-chain prover API has the symmetric problem on its startup path: it warms its in-memory checkpoint cache by iterating raw `Checkpoints` storage, which during an in-flight reversion still contains the stale post-revert digests.

Those digests would then sit in the cache and be used as continuity-proof trust anchors until the next `BlockAttested` / `CheckpointReached` / `RevertedAttestationChainTo` event rewrote it. Within that window the prover API would happily serve continuity proofs anchored at exactly the checkpoints the operator's `revert_to` was meant to invalidate — until the on-chain verifier rejects them at submission time with `Continuity proof does not match attestation or checkpoint`.

## Bug

`proof-gen-api-server/src/services/continuity_service/mod.rs` populates `checkpoint_cache` from `cc_provider.get_checkpoints_for_chain(chain_key)`. That helper in `cc-client` iterates raw `pallet_attestation::Checkpoints` storage via subxt, which during the async pruning window after `do_revert_to` still holds stale entries in pivots above `checkpoint_height` (see #975 for the full description of the on-chain window).

The runtime event path is already correct: `RevertedAttestationChainTo` triggers `revert_caches`, which `split_off`s entries above the revert height. The bug is purely on the startup load.

## Fix

Mirror the on-chain gate on the startup load.

* **`attestor-primitives`**: hoist `CHECKPOINT_BUCKET_SIZE` (was a private const inside `pallet-attestation`) plus a small `checkpoint_pivot` helper, so off-chain consumers can compute the same pivot as the pallet without depending on the pallet crate. `pallet-attestation` re-exports the constant so existing call sites keep working.

* **`cc-client`**: add `get_stable_checkpoints_for_chain(chain_key)`:

  1. Pins a single block ref via `api.blocks().at_latest().await?` so `CheckpointPruningStates` and the `Checkpoints` iteration read against the same chain state. Without the pin a revert event landing between the two reads could leave us with a pruning state from block N and checkpoints from block N+k.
  2. Fetches the chain's `CheckpointPruningState` at that hash.
  3. Iterates `Checkpoints` at the same hash and drops any entry whose pivot is `>= state.next_pivot`.

  Heights in the sync-cleaned revert bucket and in already-drained buckets stay readable. When no reversion is in flight the set matches `get_checkpoints_for_chain` exactly. Same semantics as `Pallet::checkpoint_if_stable` from #975.

* **`continuity::rpc::CcRpcProvider`**: add the trait method with rustdoc pointing back to the on-chain gate. `CcClient` impl delegates to the new `cc-client` helper. Mock provider delegates to the unfiltered set by default for tests that do not model a reversion.

* **`proof-gen-api-server`**: startup cache population now calls `get_stable_checkpoints_for_chain` instead of `get_checkpoints_for_chain`. Runtime event handling (`RevertedAttestationChainTo` -> `revert_caches`) was already correct and is unchanged.

## Why startup, not the hot path

Grepping `proof-gen-api-server` for chain RPC reads against `Checkpoints` storage: the only path that touches raw storage is the startup load. All other reads go through the in-memory `checkpoint_cache`, which is updated reactively by `BlockAttested` / `CheckpointReached` / `RevertedAttestationChainTo` events. Those event handlers already do the right thing.

## Tests

* `proof-gen-api-server/src/services/continuity_service/helpers.rs::tests::startup_uses_stable_checkpoints_and_drops_stale_pivots`
  * Injects a `CcRpcProvider` that returns different sets from `get_checkpoints_for_chain` (unfiltered: includes stale digests above the revert height) and `get_stable_checkpoints_for_chain` (filtered: only stable-pivot entries).
  * Boots `ContinuityService` with the custom provider.
  * Asserts the startup checkpoint cache contains *exactly* the stable set and that each modeled stale-pivot height is absent. This pins the startup code path to the gated read; if anyone routes startup back through `get_checkpoints_for_chain` the test fails.

Local test results:

* `proof-gen-api-server` lib tests: 39 passed (+1 new).
* `continuity` lib tests: 4 passed.
* `pallet-attestation` lib tests: 233 passed (unchanged behavior; only the const home moved).
* `cargo fmt --all` clean.
* `cargo clippy` clean on every touched crate (`attestor-primitives`, `pallet-attestation`, `cc-client`, `continuity`, `proof-gen-api-server`).

## Diff overview

| File | Change |
| --- | --- |
| `primitives/attestor/src/lib.rs` | Add `CHECKPOINT_BUCKET_SIZE` const and `checkpoint_pivot` helper. |
| `pallets/attestation/src/lib.rs` | Re-export `CHECKPOINT_BUCKET_SIZE` from `attestor-primitives`. |
| `common/cc-client/src/lib.rs` | New `get_stable_checkpoints_for_chain` with pinned-block read + pruning-state gate. |
| `common/continuity/src/rpc.rs` | New `CcRpcProvider::get_stable_checkpoints_for_chain` trait method + `CcClient` impl. |
| `common/continuity/src/mocks.rs` | Mock impl: delegate to unfiltered set (default behavior for tests not modeling a reversion). |
| `proof-gen-api-server/src/services/continuity_service/mod.rs` | Startup cache population uses the gated read. |
| `proof-gen-api-server/src/services/continuity_service/helpers.rs` | New regression test + helper `CcRpcProvider` modeling an in-flight reversion. |