### PR TITLE
fix(proof-gen-api): reject tx proofs for empty blocks

### DIFF
--- a/proof-gen-api-server/src/networking/routes/continuity.rs
+++ b/proof-gen-api-server/src/networking/routes/continuity.rs
@@ -24,13 +24,13 @@ type TxHashes = Vec<String>;
     params(
         ("chain_key" = u64, Path, description = "Chain identifier"),
         ("header_number" = u64, Path, description = "Block number"),
-        ("tx_index" = u64, Path, description = "Transaction index in the block (0 for empty blocks)")
+        ("tx_index" = u64, Path, description = "Transaction index in the block. Empty blocks have no transaction proof; request EmptyBlockTxProof (422) for those.")
     ),
     responses(
         (status = 200, description = "Continuity and merkle proof", body = SingleContinuityResponse),
         (status = 400, description = "Invalid parameters", body = ErrorResponse),
         (status = 404, description = "Block or transaction not found", body = ErrorResponse),
-        (status = 422, description = "Unprocessable: block not yet attested (BlockNotReady), or source RPC block/header inconsistent (UnsupportedBlockFormat)", body = ErrorResponse),
+        (status = 422, description = "Unprocessable: block not yet attested (BlockNotReady), source RPC block/header inconsistent (UnsupportedBlockFormat), or block contains no transactions (EmptyBlockTxProof)", body = ErrorResponse),
         (status = 503, description = "RPC unavailable", body = ErrorResponse)
     )
 )]

