### PR TITLE
perf(proof-gen): cache merkle proofs in memory

### DIFF
--- a/common/continuity/src/archiver.rs
+++ b/common/continuity/src/archiver.rs
@@ -228,6 +228,10 @@ impl EthRpcProvider for ArchiverEthProvider {
             .await
     }
 
+    async fn get_block_tx_data(&self, block_number: u64) -> Result<Vec<(H256, Vec<u8>)>> {
+        self.eth_fallback.get_block_tx_data(block_number).await
+    }
+
     async fn get_tx_position_by_hash(&self, tx_hash: H256) -> Result<Option<(u64, u64)>> {
         self.eth_fallback.get_tx_position_by_hash(tx_hash).await
     }

--- a/common/continuity/src/builder/mod.rs
+++ b/common/continuity/src/builder/mod.rs
@@ -579,6 +579,11 @@ impl ContinuityBuilder {
             .await
     }
 
+    /// Fetch all tx hashes and encoded tx bytes for a block.
+    pub async fn get_block_tx_data(&self, block_number: u64) -> Result<Vec<(H256, Vec<u8>)>> {
+        self.eth_provider.get_block_tx_data(block_number).await
+    }
+
     /// Resolve a transaction hash to its block number and index.
     ///
     /// # Arguments

--- a/common/continuity/src/rpc.rs
+++ b/common/continuity/src/rpc.rs
@@ -247,6 +247,18 @@ pub trait EthRpcProvider: Send + Sync {
         Ok((bytes, hash))
     }
 
+    /// Fetch all tx hashes and encoded tx bytes for a block in canonical order.
+    async fn get_block_tx_data(&self, block_number: u64) -> Result<Vec<(H256, Vec<u8>)>> {
+        let bytes = self.get_block_tx_bytes(block_number).await?;
+        let mut txs = Vec::with_capacity(bytes.len());
+        for (idx, tx_bytes) in bytes.into_iter().enumerate() {
+            if let Some(tx_hash) = self.get_tx_hash_by_index(block_number, idx as u64).await? {
+                txs.push((tx_hash, tx_bytes));
+            }
+        }
+        Ok(txs)
+    }
+
     /// Resolve a transaction hash to its position.
     ///
     /// # Returns
@@ -414,6 +426,23 @@ impl EthRpcProvider for ReconnectingEthRpcProvider {
                 .get(tx_index as usize)
                 .map(|item| H256::from_slice(&item.tx_hash().0));
             Ok((bytes, hash))
+        })
+        .await
+    }
+
+    async fn get_block_tx_data(&self, block_number: u64) -> Result<Vec<(H256, Vec<u8>)>> {
+        self.run("get_block_tx_data", move |client| async move {
+            let ordered = client
+                .get_block(block_number, EncodingVersion::V1)
+                .await
+                .unwrap_interrupt("Not handling user interrupts yet")
+                .context("Failed to fetch block")?;
+
+            Ok(ordered
+                .items()
+                .iter()
+                .map(|item| (H256::from_slice(&item.tx_hash().0), item.to_bytes()))
+                .collect())
         })
         .await
     }

--- a/proof-gen-api-server/Cargo.toml
+++ b/proof-gen-api-server/Cargo.toml
@@ -63,7 +63,7 @@ eth = { workspace = true }
 hex = { workspace = true }
 merkle = { workspace = true }
 prometheus-client = { workspace = true }
-stream = { workspace = true, default-features = false, features = ["cc3"] }
+stream = { workspace = true, features = ["cc3"] }
 sysinfo = { workspace = true }
 
 [features]

