### PR TITLE
fix(node): BABE revert + AccountId32 RPC override + dedup notification metrics

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -181,11 +181,23 @@ pub fn run() -> sc_cli::Result<()> {
                 // import. BABE is reverted first because its aux entries are produced
                 // earlier in the import pipeline and GRANDPA's revert is the cheaper
                 // catch-all if the first call fails for an unrelated reason.
-                let aux_revert = Box::new(move |client: Arc<_>, backend, blocks| {
-                    sc_consensus_babe::revert(client.clone(), backend, blocks)?;
-                    sc_consensus_grandpa::revert(client, blocks)?;
-                    Ok(())
-                });
+                //
+                // The closure arg types match `AuxRevertHandler<C, BA, B>` in
+                // sc_cli::commands::revert_cmd, where C/BA/B are inferred from the
+                // `cmd.run(client, backend, ...)` call below. Spell them out so
+                // `sc_consensus_babe::revert` (generic over C and BA) can resolve its
+                // type parameters — inference fails on stable rustc otherwise.
+                let aux_revert = Box::new(
+                    move |client: Arc<crate::client::Client>,
+                          backend: Arc<crate::client::FullBackend>,
+                          blocks: sp_runtime::traits::NumberFor<
+                        creditcoin3_runtime::opaque::Block,
+                    >| {
+                        sc_consensus_babe::revert(client.clone(), backend, blocks)?;
+                        sc_consensus_grandpa::revert(client, blocks)?;
+                        Ok(())
+                    },
+                );
                 Ok((cmd.run(client, backend, Some(aux_revert)), task_manager))
             })
         }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -15,6 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use futures::TryFutureExt;
 // Substrate
 use sc_cli::{ChainSpec, SubstrateCli};
@@ -173,7 +175,14 @@ pub fn run() -> sc_cli::Result<()> {
             runner.async_run(|mut config| {
                 let (client, backend, _, task_manager, _) =
                     service::new_chain_ops(&mut config, &cli.eth)?;
-                let aux_revert = Box::new(move |client, _, blocks| {
+                // Revert both BABE and GRANDPA aux data. Reverting GRANDPA on its own
+                // leaves stale BABE epoch-change / block-weight aux data behind, which can
+                // leave the recovery command in an inconsistent consensus state on next
+                // import. BABE is reverted first because its aux entries are produced
+                // earlier in the import pipeline and GRANDPA's revert is the cheaper
+                // catch-all if the first call fails for an unrelated reason.
+                let aux_revert = Box::new(move |client: Arc<_>, backend, blocks| {
+                    sc_consensus_babe::revert(client.clone(), backend, blocks)?;
                     sc_consensus_grandpa::revert(client, blocks)?;
                     Ok(())
                 });

--- a/node/src/rpc/mod.rs
+++ b/node/src/rpc/mod.rs
@@ -106,8 +106,14 @@ where
     BE: Backend<Block> + 'static,
 {
     type EstimateGasAdapter = ();
+    // The runtime maps EVM addresses to AccountId32 via HashedAddressMapping<BlakeTwo256>
+    // (see runtime/src/lib.rs::AddressMapping), so state overrides for eth_call /
+    // eth_estimateGas must target the System.Account storage key derived from AccountId32.
+    // The previous SystemAccountId20StorageOverride hashed the 20-byte EVM address directly,
+    // producing a System.Account key the runtime never reads — balance/nonce overrides were
+    // silently ignored.
     type RuntimeStorageOverride =
-        fc_rpc::frontier_backend_client::SystemAccountId20StorageOverride<Block, C, BE>;
+        fc_rpc::frontier_backend_client::SystemAccountId32StorageOverride<Block, C, BE>;
 }
 
 /// Instantiate all Full RPC extensions.

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -393,14 +393,18 @@ where
         &config.chain_spec,
     );
 
-    let metrics = Net::register_notification_metrics(
-        config.prometheus_config.as_ref().map(|cfg| &cfg.registry),
-    );
+    // Register notification metrics ONCE against the Prometheus registry, then hand a
+    // clone to both the GRANDPA peers-set config and `build_network`. Registering twice
+    // against the same registry causes the second `register()` call to fail with
+    // AlreadyReg, which substrate's metrics wrapper swallows into a disabled metrics
+    // object — the network would then run without P2P notification metrics. The metrics
+    // type is `Clone`, so a single registration suffices for both consumers.
+    let notification_metrics = Net::register_notification_metrics(config.prometheus_registry());
 
     let (grandpa_protocol_config, grandpa_notification_service) =
         sc_consensus_grandpa::grandpa_peers_set_config::<_, Net>(
             grandpa_protocol_name.clone(),
-            metrics.clone(),
+            notification_metrics.clone(),
             Arc::clone(&peer_store_handle),
         );
 
@@ -417,7 +421,6 @@ where
         Some(WarpSyncConfig::WithProvider(warp_sync))
     };
 
-    let metrics = Net::register_notification_metrics(config.prometheus_registry());
     let (network, system_rpc_tx, tx_handler_controller, network_starter, sync_service) =
         sc_service::build_network(sc_service::BuildNetworkParams {
             config: &config,
@@ -429,7 +432,7 @@ where
             block_announce_validator_builder: None,
             warp_sync_config,
             block_relay: None,
-            metrics,
+            metrics: notification_metrics,
         })?;
 
     if config.offchain_worker.enabled {


### PR DESCRIPTION
Three small node-level fixes from the audit pass. Each is independent and easy to revert if needed.

## 1. `Subcommand::Revert` — also revert BABE aux data

Previously the revert handler only called `sc_consensus_grandpa::revert(client, blocks)`, so reverting blocks left stale BABE epoch-change / block-weight aux data behind. That can leave the node in an inconsistent consensus state on the next import.

Call `sc_consensus_babe::revert(client.clone(), backend, blocks)` first (because BABE aux entries are written earlier in the import pipeline), then GRANDPA.

## 2. RPC state overrides — `SystemAccountId20StorageOverride` → `SystemAccountId32StorageOverride`

The runtime maps EVM addresses to `AccountId32` via `HashedAddressMapping<BlakeTwo256>` (`runtime/src/lib.rs::AddressMapping`), so `System.Account` is keyed by an `AccountId32`. The previous `SystemAccountId20StorageOverride` hashed the raw 20-byte EVM address, producing a `System.Account` key the runtime never reads — `eth_call` / `eth_estimateGas` balance and nonce state overrides were silently ignored.

## 3. Network notification metrics — register once, share the handle

`build_full_base` called `Net::register_notification_metrics(...)` twice against the same Prometheus registry: once for the GRANDPA peers-set config and once for `build_network`. The second `register()` fails with `AlreadyReg`, which substrate's metrics wrapper swallows into a disabled metrics object — `build_network` then runs without P2P notification metrics.

Register once, hand a clone to the GRANDPA peers-set config, and pass the original into `build_network`.

## Audit items addressed

- "The revert subcommand only reverts GRANDPA aux data and does not call the BABE aux-data revert path…"
- "`eth_call`/`eth_estimateGas` state overrides use the wrong account storage override…"
- "Network notification metrics are registered twice against the same Prometheus registry…"

## Build note

I couldn't fully build the node locally (sandbox has no clang for `librocksdb-sys`). Relying on CI to confirm the closure signature change in `command.rs` types correctly.
