### PR TITLE
fix(attestor/metrics): rollback reset + connected-peers gauge + gossipsub counter

### DIFF
--- a/attestor/attestor/src/worker/p2p/mod.rs
+++ b/attestor/attestor/src/worker/p2p/mod.rs
@@ -584,6 +584,11 @@ impl WorkerP2P {
                 ..
             } => {
                 tracing::info!(%peer_id, connection = %connection_id, "🔗 Connection established");
+                // Track *currently connected* peers separately from the Kademlia routing-table
+                // gauge (increase_peer_count below), which only fires on routing-table
+                // inserts. The two values drift in normal operation — a peer can be in the
+                // routing table without an active connection.
+                self.metrics.note_peer_connected();
             }
 
             // Disconnected from an existing remote peer
@@ -593,6 +598,7 @@ impl WorkerP2P {
                 ..
             } => {
                 tracing::info!(%peer_id, connection = %connection_id, "⛓️‍💥 Connection closed");
+                self.metrics.note_peer_disconnected();
 
                 self.ping_failures.remove(&connection_id);
 

--- a/attestor/attestor/src/worker/production/mod.rs
+++ b/attestor/attestor/src/worker/production/mod.rs
@@ -530,6 +530,29 @@ impl WorkerAttestationProduction {
                         .store(height, std::sync::atomic::Ordering::Release);
                     self.attestation_local = height;
 
+                    // Reset the production / lag metrics so dashboards reflect the rollback
+                    // immediately instead of showing the pre-revert heights. Without this,
+                    // operators see stale `attestation_local` / `attestation_finalized` and
+                    // a negative lag spike until the next forward step nudges the gauges.
+                    self.metrics.set_attestation_local(height);
+                    self.metrics.set_attestation_finalized(height);
+                    // Recompute the lag values against the rolled-back local height so the
+                    // gauges land on the right baseline. We use the last-known eth/cc3 tips
+                    // here because the stream-driven tip refresh runs on a separate arm and
+                    // may be one cycle behind. `attestation_latest_cc3 == height` after a
+                    // revert by definition, so the cc3 lag collapses to zero.
+                    let latest_eth_tip = self.stream_attestation.latest_tip();
+                    self.metrics.update_attestation_lag_eth(
+                        height,
+                        latest_eth_tip,
+                        self.attestation_interval,
+                    );
+                    self.metrics.update_attestation_lag_cc3(
+                        height,
+                        height,
+                        self.attestation_interval,
+                    );
+
                     // 1. Update the attestation pool
                     //
                     // Upon chain reversion, we clear all pending attestations in the attestation pool.

--- a/attestor/metrics/src/lib.rs
+++ b/attestor/metrics/src/lib.rs
@@ -176,6 +176,26 @@ struct Store {
         prometheus_client::metrics::gauge::Gauge<u64, std::sync::atomic::AtomicU64>,
     >,
 
+    /// Monotonic counter of gossipsub messages observed by this node.
+    ///
+    /// Stored alongside the legacy `metrics_p2p` Gauge representation (kept for backwards-
+    /// compatible dashboards), but the Counter is the right type for an ever-increasing
+    /// quantity — a gauge silently drops on overflow / wrap and is harder to reason about
+    /// when computing rates.
+    pub metrics_gossipsub_messages_total:
+        prometheus_client::metrics::counter::Counter<u64, std::sync::atomic::AtomicU64>,
+
+    /// Number of *currently connected* p2p peers (libp2p `ConnectionEstablished` minus
+    /// `ConnectionClosed`).
+    ///
+    /// This is distinct from `metrics_p2p[peer_to_peer=peers]`, which tracks the Kademlia
+    /// routing-table size (insertions / evictions). Routing-table peers and connected peers
+    /// drift apart in normal operation — a node can be in the routing table without an
+    /// active connection — so operators querying “number of attestors I'm actually talking
+    /// to right now” need a separate gauge.
+    pub metrics_connected_peers:
+        prometheus_client::metrics::gauge::Gauge<u64, std::sync::atomic::AtomicU64>,
+
     /// Metrics which keep track of failed state.
     ///
     /// - _Known invalid attestations_ ([`Counter`])
@@ -263,8 +283,27 @@ impl Metrics {
 
         registry.register(
             "peer_to_peer",
-            "Peer-to-peer networking metrics",
+            "Peer-to-peer networking metrics (Kademlia routing-table peers + legacy gossipsub message gauge)",
             metrics_p2p.clone(),
+        );
+
+        let metrics_gossipsub_messages_total = prometheus_client::metrics::counter::Counter::<
+            u64,
+            std::sync::atomic::AtomicU64,
+        >::default();
+        registry.register(
+            "gossipsub_messages_total",
+            "Monotonic count of gossipsub messages observed (use rate() for traffic).",
+            metrics_gossipsub_messages_total.clone(),
+        );
+
+        let metrics_connected_peers =
+            prometheus_client::metrics::gauge::Gauge::<u64, std::sync::atomic::AtomicU64>::default(
+            );
+        registry.register(
+            "connected_peers",
+            "Currently connected p2p peers (ConnectionEstablished minus ConnectionClosed).",
+            metrics_connected_peers.clone(),
         );
 
         registry.register(
@@ -280,6 +319,8 @@ impl Metrics {
             metrics_hardware,
             metrics_delay,
             metrics_p2p,
+            metrics_gossipsub_messages_total,
+            metrics_connected_peers,
             metrics_error,
         }));
 
@@ -455,12 +496,30 @@ impl Metrics {
     }
 
     pub fn increase_gossipsub_message_count(&self) {
+        // Bump both representations during the deprecation window:
+        // - The legacy gauge keeps existing dashboards working (they use `rate()` on a gauge).
+        // - The new counter is the correct type for monotonic counts and is what new
+        //   dashboards should target.
         self.0
             .metrics_p2p
             .get_or_create(&labels::LabelPeerToPeer {
                 peer_to_peer: labels::PeerToPeer::GossipsubMessages,
             })
             .inc();
+        self.0.metrics_gossipsub_messages_total.inc();
+    }
+
+    /// Increment the *connected* peer gauge — call from libp2p `SwarmEvent::ConnectionEstablished`.
+    /// This is independent from [`Self::increase_peer_count`], which tracks the Kademlia routing
+    /// table.
+    pub fn note_peer_connected(&self) {
+        self.0.metrics_connected_peers.inc();
+    }
+
+    /// Decrement the *connected* peer gauge — call from libp2p `SwarmEvent::ConnectionClosed`.
+    /// Counterpart to [`Self::note_peer_connected`].
+    pub fn note_peer_disconnected(&self) {
+        self.0.metrics_connected_peers.dec();
     }
 
     pub fn increase_invalid_attestation_count(&self) {


### PR DESCRIPTION
Three attestor observability fixes from the audit pass. Additive — no metric was renamed or removed, so existing prometheus dashboards keep working.

## 1. Reset production / lag metrics on rollback

The `RevertedAttestationChainTo` arm in the production worker updated `attestation_latest_cc3` / `attestation_local` internal state but left the prometheus gauges showing pre-revert heights and a stale lag measurement until the next forward step. Operators saw the chain at the wrong height and a spurious negative lag in dashboards.

Now we `set_attestation_local` / `set_attestation_finalized` to the revert height immediately and recompute eth/cc3 lag against the rolled-back local height. cc3 lag collapses to zero by definition after a revert.

## 2. Add `connected_peers` gauge (separate from Kademlia routing-table peers)

The existing `peer_to_peer{peer_to_peer=peers}` gauge tracks Kademlia routing-table inserts / evictions and never decremented on `ConnectionClosed`. Its docstring said "Active peer count" but the value really meant "known peers in the routing table".

The routing-table gauge stays so existing dashboards don't break; the new `connected_peers` gauge is bumped from `ConnectionEstablished` and decremented on `ConnectionClosed`, answering the more common "how many attestors am I actually talking to right now" question.

## 3. Add `gossipsub_messages_total` Counter alongside the legacy gauge

Gossipsub message counts are monotonic and belong in a Counter; the gauge representation is silently wrap-prone and harder to reason about with `rate()`. The existing gauge stays for backwards-compatible dashboards during a deprecation window; new dashboards should target `gossipsub_messages_total`.

## Audit items addressed

- "During rollback handling … only the internal `attestation_latest_cc3` and `attestation_local` states are reverted, while metrics remain unchanged…"
- "describes a metric as 'Active peer count', but the value actually reflects insertions and evictions in the Kademlia routing table … The metric is not decremented on `ConnectionClosed`."
- "stores both peer counts and Gossipsub message counts in the same `Gauge<u64>` family, even though message counts are monotonically increasing…"

## Deferred (separate follow-ups)

- Attestation generation latency metric description / start-time semantics (item 4): worth a separate look at whether to propagate the creation timestamp through `StreamAttestation` or just relabel.
- `StreamAttestation::new` `tip = 0` init (item 5): touches stream init lifecycle.
