### PR TITLE
cherry-pick: precompile delegate call guard (#981) → usc-dev

### DIFF
--- a/precompiles/substrate-transfer/src/lib.rs
+++ b/precompiles/substrate-transfer/src/lib.rs
@@ -51,6 +51,12 @@ where
     ) -> EvmResult<bool> {
         handle.record_log_costs_manual(3, 32)?;
 
+        if handle.context().address != handle.code_address() {
+            return Err(revert(
+                "SubstrateTransfer: cannot be called with DELEGATECALL or CALLCODE",
+            ));
+        }
+
         // Build call with origin.
         {
             log::debug!("bytes: {destination:?}");


### PR DESCRIPTION
Cherry-pick of #981 (`8df9b9230`) into `usc-dev`.

## What
Adds DELEGATECALL/CALLCODE guard to the `substrate-transfer` precompile:

```rust
if handle.context().address != handle.code_address() {
    return Err(revert(
        "SubstrateTransfer: cannot be called with DELEGATECALL or CALLCODE",
    ));
}
```

Prevents the precompile from being invoked through a delegating contract, which would otherwise let an attacker spoof the calling origin.

## Scope
- Only the precompile change from #981 was carried over.
- Version bump (`spec_version` 65 → 66) and `Cargo.lock`/`Cargo.toml` workspace version changes from the original commit were dropped — `usc-dev` is on a separate version track (currently `spec_version: 126`).

## Notes
- `cargo fmt` clean.
- `cargo clippy -p pallet-evm-precompile-substrate-transfer` clean.
- Original PR: https://github.com/gluwa/creditcoin3/pull/981