### PR TITLE
fix(chain-info): avoid panic on CheckpointBuckets/Checkpoints desync (Certik N8)

### DIFF
--- a/precompiles/chain-info/src/lib.rs
+++ b/precompiles/chain-info/src/lib.rs
@@ -231,28 +231,31 @@ where
                 let mut items_processed = 0_u64;
 
                 // We search the checkpoint bucket for the highest checkpoint below the target height.
-                maybe_highest =
+                let max_below =
                     CheckpointBuckets::<Runtime>::iter_key_prefix((chain_key, block_pivot))
                         .inspect(|_| {
                             items_processed += 1;
                         })
                         .filter(|block_number| *block_number < target_height)
-                        .max_by_key(|block_number| *block_number)
-                        .map(|block_number| {
-                            handle.record_cost(GAS_STORAGE_LOOKUP)?;
+                        .max_by_key(|block_number| *block_number);
 
-                            // At this point, we know the checkpoint exists. So we can safely unwrap.
-                            let digest =
-                                Checkpoints::<Runtime>::get(chain_key, block_number).unwrap();
-
-                            <EvmResult<HeightHashResult>>::Ok(HeightHashResult {
-                                height: block_number,
-                                hash: digest,
-                                is_attestation: false,
-                                exists: true,
-                            })
-                        })
-                        .transpose()?;
+                // `CheckpointBuckets` is expected to mirror `Checkpoints` (writes are paired).
+                // Treat any desync as a soft miss and fall through to the next pivot rather
+                // than panic — the prefix-clear paths in `clear_or_revert.rs` advance the two
+                // maps' cursors independently after chain removal.
+                maybe_highest = if let Some(block_number) = max_below {
+                    handle.record_cost(GAS_STORAGE_LOOKUP)?;
+                    Checkpoints::<Runtime>::get(chain_key, block_number).map(|digest| {
+                        HeightHashResult {
+                            height: block_number,
+                            hash: digest,
+                            is_attestation: false,
+                            exists: true,
+                        }
+                    })
+                } else {
+                    None
+                };
 
                 handle.record_cost(GAS_PER_ITERATION_ITEM * items_processed)?;
 
@@ -337,27 +340,30 @@ where
                 let mut items_processed = 0_u64;
 
                 // We search the checkpoint bucket for the lowest checkpoint above the target height.
-                maybe_lowest =
+                let min_above =
                     CheckpointBuckets::<Runtime>::iter_key_prefix((chain_key, block_pivot))
                         .inspect(|_| {
                             items_processed += 1;
                         })
                         .filter(|block_number| *block_number >= target_height)
-                        .min_by_key(|block_number| *block_number)
-                        .map(|block_number| {
-                            handle.record_cost(GAS_STORAGE_LOOKUP)?;
+                        .min_by_key(|block_number| *block_number);
 
-                            // At this point, we know the checkpoint exists. So we can safely unwrap.
-                            let digest =
-                                Checkpoints::<Runtime>::get(chain_key, block_number).unwrap();
-                            <EvmResult<HeightHashResult>>::Ok(HeightHashResult {
-                                height: block_number,
-                                hash: digest,
-                                is_attestation: false,
-                                exists: true,
-                            })
-                        })
-                        .transpose()?;
+                // See the matching note in `find_highest_attested_before`: skip on
+                // `CheckpointBuckets`/`Checkpoints` desync rather than panic, and let the
+                // outer loop continue to the next pivot.
+                maybe_lowest = if let Some(block_number) = min_above {
+                    handle.record_cost(GAS_STORAGE_LOOKUP)?;
+                    Checkpoints::<Runtime>::get(chain_key, block_number).map(|digest| {
+                        HeightHashResult {
+                            height: block_number,
+                            hash: digest,
+                            is_attestation: false,
+                            exists: true,
+                        }
+                    })
+                } else {
+                    None
+                };
 
                 handle.record_cost(GAS_PER_ITERATION_ITEM * items_processed)?;
 

--- a/precompiles/chain-info/src/lib.rs
+++ b/precompiles/chain-info/src/lib.rs
@@ -230,34 +230,39 @@ where
 
                 let mut items_processed = 0_u64;
 
