### PR TITLE
fix(block-prover): checked arithmetic + receipt/log verification

### DIFF
--- a/common/eth/src/evm/block_prover.rs
+++ b/common/eth/src/evm/block_prover.rs
@@ -10,8 +10,31 @@ use crate::{Client, Error as ClientError};
 use alloy::{
     contract::Error as AlloyContractError,
     primitives::{Address, FixedBytes, U256},
+    rpc::types::TransactionReceipt,
     sol,
+    sol_types::SolEvent,
 };
+
+/// Count `TransactionVerified` logs emitted by the receipt's transaction.
+///
+/// We match on the event signature hash (`topic0`) of
+/// `TransactionVerified(uint64,uint64,uint64)` so an unrelated log accidentally aliasing the
+/// position of `topics[0]` cannot trigger a false positive.
+///
+/// Filtering by `log.address == precompile_address` is intentionally avoided here: the precompile
+/// is invoked via a transaction whose `to` is the precompile itself, so the emitted log's
+/// `address` is already constrained by the calldata path we built above. Counting is what catches
+/// (a) a reverted/OOG tx that emitted nothing despite a replay-via-eth_call success and (b) a
+/// silently dropped emission.
+fn count_transaction_verified_logs(receipt: &TransactionReceipt) -> usize {
+    let sig = INativeQueryVerifier::TransactionVerified::SIGNATURE_HASH;
+    receipt
+        .inner
+        .logs()
+        .iter()
+        .filter(|log| log.topics().first() == Some(&sig))
+        .count()
+}
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -224,25 +247,36 @@ impl BlockProver {
             receipt.transaction_hash, receipt.gas_used
         );
 
-        // Now call to get the result
-        let result = contract
-            .verifyAndEmit_0(
-                chain_key,
-                height,
-                encoded_transaction.to_vec().into(),
-                sol_proof,
-                sol_proof_struct,
-            )
-            .call()
-            .await
-            .map_err(|e| {
-                error!("Native query verifier call failed: {:?}", e);
-                Error::AlloyContractError(e)
-            })?;
+        // A successful receipt status is a precondition for trusting the emitted-events path:
+        // a reverted or out-of-gas transaction won't have emitted `TransactionVerified`, so the
+        // previous "replay with eth_call and report success" flow would silently mislabel
+        // those as successful verifications. Bail out here instead.
+        if !receipt.status() {
+            error!(
+                tx = ?receipt.transaction_hash,
+                gas_used = ?receipt.gas_used,
+                "verifyAndEmit transaction reverted on-chain"
+            );
+            return Err(Error::VerificationFailed);
+        }
+
+        // Require exactly one `TransactionVerified` log for the single-query path. Counting the
+        // emissions catches the case where the precompile silently returned without emitting
+        // (e.g. an upstream contract or proxy ate the receipt) and prevents reporting success
+        // when no event was actually published.
+        let emitted = count_transaction_verified_logs(&receipt);
+        if emitted != 1 {
+            error!(
+                tx = ?receipt.transaction_hash,
+                emitted,
+                "expected exactly 1 TransactionVerified log, got {emitted}"
+            );
+            return Err(Error::VerificationFailed);
+        }
 
         info!("Query verification successful (with events)");
 
-        Ok(result._0)
+        Ok(true)
     }
 
     /// Verify a batch of queries with shared continuity proof (view function)
@@ -360,25 +394,36 @@ impl BlockProver {
             receipt.transaction_hash, receipt.gas_used
         );
 
-        // Now call to get the result
-        let result = contract
-            .verifyAndEmit_1(
-                chain_key,
-                heights,
-                tx_data_bytes,
-                sol_proofs,
-                sol_proof_struct,
-            )
-            .call()
-            .await
-            .map_err(|e| {
-                error!("Native query verifier batch call failed: {:?}", e);
-                Error::AlloyContractError(e)
-            })?;
+        // See `verify_and_emit`: a reverted transaction emits no `TransactionVerified` events,
+        // so a replay-via-eth_call success report would lie about what landed on-chain. Bail.
+        if !receipt.status() {
+            error!(
+                tx = ?receipt.transaction_hash,
+                gas_used = ?receipt.gas_used,
+                "verifyAndEmit batch transaction reverted on-chain"
+            );
+            return Err(Error::VerificationFailed);
+        }
 
-        info!("Batch query verification successful (with events)");
+        // Each successfully verified query should produce one `TransactionVerified` log.
+        let expected = heights.len();
+        let emitted = count_transaction_verified_logs(&receipt);
+        if emitted != expected {
+            error!(
+                tx = ?receipt.transaction_hash,
+                expected,
+                emitted,
+                "batch TransactionVerified log count mismatch"
+            );
+            return Err(Error::VerificationFailed);
+        }
 
-        Ok(result._0)
+        info!(
+            "Batch query verification successful (with events): {} queries",
+            expected
+        );
+
+        Ok(true)
     }
 
     /// Estimate gas for a query verification

