### PR TITLE
Don't query prover for CK 5 BSC

### DIFF
--- a/.github/workflows/check-prover.yml
+++ b/.github/workflows/check-prover.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Execute prover-check.ts on checkpoint boundaries
         working-directory: ./cli
         env:
-          GO_BACK_BLOCKS: ${{ matrix.GO_BACK_BLOCKS || '3600' }}
+          GO_BACK_BLOCKS: '3600'
         run: |
           node dist/scripts/prover-check.js ${{ matrix.creditcoinUrl }} ${{ matrix.chainKey }} ${{ matrix.proverUrl }} ${{ matrix.indexerUrl }} ${{ matrix.evmV1Decoder }}
 
@@ -81,8 +81,8 @@ jobs:
         working-directory: ./cli
         env:
           # LAST_SOURCE_BLOCK: '1000000'
-          GO_BACK_BLOCKS: ${{ matrix.GO_BACK_BLOCKS || '4000' }}
-          STEP_THROUGH_BLOCKS: ${{ matrix.STEP_THROUGH_BLOCKS || '7' }}
+          GO_BACK_BLOCKS: '4000'
+          STEP_THROUGH_BLOCKS: '7'
         run: |
           node dist/scripts/prover-check.js ${{ matrix.creditcoinUrl }} ${{ matrix.chainKey }} ${{ matrix.proverUrl }} "" ${{ matrix.evmV1Decoder }}
 

--- a/.github/workflows/check-prover.yml
+++ b/.github/workflows/check-prover.yml
@@ -28,15 +28,6 @@ jobs:
             evmV1Decoder: "0xf882f3a71A36E29E86615B7055f42A68D7E4cfBB"
             chainKey: 4
 
-          # CC3 Devnet, BSC Testnet
-          - creditcoinUrl: "wss://rpc.cc3-devnet.creditcoin.network/ws"
-            proverUrl: "https://prover.cc3-devnet.creditcoin.network"
-            indexerUrl: "https://graphql-usc.cc3-devnet.creditcoin.network"
-            evmV1Decoder: "0xf882f3a71A36E29E86615B7055f42A68D7E4cfBB"
-            chainKey: 5
-            GO_BACK_BLOCKS: '96000'
-            STEP_THROUGH_BLOCKS: '137'
-
           # CC3 Testnet, Sepolia Full Archive
           - creditcoinUrl: "wss://rpc.cc3-testnet.creditcoin.network/ws"
             proverUrl: "https://prover.cc3-testnet.creditcoin.network"


### PR DESCRIPTION
b/c chainstack RPC key has been maxed out, see
https://gluwa.slack.com/archives/C03MQ532BGA/p1779780506376039?thread_ts=1779438638.387709&cid=C03MQ532BGA

# Description of proposed changes

<describe what this PR is about and why we want it>

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
