### PR TITLE
fix(encoding): derive block EncodingVersion from CC3 metadata, not hardcoded V1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10627,6 +10627,7 @@ dependencies = [
  "tower-http 0.6.7",
  "tracing",
  "tracing-subscriber",
+ "usc-abi-encoding",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",

--- a/attestor/attestor/src/lib.rs
+++ b/attestor/attestor/src/lib.rs
@@ -96,6 +96,10 @@ impl Attestor {
             .map_err(Error::Init)?
             .ok_or(Error::ChainKeyNotSupported(chain_key))?;
 
+        // Source-chain block encoding from CC3 metadata, instead of assuming V1.
+        let chain_encoding =
+            usc_abi_encoding::common::EncodingVersion::from(supported_chain.chain_encoding);
+
         if supported_chain.chain_id != client_eth.chain_id() {
             return Err(Error::ChainIdMisMatch {
                 runtime: supported_chain.chain_id,
@@ -299,6 +303,7 @@ impl Attestor {
             .with_finalization_lag(maturity_delay)
             .with_max_concurrency(common::constants::MAX_CONCURRENT_RPC_CALLS)
             .with_max_parallelism(get_available_parallelism())
+            .with_encoding(chain_encoding)
             .build();
         let stream_roots = stream::eth::StreamRoots::new(config).await;
 
@@ -418,6 +423,7 @@ impl Attestor {
 
             match wait_for_genesis(
                 genesis,
+                chain_encoding,
                 &client_eth,
                 &account_id,
                 &mut stream_cc3_genesis,
@@ -697,8 +703,10 @@ async fn wait_for_eligible(
     Ok(attestors)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn wait_for_genesis(
     genesis: attestor_primitives::Height,
+    chain_encoding: usc_abi_encoding::common::EncodingVersion,
     client_eth: &eth::Client,
     account_id: &cc_client::AccountId32,
     stream_cc3: &mut stream::cc3::StreamCC3,
@@ -711,7 +719,7 @@ async fn wait_for_genesis(
     use futures::TryStreamExt as _;
 
     let block = client_eth
-        .get_block(genesis, usc_abi_encoding::common::EncodingVersion::V1)
+        .get_block(genesis, chain_encoding)
         .await
         .context("Failed to fetch genesis block")
         .map_interrupt(Error::Init)?;

--- a/common/continuity/src/builder/mod.rs
+++ b/common/continuity/src/builder/mod.rs
@@ -31,6 +31,7 @@ use indexer_client::{AttestationWithProof, IndexerClient};
 use sp_core::H256;
 use std::sync::Arc;
 use tracing::info;
+use usc_abi_encoding::common::EncodingVersion;
 
 /// Builder for generating continuity proofs.
 ///
@@ -181,10 +182,12 @@ impl ContinuityBuilder {
             .await
             .context("Failed to create ETH client")?;
 
+        let encoding = resolve_chain_encoding(&cc_client, config.chain_key).await;
+
         Ok(Self::new_with_providers(
             config,
             Arc::new(cc_client),
-            Arc::new(ReconnectingEthRpcProvider::new(eth_client)),
+            Arc::new(ReconnectingEthRpcProvider::new(eth_client, encoding)),
         ))
     }
 
@@ -242,10 +245,12 @@ impl ContinuityBuilder {
             .await
             .context("Failed to create caching ETH client")?;
 
+        let encoding = resolve_chain_encoding(&cc_client, config.chain_key).await;
+
         Ok(Self::new_with_providers(
             config,
             Arc::new(cc_client),
-            Arc::new(ReconnectingEthRpcProvider::new(eth_client)),
+            Arc::new(ReconnectingEthRpcProvider::new(eth_client, encoding)),
         ))
     }
 
@@ -696,6 +701,34 @@ impl ContinuityBuilder {
             .await?;
 
         Ok(attestation.map(|a| a.attestation.header_number))
+    }
+}
+
+/// Resolve the source-chain block encoding from CC3 supported-chain metadata.
+///
+/// Off-chain block fetching used to hardcode [`EncodingVersion::V1`]. We instead
+/// read the chain's configured `chain_encoding` so a per-chain or future encoding
+/// change is honoured. If the chain is not found or the lookup fails we fall back
+/// to V1 (the only encoding in existence today) and log, rather than failing
+/// startup.
+async fn resolve_chain_encoding(cc_client: &CcClient, chain_key: u64) -> EncodingVersion {
+    match cc_client.get_supported_chain(chain_key).await {
+        Ok(Some(chain)) => EncodingVersion::from(chain.chain_encoding),
+        Ok(None) => {
+            tracing::warn!(
+                chain_key,
+                "supported chain not found while resolving block encoding; defaulting to V1"
+            );
+            EncodingVersion::V1
+        }
+        Err(e) => {
+            tracing::warn!(
+                chain_key,
+                error = %e,
+                "failed to fetch supported chain encoding; defaulting to V1"
+            );
+            EncodingVersion::V1
+        }
     }
 }
 

--- a/common/continuity/src/rpc.rs
+++ b/common/continuity/src/rpc.rs
@@ -39,12 +39,17 @@ const RECONNECT_MAX_ATTEMPTS: usize = 5;
 #[derive(Debug)]
 pub struct ReconnectingEthRpcProvider {
     client: RwLock<eth::Client>,
+    /// Source-chain block encoding, derived from CC3 supported-chain metadata at
+    /// startup. Used for all block fetching / continuity building so that a
+    /// per-chain or future encoding change is honoured instead of assuming V1.
+    encoding: EncodingVersion,
 }
 
 impl ReconnectingEthRpcProvider {
-    pub fn new(client: eth::Client) -> Self {
+    pub fn new(client: eth::Client, encoding: EncodingVersion) -> Self {
         Self {
             client: RwLock::new(client),
+            encoding,
         }
     }
 
@@ -368,9 +373,10 @@ impl EthRpcProvider for ReconnectingEthRpcProvider {
         start: u64,
         end: u64,
     ) -> Result<Vec<Block>> {
+        let encoding = self.encoding;
         self.run("build_continuity_blocks", move |client| async move {
             ContinuityManager::new(start, end, &client)
-                .create(lower_digest, EncodingVersion::V1)
+                .create(lower_digest, encoding)
                 .await
                 .context("Failed to create continuity blocks")
         })
@@ -378,9 +384,10 @@ impl EthRpcProvider for ReconnectingEthRpcProvider {
     }
 
     async fn get_block_tx_bytes(&self, block_number: u64) -> Result<Vec<Vec<u8>>> {
+        let encoding = self.encoding;
         self.run("get_block_tx_bytes", move |client| async move {
             let ordered = client
-                .get_block(block_number, EncodingVersion::V1)
+                .get_block(block_number, encoding)
                 .await
                 .unwrap_interrupt("Not handling user interrupts yet")
                 .context("Failed to fetch block transactions")?;
@@ -391,9 +398,10 @@ impl EthRpcProvider for ReconnectingEthRpcProvider {
     }
 
     async fn get_tx_hash_by_index(&self, block_number: u64, tx_index: u64) -> Result<Option<H256>> {
+        let encoding = self.encoding;
         self.run("get_tx_hash_by_index", move |client| async move {
             let ordered = client
-                .get_block(block_number, EncodingVersion::V1)
+                .get_block(block_number, encoding)
                 .await
                 .unwrap_interrupt("Not handling user interrupts yet")
                 .context("Failed to fetch block")?;
@@ -411,11 +419,12 @@ impl EthRpcProvider for ReconnectingEthRpcProvider {
         block_number: u64,
         tx_index: u64,
     ) -> Result<(Vec<Vec<u8>>, Option<H256>)> {
+        let encoding = self.encoding;
         self.run("get_block_tx_bytes_and_tx_hash", move |client| async move {
             // One block fetch yields both the ordered tx bytes and the tx hash at `tx_index`,
             // replacing the previous two separate `get_block` calls.
             let ordered = client
-                .get_block(block_number, EncodingVersion::V1)
+                .get_block(block_number, encoding)
                 .await
                 .unwrap_interrupt("Not handling user interrupts yet")
                 .context("Failed to fetch block")?;
@@ -431,9 +440,10 @@ impl EthRpcProvider for ReconnectingEthRpcProvider {
     }
 
     async fn get_block_tx_data(&self, block_number: u64) -> Result<Vec<(H256, Vec<u8>)>> {
+        let encoding = self.encoding;
         self.run("get_block_tx_data", move |client| async move {
             let ordered = client
-                .get_block(block_number, EncodingVersion::V1)
+                .get_block(block_number, encoding)
                 .await
                 .unwrap_interrupt("Not handling user interrupts yet")
                 .context("Failed to fetch block")?;

--- a/common/streams/eth/src/roots.rs
+++ b/common/streams/eth/src/roots.rs
@@ -12,6 +12,12 @@ pub struct Config {
 
     /// Maximum number of parallel block root merkleization (CPU-bound).
     pub max_parallelism: std::num::NonZeroUsize,
+
+    /// Source-chain block encoding. Derived from CC3 supported-chain metadata by
+    /// callers that know the chain; defaults to V1 (the only encoding today) so
+    /// existing builders keep working.
+    #[default(usc_abi_encoding::common::EncodingVersion::V1)]
+    pub encoding: usc_abi_encoding::common::EncodingVersion,
 }
 
 /// Ordered Eth root stream, backed by [`eth::Client`] under the hood.
@@ -297,13 +303,14 @@ async fn stream_rpc(config: Config) -> stream_util::BoxedStream<Result<eth::Orde
 
                     let eth = config.client.clone();
                     let lag = config.finalization_lag;
+                    let encoding = config.encoding;
 
                     // Actual block fetching. No more than `max_concurrency` blocks may be
                     // fetched at once.
                     blocks.spawn(async move {
                         eth.get_block(
                             n - lag,
-                            usc_abi_encoding::common::EncodingVersion::V1
+                            encoding
                         )
                         .await
                         .map_interrupt(Error::Client)

--- a/proof-gen-api-server/Cargo.toml
+++ b/proof-gen-api-server/Cargo.toml
@@ -63,9 +63,9 @@ eth = { workspace = true }
 hex = { workspace = true }
 merkle = { workspace = true }
 prometheus-client = { workspace = true }
-usc-abi-encoding = { workspace = true }
 stream = { workspace = true, features = ["cc3"] }
 sysinfo = { workspace = true }
+usc-abi-encoding = { workspace = true }
 
 [features]
 default = []

--- a/proof-gen-api-server/Cargo.toml
+++ b/proof-gen-api-server/Cargo.toml
@@ -63,6 +63,7 @@ eth = { workspace = true }
 hex = { workspace = true }
 merkle = { workspace = true }
 prometheus-client = { workspace = true }
+usc-abi-encoding = { workspace = true }
 stream = { workspace = true, features = ["cc3"] }
 sysinfo = { workspace = true }
 

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -138,6 +138,9 @@ impl Server {
             })?
             .ok_or_else(|| anyhow!("Failed to get supported chain for chain_key {chain_key}"))?;
         let supported_chain_id = supported_chain.chain_id;
+        // Source-chain block encoding from CC3 metadata, rather than assuming V1.
+        let chain_encoding =
+            usc_abi_encoding::common::EncodingVersion::from(supported_chain.chain_encoding);
 
         let eth_fallback_urls: &[String] = &chain.eth_rpc_fallback_urls;
 
@@ -233,8 +236,9 @@ impl Server {
             );
         }
 
-        let reconnecting: continuity::rpc::SharedEthProvider =
-            Arc::new(continuity::rpc::ReconnectingEthRpcProvider::new(eth_client));
+        let reconnecting: continuity::rpc::SharedEthProvider = Arc::new(
+            continuity::rpc::ReconnectingEthRpcProvider::new(eth_client, chain_encoding),
+        );
 
         let eth_provider: continuity::rpc::SharedEthProvider =
             if let Some(ref archiver_url) = chain.archiver_url {

--- a/query-cli/src/batch_verification.rs
+++ b/query-cli/src/batch_verification.rs
@@ -8,7 +8,6 @@ use anyhow::{anyhow, Result};
 use attestor_primitives::block::{Block, ContinuityProof};
 
 use eth::Client;
-use usc_abi_encoding::common::EncodingVersion;
 use utils::block_item_traits::BlockItem;
 
 use crate::merkle;
@@ -328,7 +327,8 @@ pub async fn execute_batch_query(
 
     // Create Ethereum client
     let eth_client = Client::new(&eth_rpc_url, None).await?;
-    let encoding = EncodingVersion::V1;
+    // Source-chain block encoding from CC3 metadata, instead of assuming V1.
+    let encoding = crate::encoding::resolve_chain_encoding(&cc3_rpc_url, chain_key).await;
 
     // Create batch verifier with eth_rpc_url stored
     let config = BatchVerificationConfig {

--- a/query-cli/src/encoding.rs
+++ b/query-cli/src/encoding.rs
@@ -1,0 +1,41 @@
+//! Resolve the source-chain block encoding from CC3 supported-chain metadata.
+//!
+//! The query CLI used to hardcode [`EncodingVersion::V1`] in both the batch and
+//! interactive paths. This helper instead reads the chain's configured
+//! `chain_encoding` so a per-chain or future encoding change is honoured. If the
+//! chain cannot be resolved we fall back to V1 (the only encoding in existence
+//! today) and warn, rather than failing the query outright.
+
+use cc_client::Client as CcClient;
+use usc_abi_encoding::common::EncodingVersion;
+
+/// Fetch the configured block encoding for `chain_key` from CC3, defaulting to
+/// [`EncodingVersion::V1`] when the lookup fails or the chain is unknown.
+pub(crate) async fn resolve_chain_encoding(cc3_rpc_url: &str, chain_key: u64) -> EncodingVersion {
+    match CcClient::new_read_only(cc3_rpc_url).await {
+        Ok(client) => match client.get_supported_chain(chain_key).await {
+            Ok(Some(chain)) => EncodingVersion::from(chain.chain_encoding),
+            Ok(None) => {
+                eprintln!(
+                    "Warning: supported chain {chain_key} not found while resolving block \
+                     encoding; defaulting to V1"
+                );
+                EncodingVersion::V1
+            }
+            Err(e) => {
+                eprintln!(
+                    "Warning: failed to fetch supported chain {chain_key} encoding ({e}); \
+                     defaulting to V1"
+                );
+                EncodingVersion::V1
+            }
+        },
+        Err(e) => {
+            eprintln!(
+                "Warning: failed to connect to CC3 at {cc3_rpc_url} to resolve block encoding \
+                 ({e}); defaulting to V1"
+            );
+            EncodingVersion::V1
+        }
+    }
+}

--- a/query-cli/src/main.rs
+++ b/query-cli/src/main.rs
@@ -5,6 +5,7 @@ use utils::block_item_traits::BlockItem;
 
 mod attestation;
 mod batch_verification;
+mod encoding;
 mod merkle;
 mod native_transfer;
 mod prompt;
@@ -559,7 +560,10 @@ async fn handle_interactive_query(
         block_height: None,
         txn_hash: None,
     };
-    let prompt_output = prompt::prompt(prompt_args)?;
+    let mut prompt_output = prompt::prompt(prompt_args)?;
+
+    // Override the placeholder encoding with the chain's configured value from CC3.
+    prompt_output.encoding = encoding::resolve_chain_encoding(&cc3_rpc_url, chain_key).await;
 
     // Submit the query
     let params = NativeQueryParams {

--- a/query-cli/src/main.rs
+++ b/query-cli/src/main.rs
@@ -381,7 +381,14 @@ pub async fn submit_native_query(params: NativeQueryParams) -> Result<(), Box<dy
         txn_hash: params.txn_hash,
     };
 
-    let prompt_output = prompt_user(prompt_args).expect("Failed to prompt user");
+    let mut prompt_output = prompt_user(prompt_args).expect("Failed to prompt user");
+
+    // Resolve the source-chain block encoding from CC3 metadata, replacing the
+    // prompt's V1 placeholder. This is the single point that fetches and decodes
+    // the block (`get_block` below), so both the CLI and interactive entry points
+    // get the correct encoding here.
+    prompt_output.encoding =
+        encoding::resolve_chain_encoding(&params.cc3_rpc_url, params.chain_key).await;
 
     // Step 2: Fetch block data from source chain
     println!("\n=== Fetching Block Data ===");
@@ -560,12 +567,10 @@ async fn handle_interactive_query(
         block_height: None,
         txn_hash: None,
     };
-    let mut prompt_output = prompt::prompt(prompt_args)?;
+    let prompt_output = prompt::prompt(prompt_args)?;
 
-    // Override the placeholder encoding with the chain's configured value from CC3.
-    prompt_output.encoding = encoding::resolve_chain_encoding(&cc3_rpc_url, chain_key).await;
-
-    // Submit the query
+    // Submit the query (encoding is resolved from CC3 inside submit_native_query,
+    // which is the single point that actually fetches/decodes the block).
     let params = NativeQueryParams {
         cc3_rpc_url,
         cc3_evm_private_key,

--- a/query-cli/src/prompt.rs
+++ b/query-cli/src/prompt.rs
@@ -19,7 +19,8 @@ pub(crate) fn prompt(args: PromptArgs) -> Result<PromptOutput> {
     // Prompt the user for block height and transaction hash
     let (tx_height, tx_hash) = prompt_for_height_and_hash(args.clone());
 
-    // For now we hardcode the only version we support
+    // Placeholder encoding; the interactive handler overrides this with the
+    // chain's configured `chain_encoding` fetched from CC3 before use.
     let encoding = EncodingVersion::V1;
 
     // Display the collected information


### PR DESCRIPTION
## Audit item: off-chain paths hardcode EncodingVersion::V1

Off-chain attestation and proof-generation paths hardcoded `EncodingVersion::V1`, so a per-chain or future encoding change would silently drift between attestors, proof-gen, and query tooling. This fetches the chain's configured `chain_encoding` from CC3 supported-chain metadata at startup and threads the derived `EncodingVersion` through the live block-fetching paths.

### Changes
- **continuity**: `ReconnectingEthRpcProvider` carries an `encoding`, resolved from CC3 (`get_supported_chain`) at build time in both `ContinuityBuilder` constructors and in proof-gen-api startup (reuses the `supported_chain` already fetched there). All 5 `get_block`/`create` call-sites use it instead of V1.
- **stream_eth roots**: `Config` gains an `encoding` field (defaults to V1 so existing builders keep working); the attestor sets it from CC3 metadata.
- **attestor genesis**: `wait_for_genesis` takes the derived encoding.
- **query-cli**: new `encoding::resolve_chain_encoding` helper; both the batch and interactive paths resolve from CC3 instead of hardcoding V1.

Fallback to V1 with a warning when the chain can't be resolved (V1 is the only encoding in existence today), rather than failing startup.

### Verification
- Builds: `continuity`, `stream_eth`, `attestor`, `proof-gen-api-server`, `query-cli`
- `cargo test -p continuity` green (23 incl. doctests)
- `cargo fmt` + `cargo clippy -D warnings` clean across all touched crates