--- a/proof-gen-api-server/src/prom/mod.rs
+++ b/proof-gen-api-server/src/prom/mod.rs
@@ -497,6 +497,7 @@ mod labels {
         InvalidParameter,
         TxHashNotFound,
         TxIndexOutOfBounds,
+        EmptyBlockTxProof,
         AttestationsMissing,
         QueryOutOfRange,
         TxHashLookupUnavailable,

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -280,13 +280,15 @@ impl ContinuityService {
             .await
             .map_err(|e| map_eth_rpc_anyhow_to_service_error(e, header_number))?;
         if tx_bytes.is_empty() {
-            if tx_index != 0 {
-                return Err(ServiceError::TxIndexOutOfBounds {
-                    height: header_number,
-                    tx_index,
-                    len: 0,
-                });
-            }
+            // An empty block has no transactions, so there is nothing to build a transaction
+            // merkle proof for. We previously accepted `tx_index == 0` here and returned an
+            // empty `TransactionMerkleProof`, but the block-prover precompile rejects empty
+            // transaction bytes ("Transaction data cannot be empty"), so those proofs could
+            // never verify on-chain. Fail the API request explicitly instead of returning a
+            // payload that is guaranteed to fail downstream.
+            return Err(ServiceError::EmptyBlockTxProof {
+                height: header_number,
+            });
         } else if tx_index as usize >= tx_bytes.len() {
             return Err(ServiceError::TxIndexOutOfBounds {
                 height: header_number,
@@ -299,14 +301,13 @@ impl ContinuityService {
         // transactions this is O(n) keccak hashing; running it inline would stall the async
         // worker (and every other future sharing it) under concurrent batch load. `tx_bytes` is
         // moved in and handed back so we can still use it afterwards without cloning.
+        //
+        // Empty-block handling: the empty-block branch is gated by the EmptyBlockTxProof early
+        // return above, so `tx_bytes` is guaranteed non-empty here.
         let (tx_bytes, proof_result, merkle_root) = tokio::task::spawn_blocking(move || {
             let tree = merkle::keccak_merkle_tree::KeccakMerkleTree::new(&tx_bytes);
             let root = tree.root();
-            let proof = if tx_bytes.is_empty() {
-                Ok(TransactionMerkleProof::new(root, vec![]))
-            } else {
-                tree.generate_proof(tx_index as usize)
-            };
+            let proof = tree.generate_proof(tx_index as usize);
             (tx_bytes, proof, root)
         })
         .await
@@ -318,23 +319,15 @@ impl ContinuityService {
         })?;
 
         // The real transaction hash comes from the block fetch above (RLP-derived, not computed
-        // from the ABI-encoded bytes). For an empty block there's no tx, so no hash.
-        let tx_hash_opt = if tx_bytes.is_empty() {
-            None
-        } else {
-            fetched_tx_hash
-        };
+        // from the ABI-encoded bytes).
+        let tx_hash_opt = fetched_tx_hash;
 
         // Record merkle proof generation duration
         self.metrics
             .observe_merkle_generation(merkle_start.elapsed());
 
         // Build Proof items for DB Insert
-        let tx_bytes_for_cache = if tx_bytes.is_empty() {
-            None
-        } else {
-            Some(tx_bytes[tx_index as usize].clone())
-        };
+        let tx_bytes_for_cache = Some(tx_bytes[tx_index as usize].clone());
         Ok(MerkleProofItem {
             chain_key,
             header_number,

--- a/proof-gen-api-server/src/services/errors.rs
+++ b/proof-gen-api-server/src/services/errors.rs
@@ -94,6 +94,13 @@ pub enum ServiceError {
         tx_index: u64,
         len: usize,
     },
+    /// The block at `height` contains no transactions, so there is no transaction proof to
+    /// build. The block-prover precompile rejects empty transaction bytes, so returning the
+    /// previous "empty merkle proof at tx_index=0" payload only produced proofs that fail
+    /// on-chain verification. Callers wanting a continuity-only attestation for an empty
+    /// block should use a continuity-only endpoint instead.
+    #[error("block {height} is empty; tx proof unavailable (use a continuity-only proof)")]
+    EmptyBlockTxProof { height: u64 },
     #[error("rpc unavailable: {message}")]
     RpcUnavailable { message: String },
     #[error("merkle proof generation failed: {message}")]
@@ -161,6 +168,7 @@ impl ServiceError {
             ServiceError::AttestationsMissing { .. } => "AttestationsMissing",
             ServiceError::QueryOutOfRange { .. } => "QueryOutOfRange",
             ServiceError::TxIndexOutOfBounds { .. } => "TxIndexOutOfBounds",
+            ServiceError::EmptyBlockTxProof { .. } => "EmptyBlockTxProof",
             ServiceError::RpcUnavailable { .. } => "RpcUnavailable",
             ServiceError::MerkleError { .. } => "MerkleError",
             ServiceError::InvalidParameter { .. } => "InvalidParameter",
@@ -203,9 +211,11 @@ impl ServiceError {
             // is more accurate than 404 Not Found and lets clients distinguish
             // "keep waiting / retry" from "this will never exist".
             // Same semantics as BlockNotReady: request may be valid but payload cannot be processed.
-            Self::UnsupportedBlockFormat { .. } | Self::BlockNotReady { .. } => {
-                StatusCode::UNPROCESSABLE_ENTITY
-            }
+            // EmptyBlockTxProof joins this group: the request is well-formed and the block
+            // exists, but no transaction proof can ever be produced for an empty block.
+            Self::UnsupportedBlockFormat { .. }
+            | Self::BlockNotReady { .. }
+            | Self::EmptyBlockTxProof { .. } => StatusCode::UNPROCESSABLE_ENTITY,
             Self::MerkleError { .. } | Self::Internal { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -314,6 +324,7 @@ impl GetErrorType for ServiceError {
             ServiceError::AttestationsMissing { .. } => ErrorType::AttestationsMissing,
             ServiceError::QueryOutOfRange { .. } => ErrorType::QueryOutOfRange,
             ServiceError::TxIndexOutOfBounds { .. } => ErrorType::TxIndexOutOfBounds,
+            ServiceError::EmptyBlockTxProof { .. } => ErrorType::EmptyBlockTxProof,
             ServiceError::RpcUnavailable { .. } => ErrorType::RpcUnavailable,
             ServiceError::MerkleError { .. } => ErrorType::MerkleError,
             ServiceError::InvalidParameter { .. } => ErrorType::InvalidParameter,


### PR DESCRIPTION
## Problem

`/api/v1/proof/{chain_key}/{header_number}/{tx_index}` previously accepted `tx_index=0` against an empty block and returned an empty `TransactionMerkleProof`. The block-prover precompile rejects empty transaction bytes (`"Transaction data cannot be empty"` — see `precompiles/block-prover/src/verify.rs:207`), so those proofs could never verify on-chain — the API was returning payloads guaranteed to fail downstream.

## Fix

- New `ServiceError::EmptyBlockTxProof { height }`, mapped to **422 Unprocessable Entity** (same group as `BlockNotReady` / `UnsupportedBlockFormat` — request is well-formed but the block can't produce a transaction proof).
- `generate_merkle_proof()` returns `EmptyBlockTxProof` when `tx_bytes.is_empty()` instead of producing a useless proof. The downstream empty-branch handling in the `spawn_blocking` + cache assembly is dead now (the early return covers it), so the helper is simplified.
- New `ErrorType::EmptyBlockTxProof` for prometheus labels and route docstring update describing the new behavior.

## Behavior change for callers

Clients that previously sent `tx_index=0` for an empty block now get:

```
HTTP 422 EmptyBlockTxProof
{"code":"EmptyBlockTxProof","message":"block N is empty; tx proof unavailable (use a continuity-only proof)"}
```

If continuity-only attestations for empty blocks become a real use case, that's a separate endpoint — intentionally not adding one in this PR to keep the surgical fix focused.

## Audit item addressed

> "proof-gen-api-server allows tx_index=0 for empty blocks and returns an empty Merkle proof, but the block-prover precompile rejects empty transaction bytes, so the API can return proofs that cannot verify on-chain"
