### PR TITLE
Add CK 3, Ethereum Main @ CC3 Testnet

### DIFF
--- a/.github/workflows/check-prover.yml
+++ b/.github/workflows/check-prover.yml
@@ -14,32 +14,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # CC3 Devnet, Sepolia Full Archive
-          - creditcoinUrl: "wss://rpc.cc3-devnet.creditcoin.network/ws"
-            proverUrl: "https://prover.cc3-devnet.creditcoin.network"
-            indexerUrl: "https://graphql-usc.cc3-devnet.creditcoin.network"
-            evmV1Decoder: "0xf882f3a71A36E29E86615B7055f42A68D7E4cfBB"
-            chainKey: 1
-
-          # CC3 Devnet, Ethereum Mainnet Full Archive
-          - creditcoinUrl: "wss://rpc.cc3-devnet.creditcoin.network/ws"
-            proverUrl: "https://prover.cc3-devnet.creditcoin.network"
-            indexerUrl: "https://graphql-usc.cc3-devnet.creditcoin.network"
-            evmV1Decoder: "0xf882f3a71A36E29E86615B7055f42A68D7E4cfBB"
-            chainKey: 4
-
-          # CC3 Testnet, Sepolia Full Archive
+          # CC3 Testnet, Ethereum Mainnet Full Archive
           - creditcoinUrl: "wss://rpc.cc3-testnet.creditcoin.network/ws"
             proverUrl: "https://prover.cc3-testnet.creditcoin.network"
             indexerUrl: "https://graphql-usc.cc3-testnet.creditcoin.network"
             evmV1Decoder: "0x731c345d79Fb8BbDC541f9DF3b6317585F849F9f"
-            chainKey: 1
+            chainKey: 3
 
-          # USC Testnet v2, Sepolia from 10,050,300
-          - creditcoinUrl: "wss://rpc.usc-testnet2.creditcoin.network/ws"
-            proverUrl: "https://proof-gen-api.usc-testnet2.creditcoin.network"
-            indexerUrl: "https://attestations-graphql.usc-testnet2.creditcoin.network"
-            chainKey: 1
 
     name: CK ${{ matrix.chainKey }} / ${{ matrix.proverUrl }}
     runs-on: ubuntu-24.04
@@ -73,7 +54,8 @@ jobs:
       - name: Execute prover-check.ts on checkpoint boundaries
         working-directory: ./cli
         env:
-          GO_BACK_BLOCKS: '3600'
+          LAST_SOURCE_BLOCK: '25187400'
+          GO_BACK_BLOCKS: '25187390'
         run: |
           node dist/scripts/prover-check.js ${{ matrix.creditcoinUrl }} ${{ matrix.chainKey }} ${{ matrix.proverUrl }} ${{ matrix.indexerUrl }} ${{ matrix.evmV1Decoder }}
 
@@ -81,7 +63,7 @@ jobs:
         working-directory: ./cli
         env:
           # LAST_SOURCE_BLOCK: '1000000'
-          GO_BACK_BLOCKS: '4000'
+          GO_BACK_BLOCKS: '10000'
           STEP_THROUGH_BLOCKS: '7'
         run: |
           node dist/scripts/prover-check.js ${{ matrix.creditcoinUrl }} ${{ matrix.chainKey }} ${{ matrix.proverUrl }} "" ${{ matrix.evmV1Decoder }}


### PR DESCRIPTION
Earlier test results, incl Ethereum Mainnet @ CC3 Devnet: https://github.com/gluwa/creditcoin3/pull/938

Ethereum Mainnet, CK 3 @ CC3 Testnet:
* blocks 1...4826000, at checkpoint boundaries:
   :green_circle:  https://github.com/gluwa/creditcoin3/actions/runs/26761707280/job/79044165331
* blocks 4370000...11941000, at checkpoint boundaries:
  :green_circle:  https://github.com/gluwa/creditcoin3/actions/runs/26573057878/job/78284934397
* blocks 11941000...18013000, at checkpoint boundaries:
  :green_circle:  https://github.com/gluwa/creditcoin3/actions/runs/26638379369/job/78504401779
* blocks 18013000...25187400, at checkpoint boundaries:
  :green_circle: https://github.com/gluwa/creditcoin3/actions/runs/26741034265/job/78804878168
* blocks 25187370..25222780, at checkpoint boundaries:
  :green_circle:  https://github.com/gluwa/creditcoin3/actions/runs/26757870754/job/78862662369
* blocks 25187460..25222870, step 7:
  :green_circle:  https://github.com/gluwa/creditcoin3/actions/runs/26757870754/job/78862662369

 