### PR TITLE
chore(lockfile): pin frontier/moonbeam forks to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4102,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "evm-tracing-events"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#f969fcb8b4a4e967164ad5617305d6b1e0d54f01"
+source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#2cea7e26e638624a222b24b854fc1098bb739880"
 dependencies = [
  "environmental",
  "ethereum 0.15.0",
@@ -4192,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4204,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "fc-cli"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "clap",
  "ethereum-types 0.14.1",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4238,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "async-trait",
  "ethereum 0.15.0",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "ethereum 0.15.0",
  "ethereum-types 0.14.1",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "ethereum 0.15.0",
  "ethereum-types 0.14.1",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "ethereum 0.15.0",
  "ethereum-types 0.14.1",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "hex",
  "impl-serde 0.4.0",
@@ -4584,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "ethereum 0.15.0",
  "parity-scale-codec",
@@ -4595,7 +4595,7 @@ dependencies = [
 [[package]]
 name = "fp-dynamic-fee"
 version = "1.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "async-trait",
  "sp-core",
@@ -4605,7 +4605,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "ethereum 0.15.0",
  "ethereum-types 0.14.1",
@@ -4617,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "environmental",
  "evm",
@@ -4633,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "ethereum 0.15.0",
  "ethereum-types 0.14.1",
@@ -4649,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4661,7 +4661,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8200,7 +8200,7 @@ dependencies = [
 [[package]]
 name = "moonbeam-client-evm-tracing"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#f969fcb8b4a4e967164ad5617305d6b1e0d54f01"
+source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#2cea7e26e638624a222b24b854fc1098bb739880"
 dependencies = [
  "ethereum-types 0.14.1",
  "evm-tracing-events",
@@ -8216,7 +8216,7 @@ dependencies = [
 [[package]]
 name = "moonbeam-evm-tracer"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#f969fcb8b4a4e967164ad5617305d6b1e0d54f01"
+source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#2cea7e26e638624a222b24b854fc1098bb739880"
 dependencies = [
  "ethereum-types 0.14.1",
  "evm",
@@ -8236,7 +8236,7 @@ dependencies = [
 [[package]]
 name = "moonbeam-primitives-ext"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#f969fcb8b4a4e967164ad5617305d6b1e0d54f01"
+source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#2cea7e26e638624a222b24b854fc1098bb739880"
 dependencies = [
  "ethereum-types 0.14.1",
  "evm-tracing-events",
@@ -8249,7 +8249,7 @@ dependencies = [
 [[package]]
 name = "moonbeam-rpc-core-debug"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#f969fcb8b4a4e967164ad5617305d6b1e0d54f01"
+source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#2cea7e26e638624a222b24b854fc1098bb739880"
 dependencies = [
  "ethereum 0.15.0",
  "ethereum-types 0.14.1",
@@ -8266,7 +8266,7 @@ dependencies = [
 [[package]]
 name = "moonbeam-rpc-core-trace"
 version = "0.6.0"
-source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#f969fcb8b4a4e967164ad5617305d6b1e0d54f01"
+source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#2cea7e26e638624a222b24b854fc1098bb739880"
 dependencies = [
  "ethereum-types 0.14.1",
  "futures 0.3.31",
@@ -8280,7 +8280,7 @@ dependencies = [
 [[package]]
 name = "moonbeam-rpc-core-types"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#f969fcb8b4a4e967164ad5617305d6b1e0d54f01"
+source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#2cea7e26e638624a222b24b854fc1098bb739880"
 dependencies = [
  "ethereum-types 0.14.1",
  "serde",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "moonbeam-rpc-debug"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#f969fcb8b4a4e967164ad5617305d6b1e0d54f01"
+source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#2cea7e26e638624a222b24b854fc1098bb739880"
 dependencies = [
  "ethereum 0.15.0",
  "ethereum-types 0.14.1",
@@ -8323,7 +8323,7 @@ dependencies = [
 [[package]]
 name = "moonbeam-rpc-primitives-debug"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#f969fcb8b4a4e967164ad5617305d6b1e0d54f01"
+source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#2cea7e26e638624a222b24b854fc1098bb739880"
 dependencies = [
  "environmental",
  "ethereum 0.15.0",
@@ -8341,7 +8341,7 @@ dependencies = [
 [[package]]
 name = "moonbeam-rpc-trace"
 version = "0.6.0"
-source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#f969fcb8b4a4e967164ad5617305d6b1e0d54f01"
+source = "git+https://github.com/gluwa/moonbeam?branch=gluwa_stable_2409#2cea7e26e638624a222b24b854fc1098bb739880"
 dependencies = [
  "ethereum 0.15.0",
  "ethereum-types 0.14.1",
@@ -9155,7 +9155,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "pallet-dynamic-fee"
 version = "4.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "fp-dynamic-fee",
  "fp-evm",
@@ -9184,7 +9184,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "ethereum 0.15.0",
  "ethereum-types 0.14.1",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "environmental",
  "evm",
@@ -9230,7 +9230,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9309,7 +9309,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "fp-evm",
  "num",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9485,7 +9485,7 @@ dependencies = [
 [[package]]
 name = "pallet-hotfix-sufficients"
 version = "1.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10287,7 +10287,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "derive_more 1.0.0",
  "environmental",
@@ -10316,7 +10316,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#303a1d9373eb9fb55ffdf611ece06203aaad0051"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2409_patch#19ad069627ea422dceba63b1f7defd1f48faafbb"
 dependencies = [
  "case",
  "num_enum 0.7.3",


### PR DESCRIPTION
See https://github.com/gluwa/frontier_2/commit/19ad069627ea422dceba63b1f7defd1f48faafbb

Audit item:

> 2. add block hash param to evm calls
>
> Unknown blockHash should return a JSON-RPC error as recommended by EIP-1898, instead of falling through to zero/default/empty results or treating it as pending.
https://eips.ethereum.org/EIPS/eip-1898
(If the block is not found, the callee SHOULD raise a JSON-RPC error (the recommended error code is -32001: Resource not found).)

>Fix native_block_id to distinguish an explicit hash lookup miss from pending, and propagate that miss as an RPC error in state/execute methods instead of returning None.
