### PR TITLE
fix(attestation): reject continuity proof tail at block 0 (Certik N10)

### DIFF
--- a/pallets/attestation/src/continuity.rs
+++ b/pallets/attestation/src/continuity.rs
@@ -122,8 +122,14 @@ impl<T: Config> Pallet<T> {
             return Err(Error::<T>::InvalidAttestationContinuityProofTail.into());
         };
 
-        if tail_prev_header_number != tail_block_number - 1 {
-            error!("❌ Continuity proof tail prev digest points to an attestation/checkpoint with header number {}, but expected {}", tail_prev_header_number, tail_block_number - 1);
+        // `tail_block_number` is attacker-influenced (header_number.saturating_sub(roots.len()));
+        // a degenerate proof can drive it to 0. Reject that explicitly instead of computing
+        // `tail_block_number - 1`, which would underflow (panics under overflow-checks, wraps otherwise).
+        let expected_tail_prev_header_number = tail_block_number
+            .checked_sub(1)
+            .ok_or(Error::<T>::InvalidAttestationContinuityProofTail)?;
+        if tail_prev_header_number != expected_tail_prev_header_number {
+            error!("❌ Continuity proof tail prev digest points to an attestation/checkpoint with header number {tail_prev_header_number}, but expected {expected_tail_prev_header_number}");
             return Err(Error::<T>::InvalidAttestationContinuityProofTail.into());
         }
 

--- a/pallets/attestation/src/tests.rs
+++ b/pallets/attestation/src/tests.rs
@@ -2668,6 +2668,70 @@ fn commit_attestation_should_error_on_invalid_continuity_block() {
     })
 }
 
+// Regression: a continuity proof whose tail resolves to block 0 used to compute
+// `tail_block_number - 1`, underflowing (panic under overflow-checks). It must now be
+// rejected cleanly as an invalid tail.
+#[test]
+fn commit_attestation_should_reject_continuity_proof_tail_at_block_zero() {
+    ExtBuilder.build_and_execute(|| {
+        let attestor = Attestor::new(STASH_1, ATTESTOR_1);
+
+        assert_ok!(Attestation::register_attestor(
+            attestor.stash.clone(),
+            SUPPORTED_CHAIN_KEY,
+            attestor.attestor_id,
+        ));
+        assert_ok!(Attestation::attest(
+            RuntimeOrigin::signed(attestor.attestor_id),
+            SUPPORTED_CHAIN_KEY,
+            attestor.public_key,
+            attestor.signature
+        ));
+
+        progress_to_block(5);
+
+        // Commit the genesis attestation (header 0) so its digest is a known finalized tail.
+        let attestation_1 =
+            create_signed_attestation(vec![attestor.clone()], SUPPORTED_CHAIN_KEY, 0, None, None);
+        assert_ok!(Attestation::commit_attestation(
+            attestor.attestor_origin.clone(),
+            attestation_1.clone()
+        ));
+
+        // Craft a proof with roots.len() == header_number, so
+        // start_block_number = header_number - roots.len() = 0. The tail links to the genesis
+        // attestation, so validation reaches the `tail_block_number - 1` site with tail == 0.
+        let header_number = 5u64;
+        let continuity_proof = construct_fragment(
+            Some(attestation_1.digest()),
+            RangeInclusive::new(1, header_number),
+        );
+        assert_eq!(continuity_proof.len() as u64, header_number);
+        assert_eq!(
+            continuity_proof.start_block_number(header_number),
+            0,
+            "tail block number must be 0 to exercise the underflow guard"
+        );
+
+        let start_block = continuity_proof.start_block_number(header_number);
+        let attestation = AttestationPrimitive {
+            chain_key: SUPPORTED_CHAIN_KEY,
+            header_number,
+            header_hash: H256::random(),
+            root: H256::from([0; 32]),
+            prev_digest: Some(continuity_proof.compute_continuity_digest(start_block)),
+        };
+
+        let attestation_2 =
+            bls_sign_attestation(vec![attestor.clone()], attestation, continuity_proof);
+
+        assert_err!(
+            Attestation::commit_attestation(attestor.attestor_origin, attestation_2),
+            Error::<Test>::InvalidAttestationContinuityProofTail
+        );
+    })
+}
+
 #[test]
 fn commit_attestation_should_error_on_invalid_continuity_genesis_block() {
     ExtBuilder.build_and_execute(|| {


### PR DESCRIPTION
A continuity proof with roots.len() >= header_number drives the tail block number to 0, making `tail_block_number - 1` underflow (panic under overflow-checks, wrap otherwise). Guard with checked_sub and reject such proofs as InvalidAttestationContinuityProofTail, with a regression test.


