### PR TITLE
fix(continuity,eth): propagate Interrupt::Stop as graceful shutdown instead of panicking

### DIFF
--- a/common/continuity/src/rpc.rs
+++ b/common/continuity/src/rpc.rs
@@ -68,6 +68,18 @@ impl ReconnectingEthRpcProvider {
             match call(client).await {
                 Ok(value) => return Ok(value),
                 Err(err) => {
+                    // A user-initiated shutdown (Ctrl+C / service stop) surfaces here as an
+                    // `anyhow::Error` carrying `user::Shutdown` (via `propagate_shutdown` in the
+                    // block-fetch closures). It is not a transport failure, so do not reconnect
+                    // or burn the remaining retry budget — return immediately so the service
+                    // exits promptly.
+                    if err.chain().any(|cause| cause.is::<user::Shutdown>()) {
+                        warn!(
+                            op,
+                            attempt, "ETH RPC call interrupted by shutdown; not retrying"
+                        );
+                        return Err(err);
+                    }
                     if eth::anyhow_chain_is_inconsistent_block_payload(&err) {
                         warn!(
                             op,

--- a/common/continuity/src/rpc.rs
+++ b/common/continuity/src/rpc.rs
@@ -389,7 +389,10 @@ impl EthRpcProvider for ReconnectingEthRpcProvider {
             let ordered = client
                 .get_block(block_number, encoding)
                 .await
-                .unwrap_interrupt("Not handling user interrupts yet")
+                // Propagate a user-initiated `Interrupt::Stop` as a typed `Shutdown` error
+                // (carried inside this `anyhow::Error`) instead of panicking, so Ctrl+C /
+                // service shutdown exits gracefully.
+                .propagate_shutdown::<anyhow::Error>()
                 .context("Failed to fetch block transactions")?;
 
             Ok(ordered.items().iter().map(|item| item.to_bytes()).collect())
@@ -403,7 +406,7 @@ impl EthRpcProvider for ReconnectingEthRpcProvider {
             let ordered = client
                 .get_block(block_number, encoding)
                 .await
-                .unwrap_interrupt("Not handling user interrupts yet")
+                .propagate_shutdown::<anyhow::Error>()
                 .context("Failed to fetch block")?;
 
             Ok(ordered.items().get(tx_index as usize).map(|item| {
@@ -426,7 +429,7 @@ impl EthRpcProvider for ReconnectingEthRpcProvider {
             let ordered = client
                 .get_block(block_number, encoding)
                 .await
-                .unwrap_interrupt("Not handling user interrupts yet")
+                .propagate_shutdown::<anyhow::Error>()
                 .context("Failed to fetch block")?;
 
             let bytes = ordered.items().iter().map(|item| item.to_bytes()).collect();
@@ -445,7 +448,7 @@ impl EthRpcProvider for ReconnectingEthRpcProvider {
             let ordered = client
                 .get_block(block_number, encoding)
                 .await
-                .unwrap_interrupt("Not handling user interrupts yet")
+                .propagate_shutdown::<anyhow::Error>()
                 .context("Failed to fetch block")?;
 
             Ok(ordered

--- a/common/eth/src/continuity.rs
+++ b/common/eth/src/continuity.rs
@@ -24,6 +24,10 @@ pub enum Error {
     BlockError(#[from] BlockError),
     #[error("MMR computation join error: {0}")]
     JoinError(#[from] tokio::task::JoinError),
+    /// A user-initiated `Interrupt::Stop` (Ctrl+C / service shutdown) propagated out of a block
+    /// fetch. Surfaced as a typed error so callers exit gracefully instead of panicking.
+    #[error(transparent)]
+    Shutdown(#[from] user::Shutdown),
 }
 
 pub struct Manager<'a> {
@@ -58,10 +62,13 @@ impl<'a> Manager<'a> {
             .collect::<Vec<_>>()
             .await;
 
+        // Propagate a user-initiated `Interrupt::Stop` as `Error::Shutdown` instead of
+        // panicking, so Ctrl+C / service shutdown exits gracefully. `Interrupt::Cont` errors
+        // map to `Error::Eth` as before.
         let collected_blocks = blocks
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .unwrap_interrupt("Not handling user interrupts yet")?;
+            .propagate_shutdown::<Error>()?;
 
         // Spawn MMR computations in parallel threads
         let blocks_with_roots = stream::iter(collected_blocks)

--- a/common/streams/eth/src/error.rs
+++ b/common/streams/eth/src/error.rs
@@ -2,6 +2,18 @@
 pub enum Error {
     Client(eth::Error),
     StreamEnd,
+    /// A user-initiated `Interrupt::Stop` (Ctrl+C / service shutdown) propagated out of a block
+    /// fetch. This is **not** a connection failure: the outer `StreamRoots` layer recognizes it
+    /// and exits cleanly instead of attempting to reconnect.
+    Shutdown,
+}
+
+impl Error {
+    /// True when this error represents a user-initiated graceful shutdown rather than a
+    /// recoverable connection failure. Callers must not reconnect on this.
+    pub fn is_shutdown(&self) -> bool {
+        matches!(self, Self::Shutdown)
+    }
 }
 
 impl std::fmt::Display for Error {
@@ -9,6 +21,7 @@ impl std::fmt::Display for Error {
         match self {
             Self::Client(err) => write!(f, "{err}"),
             Self::StreamEnd => write!(f, "Unexpected end of stream"),
+            Self::Shutdown => write!(f, "shutdown requested"),
         }
     }
 }

--- a/common/streams/eth/src/roots.rs
+++ b/common/streams/eth/src/roots.rs
@@ -104,6 +104,22 @@ impl StreamRoots {
                                     }
                                 });
                             },
+                            Some(Err(err)) if err.is_shutdown() => {
+                                // User-initiated shutdown (Ctrl+C / service stop) propagated up
+                                // from the inner block stream. This is NOT a connection failure:
+                                // drain in-flight root computations and terminate the outer
+                                // stream cleanly instead of reconnecting.
+                                tracing::info!("Eth root stream shutting down on user interrupt");
+                                roots.abort_all();
+                                while !roots.is_empty() {
+                                    if let Some(Err(err)) = roots.join_next().await {
+                                        if err.is_panic() {
+                                            std::panic::resume_unwind(err.into_panic());
+                                        }
+                                    }
+                                }
+                                return;
+                            },
                             Some(Err(err)) => {
                                 // Failed to retrieve source chain block, try and regenerate the
                                 // stream (this can only be an RPC error)
@@ -291,7 +307,14 @@ async fn stream_rpc(config: Config) -> stream_util::BoxedStream<Result<eth::Orde
                             {
                                 Ok(Ok(block)) => yield Ok(block),
                                 Ok(Err(Interrupt::Cont(err))) => yield Err(err),
-                                Ok(Err(Interrupt::Stop)) => break,
+                                // User-initiated shutdown: surface a typed `Shutdown` error and
+                                // terminate the stream. The outer `StreamRoots` layer recognizes
+                                // this and exits cleanly instead of treating the stream end as a
+                                // connection failure and reconnecting.
+                                Ok(Err(Interrupt::Stop)) => {
+                                    yield Err(Error::Shutdown);
+                                    return;
+                                }
                                 Err(err) => {
                                     if err.is_panic() {
                                         std::panic::resume_unwind(err.into_panic());
@@ -322,7 +345,12 @@ async fn stream_rpc(config: Config) -> stream_util::BoxedStream<Result<eth::Orde
                     {
                         Ok(Ok(block)) => yield Ok(block),
                         Ok(Err(Interrupt::Cont(err))) => yield Err(err),
-                        Ok(Err(Interrupt::Stop)) => break,
+                        // User-initiated shutdown: surface a typed `Shutdown` error and terminate
+                        // the stream so the outer layer exits cleanly rather than reconnecting.
+                        Ok(Err(Interrupt::Stop)) => {
+                            yield Err(Error::Shutdown);
+                            return;
+                        }
                         Err(err) => {
                             if err.is_panic() {
                                 std::panic::resume_unwind(err.into_panic());

--- a/primitives/user/src/lib.rs
+++ b/primitives/user/src/lib.rs
@@ -22,8 +22,29 @@ pub mod prelude {
     pub use crate::Interrupt;
     pub use crate::MapInterrupt;
     pub use crate::OkInterrupt;
+    pub use crate::Shutdown;
+    pub use crate::ShutdownInterrupt;
     pub use crate::UnwrapInterrupt;
 }
+
+/// Typed marker error representing a user-initiated graceful shutdown (e.g. Ctrl+C /
+/// service stop) that propagated out of an [`Interrupt::Stop`].
+///
+/// Production code paths convert [`Interrupt::Stop`] into this error (via
+/// [`ShutdownInterrupt::propagate_shutdown`]) instead of panicking. Because it implements
+/// [`std::error::Error`], it can be carried inside an `anyhow::Error` and recognized by outer
+/// layers (which downcast for it) so that a shutdown results in a clean exit rather than a
+/// reconnect attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Shutdown;
+
+impl std::fmt::Display for Shutdown {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "shutdown requested")
+    }
+}
+
+impl std::error::Error for Shutdown {}
 
 #[derive(Debug)]
 pub enum Interrupt<T> {
@@ -84,6 +105,35 @@ impl<T, E> UnwrapInterrupt<T, E> for Result<T, Interrupt<E>> {
             Ok(ok) => Ok(ok),
             Err(Interrupt::Cont(err)) => Err(err),
             Err(Interrupt::Stop) => panic!("{msg}"),
+        }
+    }
+}
+
+/// Propagate an [`Interrupt`] as an ordinary error **without panicking on [`Interrupt::Stop`]**.
+///
+/// Unlike [`UnwrapInterrupt::unwrap_interrupt`] (which panics on `Stop`, and is therefore only
+/// safe in code that never receives a user interrupt), this converts:
+/// - [`Interrupt::Cont(err)`] into the underlying error `err`, and
+/// - [`Interrupt::Stop`] into the typed [`Shutdown`] marker error,
+///
+/// both projected into the caller's chosen error type `F` via [`From`]. With an `anyhow::Error`
+/// target this lets shutdown flow out of production block-fetch paths as a normal `Result::Err`
+/// that outer layers can recognize (by downcasting to [`Shutdown`]) and treat as a clean exit.
+pub trait ShutdownInterrupt<T, E> {
+    fn propagate_shutdown<F>(self) -> Result<T, F>
+    where
+        F: From<E> + From<Shutdown>;
+}
+
+impl<T, E> ShutdownInterrupt<T, E> for Result<T, Interrupt<E>> {
+    fn propagate_shutdown<F>(self) -> Result<T, F>
+    where
+        F: From<E> + From<Shutdown>,
+    {
+        match self {
+            Ok(ok) => Ok(ok),
+            Err(Interrupt::Cont(err)) => Err(F::from(err)),
+            Err(Interrupt::Stop) => Err(F::from(Shutdown)),
         }
     }
 }


### PR DESCRIPTION
Two linked audit findings on the ETH block-fetching / continuity / proof-gen shutdown paths.

## 1. `unwrap_interrupt()` panics on user Stop

> *Audit: "`unwrap_interrupt()` treats the user-issued Stop signal as a panic ... Ctrl+C or service shutdown may trigger a panic instead of a graceful exit. Remove `unwrap_interrupt()` from production paths and propagate Stop upward as an explicit typed error such as `ServiceError::Shutdown`."*

No pre-existing reusable `ServiceError` was suitable for these crates (the `proof-gen-api-server` one is HTTP-layer and not a dependency here). Added a dependency-free typed `Shutdown` marker error to `primitives/user` plus a `ShutdownInterrupt::propagate_shutdown::<F>()` trait method that maps `Interrupt::Cont(e) -> e` and `Interrupt::Stop -> Shutdown`, projected into the caller's error type via `From`.

- **continuity/rpc.rs** (4 closures): `.unwrap_interrupt("…")` → `.propagate_shutdown::<anyhow::Error>()`. `Stop` now flows out as an `anyhow::Error` carrying `Shutdown` (downcastable) instead of panicking; `.context(...)` preserved.
- **eth/continuity.rs**: new `Error::Shutdown(#[from] user::Shutdown)` variant; `.propagate_shutdown::<Error>()` on the buffered-block collection. `Interrupt::Cont` still maps to `Error::Eth`.

`unwrap_interrupt` itself is **left defined** in `primitives/user` (only removed from the production call sites) — grep confirmed the only remaining users were these sites; leaving the definition is the conservative choice for any non-production/test callers.

## 2. Stop misread as a connection failure → spurious reconnect

> *Audit: "If a spawned block fetch returns `Interrupt::Stop`, the inner stream terminates, but the outer `StreamRoots` layer may interpret this as a connection failure and attempt to reconnect. Preserve `Interrupt::Stop` through `stream_rpc` ... so Stop results in a clean exit rather than a reconnect attempt."*

- Added `Error::Shutdown` + `is_shutdown()` to `streams/eth::Error`.
- In `stream_rpc`, the two `Interrupt::Stop` sites previously did `break` (ending the inner stream, which the outer layer misread as "connection lost" → reconnect). They now `yield Err(Error::Shutdown); return;` so Stop is surfaced as a distinct typed signal.
- In `StreamRoots`, a new guard arm `Some(Err(err)) if err.is_shutdown()` drains in-flight root computations and returns (clean exit). All other errors keep the existing reconnect-with-backoff. **Stop ⇒ clean exit, transport error ⇒ reconnect.**

## Files
`primitives/user/src/lib.rs`, `common/continuity/src/rpc.rs`, `common/eth/src/continuity.rs`, `common/streams/eth/src/error.rs`, `common/streams/eth/src/roots.rs`

## Verification
- `cargo fmt` ✅
- `cargo build` / `cargo clippy -- -D warnings` ✅ clean on `user`, `eth`, `continuity`, `stream_eth`
- No unit tests exist for these paths (verified via grep); none forced.
