### PR TITLE
fix(docs): point hardhat devnet to rpc.cc3-devnet.creditcoin.network

### DIFF
--- a/docs/smart-contract-development/with-hardhat/hardhat-creditcoin3.config.ts
+++ b/docs/smart-contract-development/with-hardhat/hardhat-creditcoin3.config.ts
@@ -10,7 +10,7 @@ const config: HardhatUserConfig = {
     solidity: '0.8.24',
     networks: {
         creditcoinDevnet: {
-            url: 'https://rpc.usc-devnet.creditcoin.network',
+            url: 'https://rpc.cc3-devnet.creditcoin.network',
             accounts: [CC3TEST_PRIVATE_KEY],
         },
         creditcoinTestnet: {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -208,7 +208,7 @@ When enabled with `-v` or `--verbose`, the script outputs detailed debugging inf
 node SubmitProof.js 3 9986381 0xd93880ebc927784c9ab2605d319a1e4ff78c3d91e7d744012ee2defae273f85f \
   --private-key 0x1234...5678 \
   --api-url https://prover.cc3-devnet.creditcoin.network \
-  --cc3-rpc-url https://rpc.usc-devnet.creditcoin.network \
+  --cc3-rpc-url https://rpc.cc3-devnet.creditcoin.network \
   -v
 ```
 


### PR DESCRIPTION
## Context
CI job `docs-smart-contract-development-with-hardhat` was failing at the *Deploy contract(s) to Creditcoin Devnet* step:
https://github.com/gluwa/creditcoin3/actions/runs/27585875402/job/81635812864

The failing call originates from `creditcoinDevnet.url` in `docs/smart-contract-development/with-hardhat/hardhat-creditcoin3.config.ts`, which is read by the workflow via `npx hardhat ... print-network --network creditcoinDevnet` (see `.github/workflows/ci.yml` line ~1023). The host `rpc.usc-devnet.creditcoin.network` is no longer reachable.

## Change
- `docs/.../hardhat-creditcoin3.config.ts`: `rpc.usc-devnet` → `rpc.cc3-devnet`
- `scripts/README.md`: same URL update for consistency (only other occurrence in the repo)

Requested by @alex.todorov in Slack.