### PR TITLE
fix(pallet-attestation): validate chain_key on set_target_sample_size

### DIFF
--- a/pallets/attestation/src/impls.rs
+++ b/pallets/attestation/src/impls.rs
@@ -752,7 +752,14 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn apply_interval_updates() {
-        PendingAttestationInterval::<T>::iter().for_each(
+        // Use `drain()` rather than `iter() + bounded clear(num_supported_chains)`. The bounded
+        // clear leaked entries whenever the pending map held more rows than the supported-chain
+        // count — possible when an operator wrote a pending entry for a chain that was later
+        // removed, or via the (now fixed) `set_target_sample_size` bypass. Leaked rows re-fired
+        // every epoch, polluting `ChainAttestationInterval` / `TargetSampleSize` / `MaxCatchup`
+        // with orphaned values and emitting duplicate events. `drain()` removes each row as it
+        // applies it, so every iterated entry is guaranteed gone — no count guess.
+        PendingAttestationInterval::<T>::drain().for_each(
             |(chain_key, new_attestation_interval)| {
                 ChainAttestationInterval::<T>::set(chain_key, new_attestation_interval);
 
@@ -763,7 +770,7 @@ impl<T: Config> Pallet<T> {
             },
         );
 
-        PendingTargetSampleSize::<T>::iter().for_each(|(chain_key, new_target_sample_size)| {
+        PendingTargetSampleSize::<T>::drain().for_each(|(chain_key, new_target_sample_size)| {
             TargetSampleSize::<T>::set(chain_key, new_target_sample_size);
 
             Self::deposit_event(Event::<T>::TargetSampleSizeChanged(
@@ -772,17 +779,11 @@ impl<T: Config> Pallet<T> {
             ));
         });
 
-        PendingMaxCatchup::<T>::iter().for_each(|(chain_key, new_max_catchup)| {
+        PendingMaxCatchup::<T>::drain().for_each(|(chain_key, new_max_catchup)| {
             MaxCatchup::<T>::set(chain_key, new_max_catchup);
 
             Self::deposit_event(Event::<T>::MaxCatchupChanged(chain_key, new_max_catchup));
         });
-
-        // Clear PendingAttestationInterval, PendingTargetSampleSize & PendingMaxCatchup
-        let num_supported_chains = T::SupportedChains::supported_chains().len();
-        let _ = PendingAttestationInterval::<T>::clear(num_supported_chains as u32, None);
-        let _ = PendingTargetSampleSize::<T>::clear(num_supported_chains as u32, None);
-        let _ = PendingMaxCatchup::<T>::clear(num_supported_chains as u32, None);
     }
 
     pub(crate) fn chill_all_attestors_for_chain(chain_key: ChainKey) {

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -896,6 +896,16 @@ pub mod pallet {
                 Error::<T>::InvalidTargetSampleSize
             };
 
+            // Mirror `set_chain_attestation_interval` / `set_max_catchup`: reject pending
+            // entries for chains we don't track. Without this, the epoch hook would write
+            // `TargetSampleSize::<T>::set(bogus_key, _)` and emit an event — and because
+            // `apply_interval_updates` previously bounded its cleanup by the supported-chain
+            // count, surplus bogus entries even survived the clear and re-fired every epoch.
+            ensure!(
+                T::SupportedChains::is_chain_supported(chain_key),
+                Error::<T>::ChainNotSupported
+            );
+
             PendingTargetSampleSize::<T>::set(chain_key, Some(new_target_sample_size));
 
             Self::deposit_event(Event::<T>::PendingTargetSampleSizeSet(

--- a/pallets/attestation/src/tests.rs
+++ b/pallets/attestation/src/tests.rs
@@ -8745,3 +8745,54 @@ mod bls_key_uniqueness {
         })
     }
 }
+
+/// Regression: `set_target_sample_size` must reject unsupported chain_keys (like its peers
+/// `set_chain_attestation_interval` and `set_max_catchup`), and `apply_interval_updates` must
+/// `drain` pending entries so nothing leaks across epochs.
+mod set_target_sample_size_supported_chain_and_drain {
+    use super::*;
+    use frame_support::assert_noop;
+
+    const UNSUPPORTED_CHAIN_KEY: ChainKey = 999;
+
+    #[test]
+    fn set_target_sample_size_rejects_unsupported_chain_key() {
+        ExtBuilder.build_and_execute(|| {
+            assert_noop!(
+                Attestation::set_target_sample_size(
+                    RuntimeOrigin::root(),
+                    UNSUPPORTED_CHAIN_KEY,
+                    7
+                ),
+                Error::<Test>::ChainNotSupported
+            );
+            // And the pending entry didn't slip past the failed dispatch.
+            assert!(PendingTargetSampleSize::<Test>::get(UNSUPPORTED_CHAIN_KEY).is_none());
+        })
+    }
+
+    #[test]
+    fn apply_interval_updates_drains_all_pending_entries() {
+        ExtBuilder.build_and_execute(|| {
+            // Seed pending entries directly under multiple keys — bypassing the setter, which
+            // simulates what could happen historically before the chain-supported guard, or
+            // after a chain is removed but pending entries remain.
+            PendingAttestationInterval::<Test>::insert(SUPPORTED_CHAIN_KEY, 7);
+            PendingAttestationInterval::<Test>::insert(UNSUPPORTED_CHAIN_KEY, 9);
+
+            PendingTargetSampleSize::<Test>::insert(SUPPORTED_CHAIN_KEY, 3);
+            PendingTargetSampleSize::<Test>::insert(UNSUPPORTED_CHAIN_KEY, 5);
+
+            PendingMaxCatchup::<Test>::insert(SUPPORTED_CHAIN_KEY, 11);
+            PendingMaxCatchup::<Test>::insert(UNSUPPORTED_CHAIN_KEY, 13);
+
+            Attestation::apply_interval_updates();
+
+            // Every pending map drained — including entries for chain_keys not present in
+            // SupportedChains. Under the previous bounded-clear, the surplus entries leaked.
+            assert_eq!(PendingAttestationInterval::<Test>::iter().count(), 0);
+            assert_eq!(PendingTargetSampleSize::<Test>::iter().count(), 0);
+            assert_eq!(PendingMaxCatchup::<Test>::iter().count(), 0);
+        })
+    }
+}


### PR DESCRIPTION
Validate chain key when setting target sample and Use `drain()` rather than `iter()`