### PR TITLE
fix: dev -> usc-dev in epoch duration check script

### DIFF
--- a/.github/check-for-changes-in-epoch-duration.sh
+++ b/.github/check-for-changes-in-epoch-duration.sh
@@ -62,7 +62,7 @@ check_slot_duration() {
 
 #### main part
 
-FROM=$(git rev-parse "${1:-origin/dev}")
+FROM=$(git rev-parse "${1:-origin/usc-dev}")
 TO=$(git rev-parse "${2:-HEAD}")
 
 greenprint "DEBUG: Inspecting range $FROM..$TO"


### PR DESCRIPTION
Cherry-picks e492d21efcadad9aa33172992f43a0f1ea6be736 from #1054 into a standalone PR against `usc-dev`.

Updates `.github/check-for-changes-in-epoch-duration.sh` to default to `origin/usc-dev` instead of `origin/dev`.

Requested by @atodorov-gluwa.