### PR TITLE
feat(proof-gen): expose cache height gauges

### DIFF
--- a/proof-gen-api-server/src/prom/mod.rs
+++ b/proof-gen-api-server/src/prom/mod.rs
@@ -45,6 +45,8 @@ pub trait MetricsTrait: Send + Sync + Debug {
 
     // Business metrics
     fn observe_block_range(&self, block: u64);
+    fn set_last_attested_height(&self, chain_key: u64, height: Option<u64>);
+    fn set_last_checkpoint_height(&self, chain_key: u64, height: Option<u64>);
 }
 
 /// Metrics type alias for use throughout the codebase.
@@ -78,6 +80,8 @@ impl MetricsTrait for NoopMetrics {
 
     // Business metrics
     fn observe_block_range(&self, _block: u64) {}
+    fn set_last_attested_height(&self, _chain_key: u64, _height: Option<u64>) {}
+    fn set_last_checkpoint_height(&self, _chain_key: u64, _height: Option<u64>) {}
 }
 
 /// Comprehensive metrics for the proof-gen-api-server.
@@ -101,6 +105,8 @@ pub struct ProofGenMetrics {
 
     // Business metrics
     block_range: Histogram,
+    last_attested_height: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
+    last_checkpoint_height: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
     /// Server start time as Unix timestamp (seconds since epoch).
     /// Use PromQL `time() - proof_gen_start_time_seconds` to calculate uptime.
     /// This field is registered with Prometheus registry and accessed during encoding,
@@ -178,6 +184,20 @@ impl ProofGenMetrics {
             block_range.clone(),
         );
 
+        let last_attested_height = Family::<labels::LabelChain, Gauge<u64, AtomicU64>>::default();
+        registry.register(
+            "proof_gen_last_attested_height",
+            "Latest attested source-chain height cached by the proof-gen server",
+            last_attested_height.clone(),
+        );
+
+        let last_checkpoint_height = Family::<labels::LabelChain, Gauge<u64, AtomicU64>>::default();
+        registry.register(
+            "proof_gen_last_checkpoint_height",
+            "Latest checkpoint source-chain height cached by the proof-gen server",
+            last_checkpoint_height.clone(),
+        );
+
         let start_time_seconds = Gauge::default();
         // Set start time once at initialization (Unix timestamp)
         let now = SystemTime::now()
@@ -239,6 +259,8 @@ impl ProofGenMetrics {
             merkle_generation_duration,
             last_proof_generation_timestamp,
             block_range,
+            last_attested_height,
+            last_checkpoint_height,
             start_time_seconds,
             cpu_usage_percent,
             memory_usage_bytes,
@@ -389,6 +411,26 @@ impl MetricsTrait for ProofGenMetrics {
     fn observe_block_range(&self, block: u64) {
         self.block_range.observe(block as f64);
     }
+
+    fn set_last_attested_height(&self, chain_key: u64, height: Option<u64>) {
+        let labels = labels::LabelChain { chain_key };
+        if let Some(height) = height {
+            self.last_attested_height.get_or_create(&labels).set(height);
+        } else {
+            let _ = self.last_attested_height.remove(&labels);
+        }
+    }
+
+    fn set_last_checkpoint_height(&self, chain_key: u64, height: Option<u64>) {
+        let labels = labels::LabelChain { chain_key };
+        if let Some(height) = height {
+            self.last_checkpoint_height
+                .get_or_create(&labels)
+                .set(height);
+        } else {
+            let _ = self.last_checkpoint_height.remove(&labels);
+        }
+    }
 }
 
 /// Info metric items following the attestor pattern.
@@ -421,6 +463,11 @@ mod labels {
     #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
     pub struct LabelEndpoint {
         pub endpoint: Endpoint,
+    }
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+    pub struct LabelChain {
+        pub chain_key: u64,
     }
 
     // Transfer direction labels (for request/response size)

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -231,6 +231,8 @@ impl ContinuityService {
                 latest = ?checkpoint_map.keys().next_back(),
                 "🚀 ✅ 📝 Checkpoint cache populated from CC3"
             );
+            metrics
+                .set_last_checkpoint_height(chain_key, checkpoint_map.keys().next_back().copied());
 
             // Populate attestation cache from CC3 on startup.
             tracing::debug!(
@@ -258,6 +260,8 @@ impl ContinuityService {
                 latest = ?attestation_map.keys().next_back(),
                 "🚀 ✅ 📜 Attestation cache populated from CC3"
             );
+            let latest_attested_height = attestation_map.keys().next_back().copied();
+            metrics.set_last_attested_height(chain_key, latest_attested_height);
 
             chains.insert(
                 chain_key,
@@ -407,6 +411,38 @@ impl ContinuityService {
     pub async fn attested_height(&self, chain_key: u64) -> ServiceResult<Option<u64>> {
         let chain = self.chain_state(chain_key)?;
 
+        Ok(Self::cached_attested_height(chain.as_ref()).await)
+    }
+
+    /// Insert an attestation into the in-memory cache (called from event handler).
+    pub async fn insert_attestation(&self, chain_key: u64, block_number: u64, digest: H256) {
+        if let Some(chain) = self.chains.get(&chain_key) {
+            {
+                chain
+                    .attestation_cache
+                    .write()
+                    .await
+                    .insert(block_number, digest);
+            }
+            tracing::debug!(
+                chain_key,
+                block_number,
+                ?digest,
+                "🔧 📦 📜 attestation cached"
+            );
+            self.metrics.set_last_attested_height(
+                chain_key,
+                Self::cached_attestation_height(chain.as_ref()).await,
+            );
+        }
+    }
+
+    async fn cached_attestation_height(chain: &ChainState) -> Option<u64> {
+        let cache = chain.attestation_cache.read().await;
+        cache.keys().next_back().copied()
+    }
+
+    async fn cached_attested_height(chain: &ChainState) -> Option<u64> {
         let mut last_height = {
             let cache = chain.attestation_cache.read().await;
             cache.keys().next_back().copied()
@@ -417,24 +453,12 @@ impl ContinuityService {
             last_height = checkpoint_cache.keys().next_back().copied();
         }
 
-        Ok(last_height)
+        last_height
     }
 
-    /// Insert an attestation into the in-memory cache (called from event handler).
-    pub async fn insert_attestation(&self, chain_key: u64, block_number: u64, digest: H256) {
-        if let Some(chain) = self.chains.get(&chain_key) {
-            chain
-                .attestation_cache
-                .write()
-                .await
-                .insert(block_number, digest);
-            tracing::debug!(
-                chain_key,
-                block_number,
-                ?digest,
-                "🔧 📦 📜 attestation cached"
-            );
-        }
+    async fn cached_checkpoint_height(chain: &ChainState) -> Option<u64> {
+        let checkpoint_cache = chain.checkpoint_cache.read().await;
+        checkpoint_cache.keys().next_back().copied()
     }
 
     /// Truncate attestation and checkpoint caches to the given revert height.
@@ -472,6 +496,14 @@ impl ContinuityService {
             // Reset the builder's last-checkpoint hint so that
             // determine_checkpoint_info does not skip checks based on stale state.
             chain.builder.reset_last_checkpoint_block().await;
+            self.metrics.set_last_attested_height(
+                chain_key,
+                Self::cached_attestation_height(chain.as_ref()).await,
+            );
+            self.metrics.set_last_checkpoint_height(
+                chain_key,
+                Self::cached_checkpoint_height(chain.as_ref()).await,
+            );
         }
     }
 
@@ -490,40 +522,52 @@ impl ContinuityService {
     /// only ones the verifier will accept as proof anchors.
     pub async fn prune_attestations_at_or_below(&self, chain_key: u64, height: u64) {
         if let Some(chain) = self.chains.get(&chain_key) {
-            let split_key = height.saturating_add(1);
-            let mut att = chain.attestation_cache.write().await;
-            // split_off mutates `att` in place to hold entries < split_key
-            // and returns entries >= split_key. We want to keep the latter,
-            // so reassign unconditionally — guarding this on `removed > 0`
-            // would silently wipe the cache whenever nothing needed pruning.
-            let kept = att.split_off(&split_key);
-            let removed = att.len();
-            *att = kept;
-            if removed > 0 {
-                tracing::debug!(
-                    chain_key,
-                    height,
-                    removed,
-                    remaining = att.len(),
-                    "🔧 🧹 pruned consumed attestations after checkpoint"
-                );
+            {
+                let split_key = height.saturating_add(1);
+                let mut att = chain.attestation_cache.write().await;
+                // split_off mutates `att` in place to hold entries < split_key
+                // and returns entries >= split_key. We want to keep the latter,
+                // so reassign unconditionally — guarding this on `removed > 0`
+                // would silently wipe the cache whenever nothing needed pruning.
+                let kept = att.split_off(&split_key);
+                let removed = att.len();
+                *att = kept;
+                if removed > 0 {
+                    tracing::debug!(
+                        chain_key,
+                        height,
+                        removed,
+                        remaining = att.len(),
+                        "🔧 🧹 pruned consumed attestations after checkpoint"
+                    );
+                }
             }
+            self.metrics.set_last_attested_height(
+                chain_key,
+                Self::cached_attestation_height(chain.as_ref()).await,
+            );
         }
     }
 
     /// Insert a checkpoint into the in-memory cache (called from event handler).
     pub async fn insert_checkpoint(&self, chain_key: u64, block_number: u64, digest: H256) {
         if let Some(chain) = self.chains.get(&chain_key) {
-            chain
-                .checkpoint_cache
-                .write()
-                .await
-                .insert(block_number, digest);
+            {
+                chain
+                    .checkpoint_cache
+                    .write()
+                    .await
+                    .insert(block_number, digest);
+            }
             tracing::debug!(
                 chain_key,
                 block_number,
                 ?digest,
                 "🔧 📦 🚩 checkpoint cached"
+            );
+            self.metrics.set_last_checkpoint_height(
+                chain_key,
+                Self::cached_checkpoint_height(chain.as_ref()).await,
             );
         }
     }

--- a/proof-gen-api-server/tests/route_tests.rs
+++ b/proof-gen-api-server/tests/route_tests.rs
@@ -183,6 +183,15 @@ async fn test_metrics_route_should_return_success() {
 
     let response = app.oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+
+    let bytes = axum::body::to_bytes(response.into_body(), 32 * 1024)
+        .await
+        .unwrap();
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(body.contains("# TYPE proof_gen_last_attested_height gauge"));
+    assert!(body.contains("proof_gen_last_attested_height{chain_key=\"2\"} 1000"));
+    assert!(body.contains("# TYPE proof_gen_last_checkpoint_height gauge"));
+    assert!(body.contains("proof_gen_last_checkpoint_height{chain_key=\"2\"} 1000"));
 }
 
 #[tokio::test]

--- a/proof-gen-api-server/tests/test_utils.rs
+++ b/proof-gen-api-server/tests/test_utils.rs
@@ -14,7 +14,7 @@ mod anvil_integration {
     use continuity::{ContinuityBuilder, ContinuityConfig};
     use proof_gen_api_server::{
         build_app,
-        prom::{NoopMetrics, ProofGenMetrics},
+        prom::{Metrics, ProofGenMetrics},
         ContinuityService,
     };
     use serde_json::Value;
@@ -201,16 +201,14 @@ mod anvil_integration {
             );
         }
 
+        let prom_metrics = Arc::new(ProofGenMetrics::new(chain_keys));
+        let metrics: Metrics = prom_metrics.clone();
         let service = Arc::new(
-            ContinuityService::new(builders, NoopMetrics::new(), 10, 1_000)
+            ContinuityService::new(builders, metrics, 10, 1_000)
                 .await
                 .expect("service init"),
         );
-        build_app(
-            service,
-            allowed,
-            std::sync::Arc::new(ProofGenMetrics::new(chain_keys)),
-        )
+        build_app(service, allowed, prom_metrics)
     }
 
     /// Assert a string is a strict 0x-prefixed, lowercase H256 hex.


### PR DESCRIPTION
Expose prover attestation and checkpoint cache heights as per-chain Prometheus gauges so Grafana can monitor chain progress.


