### PR TITLE
feat(block-prover): cap continuity-proof roots to fail fast on oversized proofs

### DIFF
--- a/precompiles/block-prover/src/continuity.rs
+++ b/precompiles/block-prover/src/continuity.rs
@@ -17,6 +17,8 @@ use crate::BlockProverPrecompile;
 pub enum ContinuityVerificationError {
     /// Continuity chain doesn't have enough blocks
     InsufficientBlocks,
+    /// Continuity chain exceeds the maximum allowed number of roots
+    TooManyRoots,
     /// Continuity chain does not reach query height
     ChainDoesNotReachQueryHeight,
     /// Continuity chain does not end at a valid attestation or checkpoint
@@ -28,6 +30,7 @@ impl ContinuityVerificationError {
     pub fn message(&self) -> &'static str {
         match self {
             Self::InsufficientBlocks => "Continuity chain cannot be empty",
+            Self::TooManyRoots => "Continuity chain exceeds maximum allowed roots",
             Self::ChainDoesNotReachQueryHeight => "Continuity chain does not reach query height",
             Self::NoMatchingAttestationOrCheckpoint => {
                 "Continuity proof does not match attestation or checkpoint"
@@ -97,6 +100,13 @@ where
             return Err(continuity_revert(
                 ContinuityVerificationError::InsufficientBlocks,
             ));
+        }
+
+        // Reject absurdly large proofs early, before any hashing work. Legitimate
+        // proofs are far smaller than this cap; the per-root work is also gas-metered,
+        // so this is a fail-fast guard against pathological calldata.
+        if continuity_proof.roots.len() > crate::verify::MAX_CONTINUITY_ROOTS {
+            return Err(continuity_revert(ContinuityVerificationError::TooManyRoots));
         }
 
         // Validate the continuity chain reaches the query height (fail early before digest computation)

--- a/precompiles/block-prover/src/tests.rs
+++ b/precompiles/block-prover/src/tests.rs
@@ -414,6 +414,88 @@ fn test_verify_continuity_chain_errors_when_continuity_chain_doesnt_reach_query_
 }
 
 #[test]
+fn test_verify_continuity_chain_rejects_too_many_roots() {
+    ExtBuilder::default().build().execute_with(|| {
+        // A proof with more roots than MAX_CONTINUITY_ROOTS must fail fast,
+        // before any hashing/storage work, with the dedicated revert message.
+        let start_block_number = 1u64;
+        let oversized_len = crate::verify::MAX_CONTINUITY_ROOTS + 1;
+        let continuity_proof =
+            ContinuityProof::new(H256::zero(), vec![H256::zero(); oversized_len]);
+
+        let mut handle = MockHandle::new(
+            Account::Precompile.into(),
+            Context {
+                address: Account::Precompile.into(),
+                caller: Account::Alice.into(),
+                apparent_value: U256::zero(),
+            },
+        );
+
+        let result = BlockProverPrecompile::<Runtime>::verify_continuity_chain(
+            &mut handle,
+            &continuity_proof,
+            start_block_number,
+            1, // chain_key
+            start_block_number + oversized_len as u64 - 1,
+        );
+
+        let expected =
+            crate::encode_revert_message("Continuity chain exceeds maximum allowed roots");
+        assert!(
+            matches!(&result, Err(PrecompileFailure::Revert { output, .. }) if *output == expected),
+            "Expected TooManyRoots revert, got {result:?}"
+        );
+
+        // The guard must fire before the upfront per-root gas charge: hashing
+        // MAX_CONTINUITY_ROOTS+1 blocks would otherwise cost far more than this.
+        assert!(
+            handle.gas_used < crate::verify::CONTINUITY_BLOCK_HASH_COST,
+            "Oversized proof should be rejected before charging per-root hashing gas"
+        );
+    });
+}
+
+#[test]
+fn test_verify_continuity_chain_accepts_max_roots_boundary() {
+    ExtBuilder::default().build().execute_with(|| {
+        // A proof at exactly MAX_CONTINUITY_ROOTS must pass the length guard.
+        // It still fails later (no matching attestation/checkpoint), proving the
+        // cap itself did not reject a within-bound proof.
+        let start_block_number = 1u64;
+        let max_len = crate::verify::MAX_CONTINUITY_ROOTS;
+        let continuity_proof = ContinuityProof::new(H256::zero(), vec![H256::zero(); max_len]);
+
+        let mut handle = MockHandle::new(
+            Account::Precompile.into(),
+            Context {
+                address: Account::Precompile.into(),
+                caller: Account::Alice.into(),
+                apparent_value: U256::zero(),
+            },
+        );
+
+        let result = BlockProverPrecompile::<Runtime>::verify_continuity_chain(
+            &mut handle,
+            &continuity_proof,
+            start_block_number,
+            1, // chain_key
+            start_block_number + max_len as u64 - 1,
+        );
+
+        let too_many =
+            crate::encode_revert_message("Continuity chain exceeds maximum allowed roots");
+        match result {
+            Err(PrecompileFailure::Revert { output, .. }) => assert_ne!(
+                output, too_many,
+                "Boundary-length proof must not be rejected by the roots cap"
+            ),
+            other => panic!("Expected a (non-TooManyRoots) revert, got {other:?}"),
+        }
+    });
+}
+
+#[test]
 fn test_verify_continuity_chain_at_checkpoint_height_errors_when_supported_chain_was_removed() {
     ExtBuilder::default().build().execute_with(|| {
         let query_height = 100;

--- a/precompiles/block-prover/src/verify.rs
+++ b/precompiles/block-prover/src/verify.rs
@@ -32,6 +32,25 @@ pub const CONTINUITY_BLOCK_HASH_COST: u64 = 48; // Keccak-256 hash cost: 30 base
 // Gas cost for a storage lookup (matches cold SLOAD)
 pub const GAS_STORAGE_LOOKUP: u64 = 2_600;
 
+/// Hard upper bound on the number of continuity roots accepted in a single proof.
+///
+/// A legitimate continuity proof spans the gap between the query height and the
+/// anchoring attestation/checkpoint. The current per-chain gap is
+/// `attestation_interval * checkpoint_interval`, but both are mutable, so a proof
+/// into a historically-checkpointed region may legitimately span a wider gap than
+/// the current config implies and the historical width is not recorded on-chain.
+/// This ceiling is therefore deliberately *loose*: it sits far above any plausible
+/// historical checkpoint spacing so it never rejects a valid proof, while still
+/// failing fast on pathological inputs (e.g. the ~100k-root case) before any
+/// allocation/hashing work.
+///
+/// This is defence-in-depth, not a soundness gate: the per-root work is already
+/// gas-metered at the EVM keccak rate, and an oversized proof can only reach the
+/// revert path (success requires a real attestation/checkpoint at the final block,
+/// which an attacker cannot fabricate). It mirrors the bounded arrays used
+/// elsewhere in this precompile (`MaxBatchSize`, `ConstU10MB`).
+pub const MAX_CONTINUITY_ROOTS: usize = 50_000;
+
 // Gas cost constants for calculateTxIndex
 // Base cost: 10 gas units
 pub const CALCULATE_TX_INDEX_BASE_COST: u64 = 10;


### PR DESCRIPTION
Add an explicit MAX_CONTINUITY_ROOTS (50_000) guard in verify_continuity_chain, checked before the upfront per-root gas charge and the hashing loop. Both the single and batch verify paths route through this function, so the cap covers both.

This is defence-in-depth, not a soundness gate: per-root work is already gas-metered at the EVM keccak rate, and an oversized proof can only reach the revert path (success requires a real attestation/checkpoint at the final block). The ceiling is deliberately loose because checkpoint spacing is mutable and historical widths are not recorded on-chain, so it must never reject a valid proof while still rejecting pathological calldata early.

Mirrors the bounded arrays used elsewhere in the precompile (MaxBatchSize, ConstU10MB).