-                // We search the checkpoint bucket for the highest checkpoint below the target height.
-                let max_below =
+                // Collect this bucket's heights below the target, then probe them from
+                // highest downward. `CheckpointBuckets` is expected to mirror `Checkpoints`
+                // (writes are paired), but the prefix clears in `clear_or_revert.rs` advance
+                // the two maps' cursors independently during chain removal, so a bucket can
+                // transiently hold heights whose checkpoint was already cleared. Skip such
+                // orphans and keep probing *within* the bucket — only fall through to the
+                // next pivot once every height here is exhausted. Probing extremal-first with
+                // an early break keeps the common (no-desync) case at a single lookup.
+                let mut candidates: Vec<u64> =
                     CheckpointBuckets::<Runtime>::iter_key_prefix((chain_key, block_pivot))
                         .inspect(|_| {
                             items_processed += 1;
                         })
                         .filter(|block_number| *block_number < target_height)
-                        .max_by_key(|block_number| *block_number);
+                        .collect();
+                handle.record_cost(GAS_PER_ITERATION_ITEM * items_processed)?;
 
-                // `CheckpointBuckets` is expected to mirror `Checkpoints` (writes are paired).
-                // Treat any desync as a soft miss and fall through to the next pivot rather
-                // than panic — the prefix-clear paths in `clear_or_revert.rs` advance the two
-                // maps' cursors independently after chain removal.
-                maybe_highest = if let Some(block_number) = max_below {
+                // Highest first.
+                candidates.sort_unstable_by(|a, b| b.cmp(a));
+
+                maybe_highest = None;
+                for block_number in candidates {
                     handle.record_cost(GAS_STORAGE_LOOKUP)?;
-                    Checkpoints::<Runtime>::get(chain_key, block_number).map(|digest| {
-                        HeightHashResult {
+                    if let Some(digest) = Checkpoints::<Runtime>::get(chain_key, block_number) {
+                        maybe_highest = Some(HeightHashResult {
                             height: block_number,
                             hash: digest,
                             is_attestation: false,
                             exists: true,
-                        }
-                    })
-                } else {
-                    None
-                };
-
-                handle.record_cost(GAS_PER_ITERATION_ITEM * items_processed)?;
+                        });
+                        break;
+                    }
+                }
 
                 if maybe_highest.is_some() {
                     break;
@@ -339,33 +344,34 @@ where
 
                 let mut items_processed = 0_u64;
 
-                // We search the checkpoint bucket for the lowest checkpoint above the target height.
-                let min_above =
+                // See the matching note in `find_highest_attested_before`: probe within the
+                // bucket (lowest first) and skip orphans whose `Checkpoints` entry was already
+                // cleared, only falling through to the next pivot once this bucket is exhausted.
+                let mut candidates: Vec<u64> =
                     CheckpointBuckets::<Runtime>::iter_key_prefix((chain_key, block_pivot))
                         .inspect(|_| {
                             items_processed += 1;
                         })
                         .filter(|block_number| *block_number >= target_height)
-                        .min_by_key(|block_number| *block_number);
+                        .collect();
+                handle.record_cost(GAS_PER_ITERATION_ITEM * items_processed)?;
 
-                // See the matching note in `find_highest_attested_before`: skip on
-                // `CheckpointBuckets`/`Checkpoints` desync rather than panic, and let the
-                // outer loop continue to the next pivot.
-                maybe_lowest = if let Some(block_number) = min_above {
+                // Lowest first.
+                candidates.sort_unstable();
+
+                maybe_lowest = None;
+                for block_number in candidates {
                     handle.record_cost(GAS_STORAGE_LOOKUP)?;
-                    Checkpoints::<Runtime>::get(chain_key, block_number).map(|digest| {
-                        HeightHashResult {
+                    if let Some(digest) = Checkpoints::<Runtime>::get(chain_key, block_number) {
+                        maybe_lowest = Some(HeightHashResult {
                             height: block_number,
                             hash: digest,
                             is_attestation: false,
                             exists: true,
-                        }
-                    })
-                } else {
-                    None
-                };
-
-                handle.record_cost(GAS_PER_ITERATION_ITEM * items_processed)?;
+                        });
+                        break;
+                    }
+                }
 
                 if maybe_lowest.is_some() {
                     break;

--- a/precompiles/chain-info/src/tests.rs
+++ b/precompiles/chain-info/src/tests.rs
@@ -696,6 +696,141 @@ fn find_lowest_attested_after_skips_orphan_bucket_entry() {
         });
 }
 