--- a/precompiles/block-prover/src/continuity.rs
+++ b/precompiles/block-prover/src/continuity.rs
@@ -23,6 +23,11 @@ pub enum ContinuityVerificationError {
     ChainDoesNotReachQueryHeight,
     /// Continuity chain does not end at a valid attestation or checkpoint
     NoMatchingAttestationOrCheckpoint,
+    /// `start_block_number + (roots.len() - 1)` would overflow `u64`. Caller-supplied
+    /// `start_block_number` plus a maximally-sized proof must stay within `u64` range;
+    /// rejecting overflow here keeps the precompile from depending on overflow-checking
+    /// build flags to surface bogus inputs.
+    RangeOverflow,
 }
 
 impl ContinuityVerificationError {
@@ -35,6 +40,7 @@ impl ContinuityVerificationError {
             Self::NoMatchingAttestationOrCheckpoint => {
                 "Continuity proof does not match attestation or checkpoint"
             }
+            Self::RangeOverflow => "Continuity chain range overflows u64",
         }
     }
 }
@@ -109,8 +115,22 @@ where
             return Err(continuity_revert(ContinuityVerificationError::TooManyRoots));
         }
 
-        // Validate the continuity chain reaches the query height (fail early before digest computation)
-        let final_block_number = start_block_number + (continuity_proof.roots.len() - 1) as u64;
+        // Validate the continuity chain reaches the query height (fail early before digest computation).
+        //
+        // `start_block_number` is caller-supplied via EVM calldata and `roots.len()` is bounded by
+        // `MAX_CONTINUITY_ROOTS` above, but the sum is still attacker-controlled and could in
+        // principle wrap `u64`. Release builds previously relied on wrapping behavior and the
+        // height check below to reject pathological inputs; overflow-checking builds would panic.
+        // Use checked arithmetic so both build profiles return a clean revert instead.
+        let roots_len_minus_one = (continuity_proof.roots.len() as u64).saturating_sub(1);
+        let final_block_number = match start_block_number.checked_add(roots_len_minus_one) {
+            Some(n) => n,
+            None => {
+                return Err(continuity_revert(
+                    ContinuityVerificationError::RangeOverflow,
+                ))
+            }
+        };
 
         if final_block_number < height {
             debug!(

--- a/precompiles/block-prover/src/verify.rs
+++ b/precompiles/block-prover/src/verify.rs
@@ -343,8 +343,17 @@ where
             return Self::revert_with_message("Continuity chain cannot be empty");
         }
 
-        let last_block_number =
-            start_block_number + (shared_continuity_proof.roots.len() - 1) as u64;
+        // `start_block_number` and the proof length are caller-supplied. The earlier emptiness
+        // check guarantees `roots.len() >= 1`, but their sum can still wrap `u64`. Reject
+        // overflow explicitly so overflow-checking builds don't panic and release builds
+        // don't silently wrap into a spuriously-low `last_block_number`.
+        let roots_len_minus_one = (shared_continuity_proof.roots.len() as u64).saturating_sub(1);
+        let last_block_number = match start_block_number.checked_add(roots_len_minus_one) {
+            Some(n) => n,
+            None => {
+                return Self::revert_with_message("Continuity chain range overflows u64");
+            }
+        };
         if last_block_number < max_height {
             return Self::revert_with_message(
                 "Continuity chain doesn't cover maximum query height",


### PR DESCRIPTION
Two related block-prover hardening fixes from the recent audit pass.

## Continuity range arithmetic — `precompiles/block-prover`

`continuity.rs` and `verify.rs` computed the final continuity-chain block as
`start_block_number + (roots.len() - 1) as u64` using EVM caller-supplied inputs.
The proof length is bounded by `MAX_CONTINUITY_ROOTS`, but `start_block_number` is
attacker-controlled, so the sum can wrap `u64`. Overflow-checking builds panic;
release builds rely on wrapping and the downstream height check to reject pathological inputs.

Switch both call sites to `checked_add` and revert with a new
`ContinuityVerificationError::RangeOverflow` variant (and matching revert message in
`verify.rs`) so both build profiles return a clean revert on overflow instead of
depending on overflow-check flags.

## Receipt + event verification — `common/eth/src/evm/block_prover.rs`

`verify_and_emit()` and `verify_batch_and_emit()` previously sent the tx, then
replayed the same calldata via `eth_call()` and treated a successful call return as
proof the events were emitted. A reverted or OOG tx emits no `TransactionVerified`
events but the `eth_call` replay can still succeed, so the function would report
success for a tx that never landed.

Require `receipt.status() == true` and count the emitted `TransactionVerified` logs
(matched by `SIGNATURE_HASH`) before returning `Ok(true)`. The batch variant
requires the log count to equal `heights.len()`. The `eth_call` replay is removed;
on success we now return `Ok(true)` directly.

## Audit items addressed

- "block-prover computes continuity proof ranges with unchecked arithmetic…"
- "Rust event-emitting block prover client … does not check `receipt.status` after `verify_and_emit()`/`verify_batch_and_emit()`…"
