### PR TITLE
chore(proof-gen-api): remove total_proof_requests from health endpoint

### DIFF
--- a/proof-gen-api-server/src/networking/routes/health.rs
+++ b/proof-gen-api-server/src/networking/routes/health.rs
@@ -15,7 +15,6 @@ pub struct HealthCheckResponse {
     status: String,
     cc3_rpc_connected: bool,
     eth_rpc_connected: bool,
-    total_proof_requests: i64,
     uptime_seconds: u64,
 }
 
@@ -29,8 +28,7 @@ pub async fn health_check(
     Extension(service): Extension<Arc<ContinuityService>>,
 ) -> Json<HealthCheckResponse> {
     // Check RPC connectivity in parallel with timeout
-    let (total_requests, cc3_connected, eth_connected) = tokio::join!(
-        async { timeout(HEALTH_CHECK_TIMEOUT, service.get_proofs_counts()).await },
+    let (cc3_connected, eth_connected) = tokio::join!(
         async {
             timeout(HEALTH_CHECK_TIMEOUT, service.check_cc3_connectivity())
                 .await
@@ -43,11 +41,6 @@ pub async fn health_check(
         }
     );
 
-    let total_proof_requests = match total_requests {
-        Ok(Ok(count)) => count,
-        Ok(Err(_)) | Err(_) => 0,
-    };
-
     let status = if cc3_connected && eth_connected {
         "healthy".to_string()
     } else {
@@ -58,7 +51,6 @@ pub async fn health_check(
         status,
         cc3_rpc_connected: cc3_connected,
         eth_rpc_connected: eth_connected,
-        total_proof_requests,
         uptime_seconds: service.uptime_seconds(),
     })
 }

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -151,8 +151,6 @@ pub type ServiceResult<T> = Result<T, ServiceError>;
 pub struct ContinuityService {
     chains: HashMap<u64, Arc<ChainState>>,
     start_time: Instant,
-    /// Total number of proof requests processed (for health endpoint statistics)
-    total_proof_requests: AtomicU64,
     /// Prometheus metrics for instrumentation (uses NoopMetrics when disabled).
     metrics: Metrics,
     /// Maximum amount of concurrent futures spawned when generating proofs for batch requests or when extracting transaction indexes from transaction hashes.
@@ -277,7 +275,6 @@ impl ContinuityService {
         Ok(Self {
             chains,
             start_time: Instant::now(),
-            total_proof_requests: AtomicU64::new(0),
             metrics,
             max_batch_size,
             max_batch_span,
@@ -370,14 +367,6 @@ impl ContinuityService {
 
     pub fn uptime_seconds(&self) -> u64 {
         self.start_time.elapsed().as_secs()
-    }
-
-    /// Get total number of proof requests processed.
-    /// Returns (total_requests) for use in health endpoint.
-    pub async fn get_proofs_counts(&self) -> anyhow::Result<i64> {
-        // Return total proof requests processed since service start
-        let total = self.total_proof_requests.load(Ordering::Relaxed) as i64;
-        Ok(total)
     }
 
     /// Health check for CC3 RPC connectivity
@@ -804,9 +793,6 @@ impl ContinuityService {
         self.build_continuity(chain, headers)
             .await
             .inspect(|proof| {
-                // Increment total proof requests counter
-                self.total_proof_requests.fetch_add(1, Ordering::Relaxed);
-
                 // Record metrics
                 self.metrics.observe_proof_blocks(proof.roots.len() as u64);
                 // Record timestamp of successful proof generation


### PR DESCRIPTION
Drop the total_proof_requests field from the /api/v1/health response and the machinery that existed only to populate it: the get_proofs_counts() method, the total_proof_requests AtomicU64 counter, its init, and the fetch_add in the proof-generation path. The OpenAPI schema updates automatically from the ToSchema-derived HealthCheckResponse struct. AtomicU64/Ordering imports stay — still used by attestation_genesis_block.

