### PR TITLE
Internal Audit - Phase 1 - Point 1 and 2

### DIFF
--- a/common/cc-client/src/lib.rs
+++ b/common/cc-client/src/lib.rs
@@ -691,6 +691,7 @@ impl Client {
             &self.attestor_id(),
             header_number,
             epoch_index,
+            chain_key,
         )?;
 
         Ok(proof_of_inclusion)
@@ -719,6 +720,7 @@ impl Client {
             &self.attestor_id(),
             header_number,
             epoch_index,
+            chain_key,
         )?;
 
         Ok(proof_of_inclusion)

--- a/common/vrf/src/lib.rs
+++ b/common/vrf/src/lib.rs
@@ -13,7 +13,7 @@ use sp_core::{
 };
 use thiserror::Error;
 
-use attestor_primitives::AttestorId;
+use attestor_primitives::{AttestorId, ChainKey};
 use randomness_primitives::Randomness;
 
 #[derive(Decode, Encode, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -63,13 +63,14 @@ pub enum Error {
 ///
 /// # Arguments
 ///
-/// * `epoch` - The current epoch for which the proof is being generated.
 /// * `working_set_size` - The size of the attestor set.
 /// * `target_sample_size` - The target sample size for the attestor set.
 /// * `randomness` - A source of randomness used in VRF.
 /// * `keys` - The SR25519 key pair of the attestor.
 /// * `attestor_id` - The ID of the attestor.
-/// * `source_block_height` - The block height used for generating the transcript.
+/// * `header_number` - The block height used for generating the transcript.
+/// * `epoch` - The current epoch for which the proof is being generated.
+/// * `chain_key` - The chain key used for generating the transcript.
 ///
 /// # Returns
 ///
@@ -82,9 +83,10 @@ pub fn make_proof_of_inclusion(
     attestor_id: &AttestorId,
     header_number: u64,
     epoch: u64,
+    chain_key: ChainKey,
 ) -> Result<ProofOfInclusion, Error> {
     // Create the transcript
-    let transcript = make_transcript(header_number, randomness, attestor_id);
+    let transcript = make_transcript(header_number, randomness, attestor_id, chain_key);
 
     // Create the random number
     let random = keys.make_bytes(VRF_CONTEXT, &transcript);
@@ -123,6 +125,8 @@ pub fn make_proof_of_inclusion(
 /// * `randomness` - A source of randomness used in VRF.
 /// * `proof_of_inclusion` - The proof of inclusion to verify.
 /// * `attestor_id` - The ID of the attestor.
+/// * `header_number` - The block height used for generating the transcript.
+/// * `chain_key` - The chain key used for generating the transcript.
 ///
 /// # Returns
 ///
@@ -134,8 +138,14 @@ pub fn verify_proof_of_inclusion(
     proof_of_inclusion: &ProofOfInclusion,
     attestor_id: &AttestorId,
     header_number: u64,
+    chain_key: ChainKey,
 ) -> Result<bool, Error> {
-    let vrf_input = VrfSignData::new(make_transcript(header_number, randomness, attestor_id));
+    let vrf_input = VrfSignData::new(make_transcript(
+        header_number,
+        randomness,
+        attestor_id,
+        chain_key,
+    ));
 
     let vrf_signature = VrfSignature {
         pre_output: VrfPreOutput(
@@ -193,6 +203,7 @@ fn make_transcript(
     header_number: u64,
     randomness: &Randomness,
     attestor_id: &AttestorId,
+    chain_key: ChainKey,
 ) -> VrfTranscript {
     VrfTranscript::new(
         b"attestation_engine",
@@ -200,6 +211,7 @@ fn make_transcript(
             (b"block_number", &header_number.encode()),
             (b"randomness", randomness.as_ref()),
             (b"id", &attestor_id.encode()),
+            (b"chain_key", &chain_key.encode()),
         ],
     )
 }
@@ -217,13 +229,11 @@ fn make_transcript(
 ///
 /// Returns the threshold value as a `u128`.
 fn calculate_threshold(target_sample_size: u128, working_size: u128) -> u128 {
-    if working_size <= 1 {
+    if working_size <= 1 || target_sample_size >= working_size {
         return MAX_U128;
     }
-    // Calculate the threshold
-    MAX_U128
-        .div_ceil(working_size)
-        .saturating_mul(target_sample_size)
+
+    (MAX_U128 / working_size).saturating_mul(target_sample_size)
 }
 
 #[cfg(test)]
@@ -243,6 +253,7 @@ mod tests {
         let attestor_id = AttestorId::from_public(keys.public().0);
         let header_number = 100;
         let epoch = 1;
+        let chain_key = 1u64;
 
         let proof_of_inclusion = make_proof_of_inclusion(
             working_set_size,
@@ -252,16 +263,18 @@ mod tests {
             &attestor_id,
             header_number,
             epoch,
+            chain_key,
         )
         .unwrap();
 
         assert!(verify_proof_of_inclusion(
-            threshold,
             working_set_size,
+            threshold,
             &randomness,
             &proof_of_inclusion,
             &attestor_id,
-            header_number
+            header_number,
+            chain_key,
         )
         .unwrap());
     }
@@ -277,6 +290,7 @@ mod tests {
         let attestor_id = AttestorId::from_public(keys.public().0);
         let header_number = 100;
         let epoch = 1;
+        let chain_key = 1u64;
 
         let res = make_proof_of_inclusion(
             working_set_size,
@@ -286,6 +300,7 @@ mod tests {
             &attestor_id,
             header_number,
             epoch,
+            chain_key,
         );
 
         assert_eq!(res, Err(Error::NotSelected));
@@ -302,15 +317,17 @@ mod tests {
         let attestor_id = AttestorId::from_public(keys.public().0);
         let header_number = 100;
         let epoch = 1;
+        let chain_key = 1u64;
 
         let proof_of_inclusion = make_proof_of_inclusion(
-            threshold,
             working_set_size,
+            threshold,
             &randomness,
             &keys,
             &attestor_id,
             header_number,
             epoch,
+            chain_key,
         )
         .unwrap();
 
@@ -318,12 +335,13 @@ mod tests {
         let randomness = Randomness::from(H256::random());
 
         assert!(!verify_proof_of_inclusion(
-            threshold,
             working_set_size,
+            threshold,
             &randomness,
             &proof_of_inclusion,
             &attestor_id,
-            header_number
+            header_number,
+            chain_key,
         )
         .unwrap());
     }

--- a/common/vrf/src/lib.rs
+++ b/common/vrf/src/lib.rs
@@ -75,6 +75,7 @@ pub enum Error {
 /// # Returns
 ///
 /// Returns a `ProofOfInclusion` if successful, or an `Error` if the attestor is not selected or there is an issue with the VRF process.
+#[allow(clippy::too_many_arguments)]
 pub fn make_proof_of_inclusion(
     working_set_size: u64,
     target_sample_size: u64,


### PR DESCRIPTION
Addresses issues from internal audit phase 1 - points 1 and 2

1. `calculate_threshold` rounds the wrong way
2.  `chain_key` missing from VRF transcript