--- a/proof-gen-api-server/src/events/mod.rs
+++ b/proof-gen-api-server/src/events/mod.rs
@@ -172,6 +172,7 @@ async fn process_cc_event(
 
             let mut intervals = checkpoint_intervals.write().await;
             intervals.insert(*event_chain_key, interval_u64);
+            service.update_checkpoint_interval(*event_chain_key, interval_u64);
 
             info!(
                 "🔗 ✅ Updated checkpoint interval for chain {event_chain_key} to {}",

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -283,6 +283,7 @@ impl Server {
         let service = Arc::new(service);
 
         ProofGenMetrics::spawn_hardware_updater(self.prom_metrics.clone());
+        ContinuityService::spawn_merkle_backfill(service.clone());
 
         let allowed: std::collections::HashSet<u64> = self.config.chain_keys();
         let app = build_app(service.clone(), allowed, self.prom_metrics.clone());

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -30,7 +30,7 @@ fn classify_eth_rpc_anyhow_as_inconsistent(
 /// `RpcUnavailable` for everything else. Use
 /// [`map_eth_rpc_anyhow_to_service_error_with`] when the non-inconsistent fallback
 /// should be a different variant (e.g. `Internal`).
-fn map_eth_rpc_anyhow_to_service_error(
+pub(crate) fn map_eth_rpc_anyhow_to_service_error(
     err: AnyhowError,
     fallback_block_number: u64,
 ) -> ServiceError {

--- a/proof-gen-api-server/src/services/continuity_service/merkle_cache.rs
+++ b/proof-gen-api-server/src/services/continuity_service/merkle_cache.rs
@@ -178,19 +178,15 @@ impl MerkleProofCache {
 
     pub async fn prune_above(&self, max_height: u64) -> usize {
         let split_key = max_height.saturating_add(1);
-        let removed_blocks = {
-            let mut cache = self.inner.write().await;
-            let removed_blocks = cache.by_block.split_off(&split_key);
-            cache.processed_blocks.split_off(&split_key);
-            removed_blocks
-        };
+        let mut cache = self.inner.write().await;
+        let removed_blocks = cache.by_block.split_off(&split_key);
+        cache.processed_blocks.split_off(&split_key);
 
         let removed = removed_blocks.len();
         if removed == 0 {
             return 0;
         }
 
-        let mut cache = self.inner.write().await;
         for block in removed_blocks.into_values() {
             for tx_hash in &block.tx_hashes {
                 cache.by_tx_hash.remove(tx_hash);

--- a/proof-gen-api-server/src/services/continuity_service/merkle_cache.rs
+++ b/proof-gen-api-server/src/services/continuity_service/merkle_cache.rs
@@ -1,0 +1,312 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::Arc;
+
+use merkle::keccak_merkle_tree::KeccakMerkleTree;
+use sp_core::H256;
+use tokio::sync::RwLock;
+
+use super::MerkleProofItem;
+
+#[derive(Debug)]
+struct CachedMerkleBlock {
+    header_number: u64,
+    tx_hashes: Vec<H256>,
+    tx_bytes: Vec<Vec<u8>>,
+    tree: KeccakMerkleTree,
+}
+
+impl CachedMerkleBlock {
+    fn new(header_number: u64, txs: Vec<(H256, Vec<u8>)>) -> Self {
+        let (tx_hashes, tx_bytes): (Vec<_>, Vec<_>) = txs.into_iter().unzip();
+        let tree = KeccakMerkleTree::new(&tx_bytes);
+
+        Self {
+            header_number,
+            tx_hashes,
+            tx_bytes,
+            tree,
+        }
+    }
+
+    fn proof_item(&self, chain_key: u64, tx_index: usize) -> Option<MerkleProofItem> {
+        let tx_hash = *self.tx_hashes.get(tx_index)?;
+        let tx_bytes = self.tx_bytes.get(tx_index)?.clone();
+        let merkle_proof = self.tree.generate_proof(tx_index).ok()?;
+
+        Some(MerkleProofItem {
+            chain_key,
+            header_number: self.header_number,
+            tx_index: Some(tx_index as u64),
+            tx_hash: Some(tx_hash),
+            tx_bytes: Some(tx_bytes),
+            merkle_root: merkle_proof.root,
+            merkle_proof,
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+struct ChainMerkleCache {
+    by_block: BTreeMap<u64, Arc<CachedMerkleBlock>>,
+    by_tx_hash: HashMap<H256, (u64, usize)>,
+    processed_blocks: BTreeSet<u64>,
+}
+
+/// In-memory cache of finalized source-chain merkle data.
+///
+/// Stores one reusable merkle tree per processed block and a tx-hash index into
+/// those blocks. This avoids storing every per-transaction proof while making a
+/// tx-hash cache hit cheap to serve.
+#[derive(Debug, Default)]
+pub struct MerkleProofCache {
+    inner: RwLock<ChainMerkleCache>,
+}
+
+impl MerkleProofCache {
+    pub async fn get_by_tx_hash(&self, chain_key: u64, tx_hash: H256) -> Option<MerkleProofItem> {
+        let cache = self.inner.read().await;
+        let (header_number, tx_index) = *cache.by_tx_hash.get(&tx_hash)?;
+        let block = cache.by_block.get(&header_number)?;
+        block.proof_item(chain_key, tx_index)
+    }
+
+    pub async fn get_by_block_index(
+        &self,
+        chain_key: u64,
+        header_number: u64,
+        tx_index: u64,
+    ) -> Option<MerkleProofItem> {
+        let cache = self.inner.read().await;
+        let block = cache.by_block.get(&header_number)?;
+        block.proof_item(chain_key, tx_index as usize)
+    }
+
+    pub async fn insert_block(&self, header_number: u64, txs: Vec<(H256, Vec<u8>)>) -> usize {
+        let block = Arc::new(CachedMerkleBlock::new(header_number, txs));
+        let tx_count = block.tx_hashes.len();
+
+        self.insert_cached_block(header_number, block).await;
+
+        tx_count
+    }
+
+    pub async fn insert_block_and_get(
+        &self,
+        chain_key: u64,
+        header_number: u64,
+        txs: Vec<(H256, Vec<u8>)>,
+        tx_index: u64,
+    ) -> (usize, Option<MerkleProofItem>) {
+        let block = Arc::new(CachedMerkleBlock::new(header_number, txs));
+        let tx_count = block.tx_hashes.len();
+        let item = block.proof_item(chain_key, tx_index as usize);
+
+        self.insert_cached_block(header_number, block).await;
+
+        (tx_count, item)
+    }
+
+    async fn insert_cached_block(&self, header_number: u64, block: Arc<CachedMerkleBlock>) {
+        let mut cache = self.inner.write().await;
+        if let Some(old) = cache.by_block.remove(&header_number) {
+            for tx_hash in &old.tx_hashes {
+                cache.by_tx_hash.remove(tx_hash);
+            }
+        }
+
+        for (tx_index, tx_hash) in block.tx_hashes.iter().copied().enumerate() {
+            cache.by_tx_hash.insert(tx_hash, (header_number, tx_index));
+        }
+        cache.processed_blocks.insert(header_number);
+        cache.by_block.insert(header_number, block);
+    }
+
+    pub async fn mark_processed_empty(&self, header_number: u64) {
+        self.inner
+            .write()
+            .await
+            .processed_blocks
+            .insert(header_number);
+    }
+
+    pub async fn is_processed(&self, header_number: u64) -> bool {
+        self.inner
+            .read()
+            .await
+            .processed_blocks
+            .contains(&header_number)
+    }
+
+    pub async fn next_unprocessed_height(&self, start: u64, end: u64) -> Option<u64> {
+        let cache = self.inner.read().await;
+        (start..=end).find(|height| !cache.processed_blocks.contains(height))
+    }
+
+    pub async fn next_unprocessed_height_desc(&self, start: u64, end: u64) -> Option<u64> {
+        let cache = self.inner.read().await;
+        (start..=end)
+            .rev()
+            .find(|height| !cache.processed_blocks.contains(height))
+    }
+
+    pub async fn unprocessed_heights_desc(&self, start: u64, end: u64, limit: usize) -> Vec<u64> {
+        let cache = self.inner.read().await;
+        (start..=end)
+            .rev()
+            .filter(|height| !cache.processed_blocks.contains(height))
+            .take(limit)
+            .collect()
+    }
+
+    pub async fn prune_below(&self, min_height: u64) -> usize {
+        let mut cache = self.inner.write().await;
+        let kept_blocks = cache.by_block.split_off(&min_height);
+        let removed_blocks = std::mem::replace(&mut cache.by_block, kept_blocks);
+
+        let kept_processed = cache.processed_blocks.split_off(&min_height);
+        cache.processed_blocks = kept_processed;
+
+        let removed = removed_blocks.len();
+        for block in removed_blocks.into_values() {
+            for tx_hash in &block.tx_hashes {
+                cache.by_tx_hash.remove(tx_hash);
+            }
+        }
+
+        removed
+    }
+
+    pub async fn prune_above(&self, max_height: u64) -> usize {
+        let split_key = max_height.saturating_add(1);
+        let removed_blocks = {
+            let mut cache = self.inner.write().await;
+            let removed_blocks = cache.by_block.split_off(&split_key);
+            cache.processed_blocks.split_off(&split_key);
+            removed_blocks
+        };
+
+        let removed = removed_blocks.len();
+        if removed == 0 {
+            return 0;
+        }
+
+        let mut cache = self.inner.write().await;
+        for block in removed_blocks.into_values() {
+            for tx_hash in &block.tx_hashes {
+                cache.by_tx_hash.remove(tx_hash);
+            }
+        }
+
+        removed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tx(n: u64) -> (H256, Vec<u8>) {
+        (H256::from_low_u64_be(n), vec![n as u8])
+    }
+
+    #[tokio::test]
+    async fn lookup_returns_proof_for_cached_tx() {
+        let cache = MerkleProofCache::default();
+        cache.insert_block(100, vec![tx(1), tx(2), tx(3)]).await;
+
+        let item = cache
+            .get_by_tx_hash(7, H256::from_low_u64_be(2))
+            .await
+            .expect("tx should be cached");
+
+        assert_eq!(item.chain_key, 7);
+        assert_eq!(item.header_number, 100);
+        assert_eq!(item.tx_index, Some(1));
+        assert_eq!(item.tx_hash, Some(H256::from_low_u64_be(2)));
+        assert_eq!(item.tx_bytes, Some(vec![2]));
+        assert!(item
+            .merkle_proof
+            .verify(item.tx_bytes.as_deref().expect("tx bytes cached")));
+    }
+
+    #[tokio::test]
+    async fn lookup_by_block_index_returns_proof_for_cached_tx() {
+        let cache = MerkleProofCache::default();
+        cache.insert_block(100, vec![tx(1), tx(2), tx(3)]).await;
+
+        let item = cache
+            .get_by_block_index(7, 100, 2)
+            .await
+            .expect("tx index should be cached");
+
+        assert_eq!(item.chain_key, 7);
+        assert_eq!(item.header_number, 100);
+        assert_eq!(item.tx_index, Some(2));
+        assert_eq!(item.tx_hash, Some(H256::from_low_u64_be(3)));
+        assert_eq!(item.tx_bytes, Some(vec![3]));
+    }
+
+    #[tokio::test]
+    async fn prune_below_removes_tx_index_and_processed_blocks() {
+        let cache = MerkleProofCache::default();
+        cache.insert_block(100, vec![tx(1)]).await;
+        cache.insert_block(200, vec![tx(2)]).await;
+
+        assert_eq!(cache.prune_below(150).await, 1);
+
+        assert!(cache
+            .get_by_tx_hash(7, H256::from_low_u64_be(1))
+            .await
+            .is_none());
+        assert!(cache
+            .get_by_tx_hash(7, H256::from_low_u64_be(2))
+            .await
+            .is_some());
+        assert!(!cache.is_processed(100).await);
+        assert!(cache.is_processed(200).await);
+    }
+
+    #[tokio::test]
+    async fn prune_above_removes_reverted_blocks() {
+        let cache = MerkleProofCache::default();
+        cache.insert_block(100, vec![tx(1)]).await;
+        cache.insert_block(200, vec![tx(2)]).await;
+
+        assert_eq!(cache.prune_above(150).await, 1);
+
+        assert!(cache
+            .get_by_tx_hash(7, H256::from_low_u64_be(1))
+            .await
+            .is_some());
+        assert!(cache
+            .get_by_tx_hash(7, H256::from_low_u64_be(2))
+            .await
+            .is_none());
+        assert!(cache.is_processed(100).await);
+        assert!(!cache.is_processed(200).await);
+    }
+
+    #[tokio::test]
+    async fn next_unprocessed_height_desc_prefers_newest_missing_block() {
+        let cache = MerkleProofCache::default();
+        cache.mark_processed_empty(10).await;
+        cache.mark_processed_empty(12).await;
+
+        assert_eq!(cache.next_unprocessed_height_desc(10, 12).await, Some(11));
+
+        cache.mark_processed_empty(11).await;
+        assert_eq!(cache.next_unprocessed_height_desc(10, 12).await, None);
+    }
+
+    #[tokio::test]
+    async fn unprocessed_heights_desc_returns_newest_missing_blocks() {
+        let cache = MerkleProofCache::default();
+        cache.mark_processed_empty(11).await;
+        cache.mark_processed_empty(14).await;
+
+        assert_eq!(
+            cache.unprocessed_heights_desc(10, 14, 3).await,
+            vec![13, 12, 10]
+        );
+    }
+}

--- a/proof-gen-api-server/src/services/continuity_service/merkle_cache.rs
+++ b/proof-gen-api-server/src/services/continuity_service/merkle_cache.rs
@@ -132,11 +132,13 @@ impl MerkleProofCache {
     }
 
     pub async fn mark_processed_empty(&self, header_number: u64) {
-        self.inner
-            .write()
-            .await
-            .processed_blocks
-            .insert(header_number);
+        let mut cache = self.inner.write().await;
+        if let Some(old) = cache.by_block.remove(&header_number) {
+            for tx_hash in &old.tx_hashes {
+                cache.by_tx_hash.remove(tx_hash);
+            }
+        }
+        cache.processed_blocks.insert(header_number);
     }
 
     pub async fn is_processed(&self, header_number: u64) -> bool {
@@ -296,6 +298,21 @@ mod tests {
             .is_none());
         assert!(cache.is_processed(100).await);
         assert!(!cache.is_processed(200).await);
+    }
+
+    #[tokio::test]
+    async fn mark_processed_empty_removes_stale_cached_block() {
+        let cache = MerkleProofCache::default();
+        cache.insert_block(100, vec![tx(1), tx(2)]).await.unwrap();
+
+        cache.mark_processed_empty(100).await;
+
+        assert!(cache
+            .get_by_tx_hash(7, H256::from_low_u64_be(1))
+            .await
+            .is_none());
+        assert!(cache.get_by_block_index(7, 100, 0).await.is_none());
+        assert!(cache.is_processed(100).await);
     }
 
     #[tokio::test]

--- a/proof-gen-api-server/src/services/continuity_service/merkle_cache.rs
+++ b/proof-gen-api-server/src/services/continuity_service/merkle_cache.rs
@@ -28,6 +28,12 @@ impl CachedMerkleBlock {
         }
     }
 
+    async fn build(header_number: u64, txs: Vec<(H256, Vec<u8>)>) -> Result<Self, String> {
+        tokio::task::spawn_blocking(move || Self::new(header_number, txs))
+            .await
+            .map_err(|err| format!("merkle cache build task panicked: {err}"))
+    }
+
     fn proof_item(&self, chain_key: u64, tx_index: usize) -> Option<MerkleProofItem> {
         let tx_hash = *self.tx_hashes.get(tx_index)?;
         let tx_bytes = self.tx_bytes.get(tx_index)?.clone();
@@ -81,13 +87,17 @@ impl MerkleProofCache {
         block.proof_item(chain_key, tx_index as usize)
     }
 
-    pub async fn insert_block(&self, header_number: u64, txs: Vec<(H256, Vec<u8>)>) -> usize {
-        let block = Arc::new(CachedMerkleBlock::new(header_number, txs));
+    pub async fn insert_block(
+        &self,
+        header_number: u64,
+        txs: Vec<(H256, Vec<u8>)>,
+    ) -> Result<usize, String> {
+        let block = Arc::new(CachedMerkleBlock::build(header_number, txs).await?);
         let tx_count = block.tx_hashes.len();
 
         self.insert_cached_block(header_number, block).await;
 
-        tx_count
+        Ok(tx_count)
     }
 
     pub async fn insert_block_and_get(
@@ -96,14 +106,14 @@ impl MerkleProofCache {
         header_number: u64,
         txs: Vec<(H256, Vec<u8>)>,
         tx_index: u64,
-    ) -> (usize, Option<MerkleProofItem>) {
-        let block = Arc::new(CachedMerkleBlock::new(header_number, txs));
+    ) -> Result<(usize, Option<MerkleProofItem>), String> {
+        let block = Arc::new(CachedMerkleBlock::build(header_number, txs).await?);
         let tx_count = block.tx_hashes.len();
         let item = block.proof_item(chain_key, tx_index as usize);
 
         self.insert_cached_block(header_number, block).await;
 
-        (tx_count, item)
+        Ok((tx_count, item))
     }
 
     async fn insert_cached_block(&self, header_number: u64, block: Arc<CachedMerkleBlock>) {
@@ -208,7 +218,10 @@ mod tests {
     #[tokio::test]
     async fn lookup_returns_proof_for_cached_tx() {
         let cache = MerkleProofCache::default();
-        cache.insert_block(100, vec![tx(1), tx(2), tx(3)]).await;
+        cache
+            .insert_block(100, vec![tx(1), tx(2), tx(3)])
+            .await
+            .unwrap();
 
         let item = cache
             .get_by_tx_hash(7, H256::from_low_u64_be(2))
@@ -228,7 +241,10 @@ mod tests {
     #[tokio::test]
     async fn lookup_by_block_index_returns_proof_for_cached_tx() {
         let cache = MerkleProofCache::default();
-        cache.insert_block(100, vec![tx(1), tx(2), tx(3)]).await;
+        cache
+            .insert_block(100, vec![tx(1), tx(2), tx(3)])
+            .await
+            .unwrap();
 
         let item = cache
             .get_by_block_index(7, 100, 2)
@@ -245,8 +261,8 @@ mod tests {
     #[tokio::test]
     async fn prune_below_removes_tx_index_and_processed_blocks() {
         let cache = MerkleProofCache::default();
-        cache.insert_block(100, vec![tx(1)]).await;
-        cache.insert_block(200, vec![tx(2)]).await;
+        cache.insert_block(100, vec![tx(1)]).await.unwrap();
+        cache.insert_block(200, vec![tx(2)]).await.unwrap();
 
         assert_eq!(cache.prune_below(150).await, 1);
 
@@ -265,8 +281,8 @@ mod tests {
     #[tokio::test]
     async fn prune_above_removes_reverted_blocks() {
         let cache = MerkleProofCache::default();
-        cache.insert_block(100, vec![tx(1)]).await;
-        cache.insert_block(200, vec![tx(2)]).await;
+        cache.insert_block(100, vec![tx(1)]).await.unwrap();
+        cache.insert_block(200, vec![tx(2)]).await.unwrap();
 
         assert_eq!(cache.prune_above(150).await, 1);
 

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -8,21 +8,24 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
 };
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::prom::Metrics;
 use crate::services::continuity_service::helpers::*;
 use attestor_primitives::block::ContinuityProof;
 use continuity::ContinuityBuilder;
 use merkle::proof::TransactionMerkleProof;
+use merkle_cache::MerkleProofCache;
 
 pub mod helpers;
+mod merkle_cache;
 
 /// Per-source-chain state: ETH-backed builder and CC3-derived caches.
 pub struct ChainState {
     pub builder: Arc<ContinuityBuilder>,
     pub checkpoint_cache: tokio::sync::RwLock<BTreeMap<u64, H256>>,
     pub attestation_cache: tokio::sync::RwLock<BTreeMap<u64, H256>>,
+    pub merkle_proof_cache: MerkleProofCache,
     pub attestation_genesis_block: AtomicU64,
 }
 
@@ -161,6 +164,11 @@ pub struct ContinuityService {
     max_batch_span: u64,
 }
 
+const MERKLE_BACKFILL_POLL_INTERVAL: Duration = Duration::from_secs(15);
+const MERKLE_BACKFILL_MAX_BLOCKS_PER_TICK: usize = 50;
+const MERKLE_BACKFILL_MAX_CONCURRENCY: usize = 8;
+const MERKLE_PROOF_CACHE_CHECKPOINT_RETENTION_MULTIPLIER: u64 = 4;
+
 impl ContinuityService {
     /// Create a new ContinuityService, fetching the attestation genesis block from the chain.
     ///
@@ -267,6 +275,7 @@ impl ContinuityService {
                     builder,
                     checkpoint_cache: tokio::sync::RwLock::new(checkpoint_map),
                     attestation_cache: tokio::sync::RwLock::new(attestation_map),
+                    merkle_proof_cache: MerkleProofCache::default(),
                     attestation_genesis_block: AtomicU64::new(attestation_genesis_block),
                 }),
             );
@@ -293,6 +302,215 @@ impl ContinuityService {
 
     pub(crate) fn configured_chain_keys(&self) -> std::collections::HashSet<u64> {
         self.chains.keys().copied().collect()
+    }
+
+    pub fn spawn_merkle_backfill(service: Arc<Self>) {
+        for chain in service.chains.values().cloned().collect::<Vec<_>>() {
+            let service = service.clone();
+            tokio::spawn(async move {
+                tracing::info!(
+                    chain_key = chain.builder.config.chain_key,
+                    poll_interval_secs = MERKLE_BACKFILL_POLL_INTERVAL.as_secs(),
+                    max_blocks_per_tick = MERKLE_BACKFILL_MAX_BLOCKS_PER_TICK,
+                    max_concurrency = MERKLE_BACKFILL_MAX_CONCURRENCY,
+                    "merkle proof cache backfill worker started"
+                );
+                loop {
+                    if let Err(err) = service.backfill_merkle_cache_for_chain(chain.clone()).await {
+                        tracing::warn!(
+                            chain_key = chain.builder.config.chain_key,
+                            error = %err,
+                            "merkle proof cache backfill tick failed"
+                        );
+                    }
+                    tokio::time::sleep(MERKLE_BACKFILL_POLL_INTERVAL).await;
+                }
+            });
+        }
+    }
+
+    async fn backfill_merkle_cache_for_chain(&self, chain: Arc<ChainState>) -> anyhow::Result<()> {
+        let chain_key = chain.builder.config.chain_key;
+        let (_, confirmed_tip) = chain.builder.get_confirmed_last_block().await?;
+        let Some(latest_attested_height) = Self::cached_attested_height(chain.as_ref()).await
+        else {
+            tracing::info!(
+                chain_key,
+                confirmed_tip,
+                "merkle proof cache backfill waiting for attested height"
+            );
+            return Ok(());
+        };
+        let cache_tip = latest_attested_height.min(confirmed_tip);
+        let retention_blocks = self.merkle_cache_retention_blocks(chain.as_ref());
+        let genesis = chain.attestation_genesis_block.load(Ordering::Relaxed);
+        let start = cache_tip.saturating_sub(retention_blocks).max(genesis);
+
+        if start > cache_tip {
+            return Ok(());
+        }
+
+        let heights = chain
+            .merkle_proof_cache
+            .unprocessed_heights_desc(start, cache_tip, MERKLE_BACKFILL_MAX_BLOCKS_PER_TICK)
+            .await;
+        if heights.is_empty() {
+            tracing::info!(
+                chain_key,
+                confirmed_tip,
+                latest_attested_height,
+                cache_tip,
+                retained_from = start,
+                retention_blocks,
+                "merkle proof cache backfill already warm for retained range"
+            );
+            return Ok(());
+        }
+
+        use futures::StreamExt as _;
+
+        let concurrency = self
+            .max_batch_size
+            .clamp(1, MERKLE_BACKFILL_MAX_CONCURRENCY);
+        let results = futures::stream::iter(heights.into_iter().map(|height| {
+            let chain = chain.clone();
+            async move {
+                let result = self.precompute_merkle_cache_block(&chain, height).await;
+                (height, result)
+            }
+        }))
+        .buffer_unordered(concurrency)
+        .collect::<Vec<_>>()
+        .await;
+
+        let mut cached_blocks = 0usize;
+        let mut cached_txs = 0usize;
+        let mut failed_blocks = 0usize;
+        let mut min_height = u64::MAX;
+        let mut max_height = 0u64;
+
+        for (height, result) in results {
+            min_height = min_height.min(height);
+            max_height = max_height.max(height);
+            match result {
+                Ok(tx_count) => {
+                    cached_blocks += 1;
+                    cached_txs += tx_count;
+                    tracing::debug!(
+                        chain_key,
+                        height,
+                        tx_count,
+                        "merkle proof cache backfilled source block"
+                    );
+                }
+                Err(err) => {
+                    failed_blocks += 1;
+                    tracing::warn!(
+                        chain_key,
+                        height,
+                        error = %err,
+                        "failed to backfill merkle proof cache block"
+                    );
+                }
+            }
+        }
+
+        tracing::info!(
+            chain_key,
+            confirmed_tip,
+            latest_attested_height,
+            cache_tip,
+            retained_from = start,
+            min_height,
+            max_height,
+            cached_blocks,
+            cached_txs,
+            failed_blocks,
+            "merkle proof cache backfill tick completed"
+        );
+
+        let min_retained = cache_tip.saturating_sub(retention_blocks).max(genesis);
+        let removed = chain.merkle_proof_cache.prune_below(min_retained).await;
+        if removed > 0 {
+            tracing::info!(
+                chain_key,
+                min_retained,
+                removed,
+                "pruned old merkle proof cache blocks after backfill"
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn precompute_merkle_cache_block(
+        &self,
+        chain: &Arc<ChainState>,
+        header_number: u64,
+    ) -> ServiceResult<usize> {
+        let txs = chain
+            .builder
+            .get_block_tx_data(header_number)
+            .await
+            .map_err(|err| map_eth_rpc_anyhow_to_service_error(err, header_number))?;
+
+        if txs.is_empty() {
+            chain
+                .merkle_proof_cache
+                .mark_processed_empty(header_number)
+                .await;
+            return Ok(0);
+        }
+
+        Ok(chain
+            .merkle_proof_cache
+            .insert_block(header_number, txs)
+            .await)
+    }
+
+    async fn precompute_merkle_cache_block_for_tx(
+        &self,
+        chain: &Arc<ChainState>,
+        header_number: u64,
+        tx_index: u64,
+    ) -> ServiceResult<Option<MerkleProofItem>> {
+        let txs = chain
+            .builder
+            .get_block_tx_data(header_number)
+            .await
+            .map_err(|err| map_eth_rpc_anyhow_to_service_error(err, header_number))?;
+
+        if txs.is_empty() {
+            chain
+                .merkle_proof_cache
+                .mark_processed_empty(header_number)
+                .await;
+            return Ok(None);
+        }
+
+        let (tx_count, item) = chain
+            .merkle_proof_cache
+            .insert_block_and_get(chain.builder.config.chain_key, header_number, txs, tx_index)
+            .await;
+
+        tracing::info!(
+            chain_key = chain.builder.config.chain_key,
+            header_number,
+            tx_index,
+            tx_count,
+            cache_hit = item.is_some(),
+            "merkle proof cache on-demand fill completed"
+        );
+
+        Ok(item)
+    }
+
+    fn merkle_cache_retention_blocks(&self, chain: &ChainState) -> u64 {
+        chain
+            .builder
+            .config
+            .checkpoint_block_interval()
+            .saturating_mul(MERKLE_PROOF_CACHE_CHECKPOINT_RETENTION_MULTIPLIER)
     }
 
     /// Update the continuity builder's last-checkpoint hint (from on-chain events).
@@ -482,6 +700,16 @@ impl ContinuityService {
                 );
             }
 
+            let removed_merkle = chain.merkle_proof_cache.prune_above(revert_height).await;
+            if removed_merkle > 0 {
+                tracing::info!(
+                    chain_key,
+                    revert_height,
+                    removed = removed_merkle,
+                    "🔧 ↩️  Reverted merkle proof cache"
+                );
+            }
+
             // Reset the builder's last-checkpoint hint so that
             // determine_checkpoint_info does not skip checks based on stale state.
             chain.builder.reset_last_checkpoint_block().await;
@@ -558,6 +786,19 @@ impl ContinuityService {
                 chain_key,
                 Self::cached_checkpoint_height(chain.as_ref()).await,
             );
+
+            let retention_blocks = self.merkle_cache_retention_blocks(chain.as_ref());
+            let min_retained = block_number.saturating_sub(retention_blocks);
+            let removed = chain.merkle_proof_cache.prune_below(min_retained).await;
+            if removed > 0 {
+                tracing::debug!(
+                    chain_key,
+                    block_number,
+                    min_retained,
+                    removed,
+                    "🔧 🧹 pruned merkle proof cache after checkpoint"
+                );
+            }
         }
     }
 
@@ -855,6 +1096,56 @@ impl ContinuityService {
         })
     }
 
+    async fn get_proof_with_cached_merkle(
+        &self,
+        chain: &Arc<ChainState>,
+        merkle: MerkleProofItem,
+    ) -> ServiceResult<SingleContinuityResponse> {
+        if merkle.tx_index.is_none() {
+            return Err(ServiceError::Internal {
+                message: "cached merkle proof missing tx_index".to_string(),
+            });
+        }
+        let header_number = merkle.header_number;
+        let chain_key = chain.builder.config.chain_key;
+
+        self.validate_blocks(chain, &[header_number]).await?;
+        self.metrics.observe_block_range(header_number);
+
+        let headers = [header_number];
+        let continuity_proof = self.get_continuity_proof_for(chain, &headers).await?;
+
+        Ok(Self::single_response_from_merkle(
+            chain_key,
+            continuity_proof,
+            merkle,
+            true,
+        ))
+    }
+
+    fn single_response_from_merkle(
+        chain_key: u64,
+        continuity_proof: ContinuityProof,
+        merkle: MerkleProofItem,
+        cached: bool,
+    ) -> SingleContinuityResponse {
+        let tx_index = merkle.tx_index.unwrap_or_default();
+        let tx_hash = merkle.tx_hash.map(|h| format!("0x{h:x}"));
+        let tx_bytes = merkle.tx_bytes.map(|b| format!("0x{}", hex::encode(&b)));
+
+        SingleContinuityResponse {
+            chain_key,
+            header_number: merkle.header_number,
+            tx_index,
+            tx_hash,
+            tx_bytes,
+            continuity_proof,
+            merkle_proof: merkle.merkle_proof,
+            cached,
+            generated_at: Utc::now(),
+        }
+    }
+
     /// Get batch of proofs for a list of blocks, optionally including merkle proof for specific transactions.
     ///
     /// `queries` is guaranteed to be non-empty and ordered both per header and per transaction index, so we can safely unwrap when building the response.
@@ -971,11 +1262,91 @@ impl ContinuityService {
         tx_hash: String,
     ) -> ServiceResult<SingleContinuityResponse> {
         let tx_h256 = parse_tx_hash(&tx_hash)?;
+
+        if let Some(merkle) = chain
+            .merkle_proof_cache
+            .get_by_tx_hash(chain.builder.config.chain_key, tx_h256)
+            .await
+        {
+            tracing::info!(
+                chain_key = chain.builder.config.chain_key,
+                tx_hash = ?tx_h256,
+                header_number = merkle.header_number,
+                tx_index = ?merkle.tx_index,
+                "merkle proof cache hit by tx hash"
+            );
+            let response = self.get_proof_with_cached_merkle(chain, merkle).await?;
+            return match &response.tx_hash {
+                Some(computed_hash) if parse_tx_hash(computed_hash)? == tx_h256 => Ok(response),
+                Some(computed_hash) => Err(ServiceError::TxHashNotFound {
+                    tx_hash: format!(
+                        "Cached transaction hash mismatch: requested 0x{tx_h256:x}, found {computed_hash} at block {} index {}",
+                        response.header_number, response.tx_index
+                    ),
+                }),
+                None => Err(ServiceError::Internal {
+                    message: format!(
+                        "tx_hash missing from cached proof. tx_hash: {tx_h256:x}"
+                    ),
+                }),
+            };
+        }
+
         let (header_number, tx_index) = self
             .get_height_and_index_for_tx_hash(chain, tx_h256)
             .await?;
 
-        let response = self.get_proof(chain, header_number, tx_index).await?;
+        let headers = [header_number];
+        self.validate_blocks(chain, &headers).await?;
+        self.metrics.observe_block_range(header_number);
+
+        let (continuity_proof, on_demand_merkle) = tokio::try_join!(
+            self.get_continuity_proof_for(chain, &headers),
+            self.precompute_merkle_cache_block_for_tx(chain, header_number, tx_index),
+        )?;
+
+        let cached_merkle = if on_demand_merkle.is_some() {
+            on_demand_merkle
+        } else if let Some(merkle) = chain
+            .merkle_proof_cache
+            .get_by_tx_hash(chain.builder.config.chain_key, tx_h256)
+            .await
+        {
+            Some(merkle)
+        } else {
+            chain
+                .merkle_proof_cache
+                .get_by_block_index(chain.builder.config.chain_key, header_number, tx_index)
+                .await
+        };
+
+        tracing::info!(
+            chain_key = chain.builder.config.chain_key,
+            header_number,
+            tx_index,
+            tx_hash = ?tx_h256,
+            cache_hit = cached_merkle.is_some(),
+            "resolved proof-by-tx merkle cache after on-demand precompute"
+        );
+
+        let response = if let Some(merkle) = cached_merkle {
+            Self::single_response_from_merkle(
+                chain.builder.config.chain_key,
+                continuity_proof,
+                merkle,
+                true,
+            )
+        } else {
+            let merkle = self
+                .generate_merkle_proof(chain, header_number, tx_index)
+                .await?;
+            Self::single_response_from_merkle(
+                chain.builder.config.chain_key,
+                continuity_proof,
+                merkle,
+                false,
+            )
+        };
 
         // Verify tx_hash matches
         match &response.tx_hash {

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -27,6 +27,7 @@ pub struct ChainState {
     pub attestation_cache: tokio::sync::RwLock<BTreeMap<u64, H256>>,
     pub merkle_proof_cache: MerkleProofCache,
     pub attestation_genesis_block: AtomicU64,
+    pub checkpoint_interval: AtomicU64,
 }
 
 // Single block proof query object, used in batch requests to specify which transactions to include merkle proofs for. If a block is included in the batch but not listed in the tx_indexes, it will be processed with tx_index = None (continuity proof only)
@@ -268,6 +269,7 @@ impl ContinuityService {
             );
             let latest_attested_height = attestation_map.keys().next_back().copied();
             metrics.set_last_attested_height(chain_key, latest_attested_height);
+            let checkpoint_interval = builder.config.checkpoint_interval;
 
             chains.insert(
                 chain_key,
@@ -277,6 +279,7 @@ impl ContinuityService {
                     attestation_cache: tokio::sync::RwLock::new(attestation_map),
                     merkle_proof_cache: MerkleProofCache::default(),
                     attestation_genesis_block: AtomicU64::new(attestation_genesis_block),
+                    checkpoint_interval: AtomicU64::new(checkpoint_interval),
                 }),
             );
         }
@@ -462,10 +465,11 @@ impl ContinuityService {
             return Ok(0);
         }
 
-        Ok(chain
+        chain
             .merkle_proof_cache
             .insert_block(header_number, txs)
-            .await)
+            .await
+            .map_err(|message| ServiceError::MerkleError { message })
     }
 
     async fn precompute_merkle_cache_block_for_tx(
@@ -491,7 +495,8 @@ impl ContinuityService {
         let (tx_count, item) = chain
             .merkle_proof_cache
             .insert_block_and_get(chain.builder.config.chain_key, header_number, txs, tx_index)
-            .await;
+            .await
+            .map_err(|message| ServiceError::MerkleError { message })?;
 
         tracing::info!(
             chain_key = chain.builder.config.chain_key,
@@ -506,10 +511,12 @@ impl ContinuityService {
     }
 
     fn merkle_cache_retention_blocks(&self, chain: &ChainState) -> u64 {
+        let checkpoint_interval = chain.checkpoint_interval.load(Ordering::Relaxed);
         chain
             .builder
             .config
-            .checkpoint_block_interval()
+            .attestation_interval
+            .saturating_mul(checkpoint_interval)
             .saturating_mul(MERKLE_PROOF_CACHE_CHECKPOINT_RETENTION_MULTIPLIER)
     }
 
@@ -520,6 +527,15 @@ impl ContinuityService {
                 .builder
                 .update_last_checkpoint_block(block_number)
                 .await;
+        }
+    }
+
+    /// Update the checkpoint interval used by merkle-cache retention sizing.
+    pub fn update_checkpoint_interval(&self, chain_key: u64, checkpoint_interval: u64) {
+        if let Some(chain) = self.chains.get(&chain_key) {
+            chain
+                .checkpoint_interval
+                .store(checkpoint_interval, Ordering::Relaxed);
         }
     }
 

--- a/query-cli/Cargo.toml
+++ b/query-cli/Cargo.toml
@@ -16,7 +16,7 @@ futures = { workspace = true }
 hex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
-stream = { workspace = true, default-features = false, features = ["cc3"] }
+stream = { workspace = true, features = ["cc3"] }
 tokio = { workspace = true, features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
## Summary

Adds an in-memory merkle proof cache to proof-gen so repeated or pre-warmed `proof-by-tx` requests can skip the expensive source-chain block/receipt fetch and merkle tree build.

- Caches finalized source-chain merkle data per chain, indexed by tx hash and block/tx index.
- Starts a background backfill worker that warms blocks around the latest CC3-attested source height.
- Bounds the warm window to the latest proofable block: `min(latest_attested_height, confirmed_evm_tip)`.
- Keeps roughly 4 checkpoint intervals of source blocks warm and prunes older cached blocks as the attested head advances.
- Handles checkpoint/revert events by pruning the merkle cache alongside existing attestation/checkpoint caches.
- Adds on-demand fill for cache misses so the first request populates the cache and later requests can hit it.
- Adds `info` logs for backfill progress, warm-window status, cache hits, on-demand fills, and pruning.

## Benchmarks / behavior

Observed warm-cache hit:

- Request had `merkle proof cache hit by tx hash`
- Returned `cached=true`
- Latency dropped to around `250-500ms`
- Remaining latency was mostly continuity proof / archiver `/roots` work

Observed first on-demand fill:

- Returned `cached=true` after filling the block during the request
- Still paid the expensive block/receipt fetch + merkle tree build
- Subsequent request for the same tx hit the cache

## Notes

This is an in-memory L1 cache. It improves warm hits within a running prover process, but it does not persist across restarts or share cache state across replicas. A shared Redis/L2 cache could be added later if we want fleet-wide prewarming and persistence.

## Validation

- `cargo test -p proof-gen-api-server continuity_service --lib`
- `cargo clippy -p proof-gen-api-server --all-targets`
- `cargo fmt`
- `git diff --check`