### PR TITLE
chore: adjust chainspecs to use EvmSafe in eth networks

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -421,7 +421,7 @@ fn devnet_genesis(
                     1,
                     "Ethereum".as_bytes().to_vec(),
                     ChainEncodingVersion::V1,
-                    MATURITY_FIXED_DELAY_10.to_string(),
+                    MATURITY_EVM_SAFE.to_string(),
                 ),
                 // 2 Anvil network one
                 (
@@ -435,7 +435,7 @@ fn devnet_genesis(
                     11155111,
                     "Sepolia ethereum".as_bytes().to_vec(),
                     ChainEncodingVersion::V1,
-                    MATURITY_FIXED_DELAY_10.to_string(),
+                    MATURITY_EVM_SAFE.to_string(),
                 ),
                 // 4. Anvil network two
                 (
@@ -457,7 +457,7 @@ fn devnet_genesis(
                     80002,
                     "Polygon amoy testnet".as_bytes().to_vec(),
                     ChainEncodingVersion::V1,
-                    MATURITY_FIXED_DELAY_10.to_string(),
+                    MATURITY_EVM_SAFE.to_string(),
                 ),
             ],
             _phantom: Default::default(),


### PR DESCRIPTION
Use `EvmSafe` for eth networks in dev environments
