### PR TITLE
fix(attestor/metrics): add connected_peers gauge for ConnectionEstablished / Closed

### DIFF
--- a/attestor/attestor/src/tasks/p2p/mod.rs
+++ b/attestor/attestor/src/tasks/p2p/mod.rs
@@ -280,8 +280,20 @@ async fn handle_swarm(
                 .gossipsub
                 .report_message_validation_result(&message_id, &propagation_source, decision);
         }
-        SwarmEvent::ConnectionClosed { connection_id, .. } => {
-            shared.metrics.note_peer_disconnected();
+        SwarmEvent::ConnectionClosed {
+            connection_id,
+            num_established,
+            ..
+        } => {
+            // Only decrement the per-peer gauge when this was the *last* connection to the
+            // remote peer (`num_established` is the post-close count). The swarm allows multiple
+            // simultaneous transports (TCP + QUIC) and up to a per-peer connection limit, so
+            // a single peer can produce several ConnectionEstablished / ConnectionClosed pairs.
+            // Counting all of them would inflate the gauge and let it diverge from “distinct
+            // peers I'm actually talking to right now”.
+            if num_established == 0 {
+                shared.metrics.note_peer_disconnected();
+            }
             ping_failures.remove(&connection_id);
             *can_broadcast = swarm
                 .behaviour()
@@ -314,14 +326,20 @@ async fn handle_swarm(
         SwarmEvent::ConnectionEstablished {
             peer_id,
             connection_id,
+            num_established,
             ..
         } => {
             tracing::info!(%peer_id, %connection_id, "🔗 connection up");
-            // Track currently-connected peers independently from the Kademlia routing-table
-            // gauge (`note_routing_peer_added`). The two diverge — a peer can be in the
-            // routing table without an active connection — so dashboards asking “how many
-            // peers am I actually talking to right now” need this separate counter.
-            shared.metrics.note_peer_connected();
+            // Track *distinct* connected peers — only bump the gauge when this is the first
+            // established connection to the remote peer (`num_established == 1` includes this
+            // one). The swarm enables both TCP and QUIC and allows multiple simultaneous
+            // connections per peer, so a single peer can fire ConnectionEstablished several
+            // times; counting each one would have the gauge measure connections, not peers.
+            // Separate from the Kademlia routing-table gauge (`note_routing_peer_added`),
+            // which can hold a peer with no live connection.
+            if num_established.get() == 1 {
+                shared.metrics.note_peer_connected();
+            }
         }
         SwarmEvent::OutgoingConnectionError {
             peer_id,

--- a/attestor/attestor/src/tasks/p2p/mod.rs
+++ b/attestor/attestor/src/tasks/p2p/mod.rs
@@ -281,6 +281,7 @@ async fn handle_swarm(
                 .report_message_validation_result(&message_id, &propagation_source, decision);
         }
         SwarmEvent::ConnectionClosed { connection_id, .. } => {
+            shared.metrics.note_peer_disconnected();
             ping_failures.remove(&connection_id);
             *can_broadcast = swarm
                 .behaviour()
@@ -316,6 +317,11 @@ async fn handle_swarm(
             ..
         } => {
             tracing::info!(%peer_id, %connection_id, "🔗 connection up");
+            // Track currently-connected peers independently from the Kademlia routing-table
+            // gauge (`note_routing_peer_added`). The two diverge — a peer can be in the
+            // routing table without an active connection — so dashboards asking “how many
+            // peers am I actually talking to right now” need this separate counter.
+            shared.metrics.note_peer_connected();
         }
         SwarmEvent::OutgoingConnectionError {
             peer_id,

--- a/attestor/metrics/src/lib.rs
+++ b/attestor/metrics/src/lib.rs
@@ -166,8 +166,13 @@ struct Store {
         prometheus_client::metrics::gauge::Gauge<u64, std::sync::atomic::AtomicU64>,
     >,
 
-    /// Currently connected p2p peers — incremented on libp2p `ConnectionEstablished`,
-    /// decremented on `ConnectionClosed`.
+    /// Currently connected p2p peers (distinct remote peers, not raw connections).
+    ///
+    /// Bumped only when libp2p `ConnectionEstablished` fires with `num_established == 1`
+    /// (first established connection to that peer), and decremented only when
+    /// `ConnectionClosed` fires with `num_established == 0` (last remaining connection
+    /// closed). The swarm enables TCP + QUIC and allows multiple connections per peer, so
+    /// counting every connection event would inflate the gauge above the actual peer count.
     ///
     /// This is distinct from [`metrics_p2p`] (Kademlia routing-table size): routing-table
     /// entries and live connections drift apart in normal operation — a peer can stay in the
@@ -507,14 +512,18 @@ impl Metrics {
     }
 
     /// Increment the *currently connected* peer gauge — call from libp2p
-    /// `SwarmEvent::ConnectionEstablished`. Independent from [`Self::note_routing_peer_added`],
-    /// which tracks the Kademlia routing-table.
+    /// `SwarmEvent::ConnectionEstablished` **only when `num_established == 1`** (first
+    /// connection to the remote peer). Subsequent connections from the same peer (additional
+    /// transports, parallel dials) must not bump this gauge or it stops representing distinct
+    /// peers. Independent from [`Self::note_routing_peer_added`], which tracks the Kademlia
+    /// routing-table.
     pub fn note_peer_connected(&self) {
         self.0.metrics_connected_peers.inc();
     }
 
     /// Decrement the *currently connected* peer gauge — call from libp2p
-    /// `SwarmEvent::ConnectionClosed`. Counterpart to [`Self::note_peer_connected`].
+    /// `SwarmEvent::ConnectionClosed` **only when `num_established == 0`** (last connection
+    /// to the remote peer closed). Counterpart to [`Self::note_peer_connected`].
     pub fn note_peer_disconnected(&self) {
         self.0.metrics_connected_peers.dec();
     }

--- a/attestor/metrics/src/lib.rs
+++ b/attestor/metrics/src/lib.rs
@@ -148,8 +148,8 @@ struct Store {
     /// and [`note_routing_peer_evicted`].
     ///
     /// For traffic-rate dashboards see [`metrics_p2p_messages`] (Counter); for actual connected
-    /// peers, instrument `ConnectionEstablished` / `ConnectionClosed` separately (not yet
-    /// exposed).
+    /// peers, see [`metrics_connected_peers`] which is incremented on `ConnectionEstablished`
+    /// and decremented on `ConnectionClosed`.
     ///
     /// ✅ Routing-table size **comfortably above quorum** indicates a healthy mesh.
     /// ⚠️ Routing-table size **at quorum** is borderline; gossip mesh may be smaller.
@@ -160,10 +160,21 @@ struct Store {
     /// [`note_routing_peer_added`]: Self::note_routing_peer_added
     /// [`note_routing_peer_evicted`]: Self::note_routing_peer_evicted
     /// [`metrics_p2p_messages`]: Self::metrics_p2p_messages
+    /// [`metrics_connected_peers`]: Self::metrics_connected_peers
     pub metrics_p2p: prometheus_client::metrics::family::Family<
         labels::LabelPeerToPeer,
         prometheus_client::metrics::gauge::Gauge<u64, std::sync::atomic::AtomicU64>,
     >,
+
+    /// Currently connected p2p peers — incremented on libp2p `ConnectionEstablished`,
+    /// decremented on `ConnectionClosed`.
+    ///
+    /// This is distinct from [`metrics_p2p`] (Kademlia routing-table size): routing-table
+    /// entries and live connections drift apart in normal operation — a peer can stay in the
+    /// routing table without an active connection — so operators querying “how many attestors
+    /// am I actually talking to right now” need this separate gauge.
+    pub metrics_connected_peers:
+        prometheus_client::metrics::gauge::Gauge<u64, std::sync::atomic::AtomicU64>,
 
     /// Counter for gossipsub message traffic. Monotonically increasing — meant to be consumed
     /// via the PromQL [`rate`] function to analyze message-frequency variance.
@@ -234,6 +245,9 @@ impl Metrics {
         });
         let metrics_p2p = prometheus_client::metrics::family::Family::default();
         let metrics_p2p_messages = prometheus_client::metrics::family::Family::default();
+        let metrics_connected_peers =
+            prometheus_client::metrics::gauge::Gauge::<u64, std::sync::atomic::AtomicU64>::default(
+            );
         let metrics_error = prometheus_client::metrics::family::Family::default();
 
         registry.register(
@@ -284,6 +298,12 @@ impl Metrics {
         );
 
         registry.register(
+            "connected_peers",
+            "Currently connected p2p peers (ConnectionEstablished minus ConnectionClosed)",
+            metrics_connected_peers.clone(),
+        );
+
+        registry.register(
             "failed_states",
             "Counts of various failure states",
             metrics_error.clone(),
@@ -297,6 +317,7 @@ impl Metrics {
             metrics_delay,
             metrics_p2p,
             metrics_p2p_messages,
+            metrics_connected_peers,
             metrics_error,
         }));
 
@@ -483,6 +504,19 @@ impl Metrics {
                 peer_to_peer: labels::PeerToPeer::RoutingPeers,
             })
             .dec();
+    }
+
+    /// Increment the *currently connected* peer gauge — call from libp2p
+    /// `SwarmEvent::ConnectionEstablished`. Independent from [`Self::note_routing_peer_added`],
+    /// which tracks the Kademlia routing-table.
+    pub fn note_peer_connected(&self) {
+        self.0.metrics_connected_peers.inc();
+    }
+
+    /// Decrement the *currently connected* peer gauge — call from libp2p
+    /// `SwarmEvent::ConnectionClosed`. Counterpart to [`Self::note_peer_connected`].
+    pub fn note_peer_disconnected(&self) {
+        self.0.metrics_connected_peers.dec();
     }
 
     pub fn increase_gossipsub_message_count(&self) {


### PR DESCRIPTION
Redo of #1089 against `attestor_v2` per Dylan. Most of #1089's content is already in `attestor_v2`:

- ✅ **Item 1 (rollback metrics reset)** — already done in `attestor/attestor/src/tasks/production.rs` (`set_attestation_finalized` + `set_attestation_local` + `update_attestation_lag_eth/cc3` after `RevertedAttestationChainTo`).
- ✅ **Item 3 (gossipsub Counter)** — already split out into a dedicated Counter family (`metrics_p2p_messages`) and the routing-table gauge renamed from the misleading "Active peer count" to `peer_to_peer{peer_to_peer=routing_peers}`.

What's still missing is **item 2's "actual connected peers" gauge**. The routing-table gauge tracks Kademlia routing-table inserts / evictions, which is independent of whether any connection to that peer is currently open — a routed peer with no live connection is still counted, and the metric never decrements on `ConnectionClosed`. The `lib.rs` doc even calls it out:

> For traffic-rate dashboards see `metrics_p2p_messages` (Counter); for actual connected peers, instrument `ConnectionEstablished` / `ConnectionClosed` separately *(not yet exposed)*.

This PR exposes it.

## Changes

- `metrics_connected_peers`: `Gauge<u64>` on `Store`, registered as a top-level `connected_peers` metric (kept separate from `metrics_p2p` so dashboards and the docstring stay unambiguous about which value means which thing).
- `note_peer_connected()` / `note_peer_disconnected()` helpers.
- Wired into `tasks/p2p/mod.rs` in `SwarmEvent::ConnectionEstablished` / `ConnectionClosed`.

## Audit item addressed

- "describes a metric as 'Active peer count', but the value actually reflects insertions and evictions in the Kademlia routing table … The metric is not decremented on `ConnectionClosed`. **Action: Rename … or expose a separate gauge for actual connected peers…**"

The rename was already done; this PR adds the separate connected-peers gauge.

## Still deferred

- Item 4: handler-delay vs. total-generation latency metric description — `attestor_v2` already renamed it to `update_attestation_handler_delay` and the docstring explicitly says it's handler-delay only; further work would mean propagating creation timestamps through `StreamAttestation`, which is more invasive than a metrics PR should be.
- Item 5: `StreamAttestation::new tip = 0` init — touches stream init lifecycle, separate PR.

## Related

Replaces #1089 (closed).