+// Regression for the within-bucket case: a single pivot can hold several heights and only
+// the extremal one may be orphaned. The search must probe the remaining heights in the same
+// bucket before moving on, otherwise callers get a wrong (further-pivot) height or an empty
+// result even though a valid checkpoint exists in the bucket.
+#[test]
+fn find_highest_attested_before_probes_within_bucket_past_orphan() {
+    let alice: H160 = Alice.into();
+
+    let target_height: u64 = 1500;
+    let orphan_height: u64 = 1400; // extremal-below in the target bucket, but orphaned
+    let valid_in_bucket: u64 = 1200; // same bucket (pivot 1000), has a real checkpoint
+    let valid_digest = H256::from_slice(&[11_u8; 32]);
+    // A valid checkpoint one pivot lower acts as a distractor: if the search wrongly
+    // abandoned the bucket it would return this instead.
+    let distractor_height: u64 = 800;
+    let distractor_digest = H256::from_slice(&[22_u8; 32]);
+    let last_checkpoint_height: u64 = 2000; // >= target, forces the bucket-search branch
+
+    let expected_result = HeightHashResult {
+        height: valid_in_bucket,
+        hash: valid_digest,
+        is_attestation: false,
+        exists: true,
+    };
+
+    ExtBuilder::default()
+        .with_balances(vec![(alice.into(), 300)])
+        .build()
+        .execute_with(|| {
+            LastCheckpoint::<Runtime>::insert(
+                SUPPORTED_CHAIN_KEY,
+                AttestationCheckpoint {
+                    block_number: last_checkpoint_height,
+                    digest: H256::random(),
+                },
+            );
+
+            let pivot = AttestationPallet::<Runtime>::compute_block_index_for(orphan_height);
+            // Orphan: bucket entry, no checkpoint.
+            CheckpointBuckets::<Runtime>::insert((SUPPORTED_CHAIN_KEY, pivot, orphan_height), ());
+            // Valid, same bucket.
+            CheckpointBuckets::<Runtime>::insert((SUPPORTED_CHAIN_KEY, pivot, valid_in_bucket), ());
+            Checkpoints::<Runtime>::insert(SUPPORTED_CHAIN_KEY, valid_in_bucket, valid_digest);
+
+            // Distractor in the next pivot down.
+            let distractor_pivot =
+                AttestationPallet::<Runtime>::compute_block_index_for(distractor_height);
+            CheckpointBuckets::<Runtime>::insert(
+                (SUPPORTED_CHAIN_KEY, distractor_pivot, distractor_height),
+                (),
+            );
+            Checkpoints::<Runtime>::insert(
+                SUPPORTED_CHAIN_KEY,
+                distractor_height,
+                distractor_digest,
+            );
+
+            precompiles()
+                .prepare_test(
+                    alice,
+                    Precompile,
+                    PCall::find_highest_attested_before {
+                        chain_key: SUPPORTED_CHAIN_KEY,
+                        target_height,
+                    },
+                )
+                .execute_returns(expected_result);
+        });
+}
+
+#[test]
+fn find_lowest_attested_after_probes_within_bucket_past_orphan() {
+    let alice: H160 = Alice.into();
+
+    let target_height: u64 = 1500;
+    let orphan_height: u64 = 1600; // extremal-above in the target bucket, but orphaned
+    let valid_in_bucket: u64 = 1800; // same bucket (pivot 1000), has a real checkpoint
+    let valid_digest = H256::from_slice(&[33_u8; 32]);
+    // Distractor one pivot higher: returned only if the bucket were wrongly abandoned.
+    let distractor_height: u64 = 2400;
+    let distractor_digest = H256::from_slice(&[44_u8; 32]);
+    let last_checkpoint_height: u64 = 3000; // > target, forces the bucket-search branch
+
+    let expected_result = HeightHashResult {
+        height: valid_in_bucket,
+        hash: valid_digest,
+        is_attestation: false,
+        exists: true,
+    };
+
+    ExtBuilder::default()
+        .with_balances(vec![(alice.into(), 300)])
+        .build()
+        .execute_with(|| {
+            LastCheckpoint::<Runtime>::insert(
+                SUPPORTED_CHAIN_KEY,
+                AttestationCheckpoint {
+                    block_number: last_checkpoint_height,
+                    digest: H256::random(),
+                },
+            );
+
+            let pivot = AttestationPallet::<Runtime>::compute_block_index_for(target_height);
+            // Orphan: bucket entry, no checkpoint.
+            CheckpointBuckets::<Runtime>::insert((SUPPORTED_CHAIN_KEY, pivot, orphan_height), ());
+            // Valid, same bucket.
+            CheckpointBuckets::<Runtime>::insert((SUPPORTED_CHAIN_KEY, pivot, valid_in_bucket), ());
+            Checkpoints::<Runtime>::insert(SUPPORTED_CHAIN_KEY, valid_in_bucket, valid_digest);
+
+            // Distractor in the next pivot up.
+            let distractor_pivot =
+                AttestationPallet::<Runtime>::compute_block_index_for(distractor_height);
+            CheckpointBuckets::<Runtime>::insert(
+                (SUPPORTED_CHAIN_KEY, distractor_pivot, distractor_height),
+                (),
+            );
+            Checkpoints::<Runtime>::insert(
+                SUPPORTED_CHAIN_KEY,
+                distractor_height,
+                distractor_digest,
+            );
+
+            precompiles()
+                .prepare_test(
+                    alice,
+                    Precompile,
+                    PCall::find_lowest_attested_after {
+                        chain_key: SUPPORTED_CHAIN_KEY,
+                        target_height,
+                    },
+                )
+                .execute_returns(expected_result);
+        });
+}
+
 #[test]
 fn get_checkpoint_by_height_returns_default_when_no_checkpoint_at_query_height() {
     let alice: H160 = Alice.into();

--- a/precompiles/chain-info/src/tests.rs
+++ b/precompiles/chain-info/src/tests.rs
@@ -8,7 +8,10 @@ use crate::{
 
 use attestor_primitives::{AttestationCheckpoint, AttestationData, SignedAttestation};
 
-use pallet_attestation::{Attestations, Checkpoints, LastCheckpoint, LastDigest};
+use pallet_attestation::{
+    Attestations, CheckpointBuckets, Checkpoints, LastCheckpoint, LastDigest,
+    Pallet as AttestationPallet,
+};
 use precompile_utils::{prelude::UnboundedBytes, testing::*};
 
 use sp_core::{H160, H256};
@@ -564,6 +567,129 @@ fn get_checkpoint_by_height_works() {
                     PCall::get_checkpoint_for_height {
                         chain_key: SUPPORTED_CHAIN_KEY,
                         height: fake_height,
+                    },
+                )
+                .execute_returns(expected_result);
+        });
+}
+
+// Regression: `CheckpointBuckets` and `Checkpoints` are written/removed as a pair, but the
+// prefix-clear paths in `clear_or_revert.rs` advance their cursors independently after a chain
+// removal, so a bucket entry can briefly outlive its checkpoint. The bucket-search precompiles
+// must skip such an orphan rather than `.unwrap()` on the missing checkpoint — a panic here
+// would trap runtime WASM and halt block import (DoS).
+#[test]
+fn find_highest_attested_before_skips_orphan_bucket_entry() {
+    let alice: H160 = Alice.into();
+
+    let target_height: u64 = 1500;
+    let orphan_height: u64 = 1400; // < target, sits in the pivot bucket just below target
+    let valid_height: u64 = 800; // < target, in the next pivot down, has a real checkpoint
+    let valid_digest = H256::from_slice(&[7_u8; 32]);
+    let last_checkpoint_height: u64 = 2000; // >= target, forces the bucket-search branch
+
+    let expected_result = HeightHashResult {
+        height: valid_height,
+        hash: valid_digest,
+        is_attestation: false,
+        exists: true,
+    };
+
+    ExtBuilder::default()
+        .with_balances(vec![(alice.into(), 300)])
+        .build()
+        .execute_with(|| {
+            LastCheckpoint::<Runtime>::insert(
+                SUPPORTED_CHAIN_KEY,
+                AttestationCheckpoint {
+                    block_number: last_checkpoint_height,
+                    digest: H256::random(),
+                },
+            );
+
+            // Orphan bucket entry with no matching `Checkpoints` value: the desync window.
+            let orphan_pivot = AttestationPallet::<Runtime>::compute_block_index_for(orphan_height);
+            CheckpointBuckets::<Runtime>::insert(
+                (SUPPORTED_CHAIN_KEY, orphan_pivot, orphan_height),
+                (),
+            );
+            assert!(Checkpoints::<Runtime>::get(SUPPORTED_CHAIN_KEY, orphan_height).is_none());
+
+            // A consistent checkpoint one pivot lower; the search should skip the orphan and
+            // fall through to this one.
+            let valid_pivot = AttestationPallet::<Runtime>::compute_block_index_for(valid_height);
+            CheckpointBuckets::<Runtime>::insert(
+                (SUPPORTED_CHAIN_KEY, valid_pivot, valid_height),
+                (),
+            );
+            Checkpoints::<Runtime>::insert(SUPPORTED_CHAIN_KEY, valid_height, valid_digest);
+
+            precompiles()
+                .prepare_test(
+                    alice,
+                    Precompile,
+                    PCall::find_highest_attested_before {
+                        chain_key: SUPPORTED_CHAIN_KEY,
+                        target_height,
+                    },
+                )
+                .execute_returns(expected_result);
+        });
+}
+
+#[test]
+fn find_lowest_attested_after_skips_orphan_bucket_entry() {
+    let alice: H160 = Alice.into();
+
+    let target_height: u64 = 1500;
+    let orphan_height: u64 = 1600; // >= target, sits in the pivot bucket at target
+    let valid_height: u64 = 2400; // >= target, in the next pivot up, has a real checkpoint
+    let valid_digest = H256::from_slice(&[9_u8; 32]);
+    let last_checkpoint_height: u64 = 3000; // > target, forces the bucket-search branch
+
+    let expected_result = HeightHashResult {
+        height: valid_height,
+        hash: valid_digest,
+        is_attestation: false,
+        exists: true,
+    };
+
+    ExtBuilder::default()
+        .with_balances(vec![(alice.into(), 300)])
+        .build()
+        .execute_with(|| {
+            LastCheckpoint::<Runtime>::insert(
+                SUPPORTED_CHAIN_KEY,
+                AttestationCheckpoint {
+                    block_number: last_checkpoint_height,
+                    digest: H256::random(),
+                },
+            );
+
+            // Orphan bucket entry with no matching `Checkpoints` value: the desync window.
+            let orphan_pivot = AttestationPallet::<Runtime>::compute_block_index_for(orphan_height);
+            CheckpointBuckets::<Runtime>::insert(
+                (SUPPORTED_CHAIN_KEY, orphan_pivot, orphan_height),
+                (),
+            );
+            assert!(Checkpoints::<Runtime>::get(SUPPORTED_CHAIN_KEY, orphan_height).is_none());
+
+            // A consistent checkpoint one pivot higher; the search should skip the orphan and
+            // fall through to this one.
+            let valid_pivot = AttestationPallet::<Runtime>::compute_block_index_for(valid_height);
+            CheckpointBuckets::<Runtime>::insert(
+                (SUPPORTED_CHAIN_KEY, valid_pivot, valid_height),
+                (),
+            );
+            Checkpoints::<Runtime>::insert(SUPPORTED_CHAIN_KEY, valid_height, valid_digest);
+
+            precompiles()
+                .prepare_test(
+                    alice,
+                    Precompile,
+                    PCall::find_lowest_attested_after {
+                        chain_key: SUPPORTED_CHAIN_KEY,
+                        target_height,
                     },
                 )
                 .execute_returns(expected_result);


### PR DESCRIPTION
The bucket-search precompiles unwrapped Checkpoints::get assuming every CheckpointBuckets entry has a matching checkpoint. The prefix-clear paths in clear_or_revert.rs advance the two maps' cursors independently after a chain removal, so a bucket entry can briefly outlive its checkpoint. An unwrap there would trap runtime WASM and halt block import (DoS). Skip orphan entries and continue the pivot search instead. Adds regression tests covering both find_highest_attested_before and find_lowest_attested_after.

