### PR TITLE
Update `redis` from 8.6.3-alpine to 8.8.0-alpine in /proof-gen-api-se…

### DIFF
--- a/proof-gen-api-server/redis.Dockerfile
+++ b/proof-gen-api-server/redis.Dockerfile
@@ -1,4 +1,4 @@
-FROM redis:8.6.3-alpine
+FROM redis:8.8.0-alpine
 # redis user is defined in the base image
 USER redis
 COPY redis.conf /usr/local/etc/redis/redis.conf


### PR DESCRIPTION
…rver


Extracted from https://github.com/gluwa/creditcoin3/pull/1023