### PR TITLE
Raise Utilized Compute Per Block to Match Polkadot Standard

### DIFF
--- a/cli/src/scripts/prover-check.ts
+++ b/cli/src/scripts/prover-check.ts
@@ -183,9 +183,7 @@ async function main(
     }
     const blockGasLimit = latestBlock.gasLimit;
     const totalGasThreshold = (blockGasLimit * 7n) / 10n;
-    console.log(
-        `**** INFO: on-chain EVM block gas limit = ${blockGasLimit}, 70% threshold = ${totalGasThreshold}`,
-    );
+    console.log(`**** INFO: on-chain EVM block gas limit = ${blockGasLimit}, 70% threshold = ${totalGasThreshold}`);
 
     const sleepTime = parseInt(process.env.SLEEP_TIME || '500', 10);
     for (const blockNumber of blocksToInspect) {

--- a/cli/src/scripts/prover-check.ts
+++ b/cli/src/scripts/prover-check.ts
@@ -173,6 +173,20 @@ async function main(
     const verifyAndEmitSingleFragment =
         'verifyAndEmit(uint64,uint64,bytes,(bytes32,(bytes32,bool)[]),(bytes32,bytes32[]))';
 
+    // Read the EVM block gas limit from chain instead of hard-coding it, so this check tracks the
+    // runtime's configured `BlockGasLimit` (which changes across releases). Frontier reports that
+    // configured limit as the block `gasLimit` over the standard eth RPC, so any finalized block
+    // carries the current value. Fetched once since it is constant for a given runtime.
+    const latestBlock = await creditcoinWs.getBlock('finalized');
+    if (latestBlock === null || latestBlock.gasLimit <= 0n) {
+        throw new Error('could not read EVM block gas limit from chain');
+    }
+    const blockGasLimit = latestBlock.gasLimit;
+    const totalGasThreshold = (blockGasLimit * 7n) / 10n;
+    console.log(
+        `**** INFO: on-chain EVM block gas limit = ${blockGasLimit}, 70% threshold = ${totalGasThreshold}`,
+    );
+
     const sleepTime = parseInt(process.env.SLEEP_TIME || '500', 10);
     for (const blockNumber of blocksToInspect) {
         console.log(`... get proof for source chain block ${blockNumber}`);
@@ -231,14 +245,11 @@ async function main(
             console.log(`    ... decoded as type ${decoded.type}, gasForDecoding=${gasForDecoding}`);
         }
 
-        // Add a 10% safety margin to the raw estimates and reject if the
-        // combined cost crosses 70% of the 75M block gas limit. Using bigint
-        // math (11/10 and 7/10) keeps the value precise and consistent with
-        // the rest of the script. The 70% threshold is an explicit decision;
-        // see commit log + linked Slack thread for context.
+        // Add a 10% safety margin to the raw estimates and reject if the combined cost crosses 70%
+        // of the on-chain block gas limit (read above). Using bigint math (11/10 and 7/10) keeps
+        // the value precise and consistent with the rest of the script. The 70% threshold is an
+        // explicit decision; see commit log + linked Slack thread for context.
         const totalGas = ((gasForVerification + gasForDecoding) * 11n) / 10n;
-        const blockGasLimit = 75_000_000n;
-        const totalGasThreshold = (blockGasLimit * 7n) / 10n;
         console.log(`    ... totalGas (with 10% margin)=${totalGas} (threshold=${totalGasThreshold})`);
         if (totalGas >= totalGasThreshold) {
             throw new Error(

--- a/cli/src/test/alphabeticalSequencer.js
+++ b/cli/src/test/alphabeticalSequencer.js
@@ -1,9 +1,9 @@
 const Sequencer = require('@jest/test-sequencer').default;
 
 class AlphabeticalSequencer extends Sequencer {
-  sort(tests) {
-    return tests.sort((a, b) => a.path.localeCompare(b.path));
-  }
+    sort(tests) {
+        return tests.sort((a, b) => a.path.localeCompare(b.path));
+    }
 }
 
 module.exports = AlphabeticalSequencer;

--- a/cli/src/test/blockchain-tests/precompiles/attestor-stash.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/attestor-stash.test.ts
@@ -35,7 +35,7 @@ describe('Precompile: AttestorStash', (): void => {
     let gasPrice: bigint;
     // PoV-heavy calls need an explicit gas limit; auto-estimate under-counts the
     // proof-size component (5 KB @ ratio 14.3 → ~72 K PoV gas alone).
-    const GAS_LIMIT = 300_000;
+    const GAS_LIMIT = 1_000_000;
 
     // Alith's derived Substrate account (via HashedAddressMapping<BlakeTwo256>).
     // This is the `stash` AccountId used by pallet-attestation when the precompile

--- a/cli/src/test/blockchain-tests/precompiles/attestor-stash.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/attestor-stash.test.ts
@@ -32,10 +32,25 @@ describe('Precompile: AttestorStash', (): void => {
     let provider: any;
     let alith: any;
     let api: ApiPromise;
-    let gasPrice: bigint;
     // PoV-heavy calls need an explicit gas limit; auto-estimate under-counts the
     // proof-size component (5 KB @ ratio 14.3 → ~72 K PoV gas alone).
-    const GAS_LIMIT = 1_000_000;
+    const GAS_LIMIT = 20_000_000;
+
+    // Build fee overrides for a state-changing tx. We use EIP-1559 fields rather
+    // than a pinned legacy `gasPrice`: pallet-base-fee lets the block base fee
+    // drift up as earlier blocks fill past the 50% ideal, and a legacy tx whose
+    // `gasPrice` sits below the current base fee is pool-accepted but never mined,
+    // so `tx.wait()` hangs until the jest timeout. `maxFeePerGas` is a ceiling
+    // (not the price paid), so the tx stays includable across base-fee drift while
+    // still only being charged base fee + tip. Fetched fresh at call time.
+    const feeOverrides = async () => {
+        const fee = await provider.getFeeData();
+        return {
+            maxFeePerGas: fee.maxFeePerGas ?? fee.gasPrice * 2n,
+            maxPriorityFeePerGas: fee.maxPriorityFeePerGas ?? 1_000_000_000n,
+            gasLimit: GAS_LIMIT,
+        };
+    };
 
     // Alith's derived Substrate account (via HashedAddressMapping<BlakeTwo256>).
     // This is the `stash` AccountId used by pallet-attestation when the precompile
@@ -73,10 +88,6 @@ describe('Precompile: AttestorStash', (): void => {
         await api.disconnect();
     });
 
-    beforeEach(async () => {
-        gasPrice = (await provider.getFeeData()).gasPrice;
-    });
-
     // -----------------------------------------------------------------------------
     // registerAttestor
     // -----------------------------------------------------------------------------
@@ -86,7 +97,7 @@ describe('Precompile: AttestorStash', (): void => {
         const before = await api.query.attestation.attestors(chainKey, attestorId);
         expect(before.isSome).toBe(false);
 
-        const tx = await contract.registerAttestor(chainKey, attestorId, { gasPrice, gasLimit: GAS_LIMIT });
+        const tx = await contract.registerAttestor(chainKey, attestorId, await feeOverrides());
         const receipt = await tx.wait();
         expect(receipt.status).toBe(1);
 
@@ -212,7 +223,7 @@ describe('Precompile: AttestorStash', (): void => {
     // -----------------------------------------------------------------------------
 
     test('unregisterAttestor succeeds, removes Attestors storage entry, and emits AttestorUnregistered', async () => {
-        const tx = await contract.unregisterAttestor(chainKey, attestorId, { gasPrice, gasLimit: GAS_LIMIT });
+        const tx = await contract.unregisterAttestor(chainKey, attestorId, await feeOverrides());
         const receipt = await tx.wait();
         expect(receipt.status).toBe(1);
 
@@ -229,7 +240,7 @@ describe('Precompile: AttestorStash', (): void => {
         expect(log.topics[1]).toBe(chainKeyTopic(chainKey));
         expect(log.topics[2]).toBe(attestorId.toLowerCase());
         expect(log.topics[3]).toBe(addressTopic(alith.address));
-    }, 60_000);
+    }, 120_000);
 
     test('unregisterAttestor a second time reverts (AddressNotAttestor)', async () => {
         await expect(contract.unregisterAttestor.staticCall(chainKey, attestorId)).rejects.toThrow(
@@ -253,12 +264,10 @@ describe('Precompile: AttestorStash', (): void => {
             const unbondingPeriod: number = api.consts.attestation.bondingDuration.toNumber();
             await waitEras(unbondingPeriod + 1, api);
 
-            // Refresh `gasPrice` now that several minutes have elapsed: the
-            // EIP-1559 base fee cached in `beforeEach` has drifted and submitting
-            // with the stale value yields "gas price less than block base fee".
-            gasPrice = (await provider.getFeeData()).gasPrice;
-
-            const tx = await contract.withdrawUnbonded({ gasPrice, gasLimit: GAS_LIMIT });
+            // `feeOverrides()` fetches fresh EIP-1559 fields at call time, so the
+            // several-minute wait above (during which the base fee drifts) is
+            // handled without a stale legacy `gasPrice`.
+            const tx = await contract.withdrawUnbonded(await feeOverrides());
             const receipt = await tx.wait();
             expect(receipt.status).toBe(1);
 

--- a/cli/src/test/blockchain-tests/precompiles/ed25519-verifier.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/ed25519-verifier.test.ts
@@ -15,7 +15,7 @@ describe('Precompile: Ed25519Verifier.verify()', (): void => {
     let alith: any;
     let api: ApiPromise;
     let gasPrice: bigint;
-    let gasLimit: number;
+    let gasLimit: bigint;
     let keyring: Keyring;
 
     beforeAll(async () => {
@@ -40,7 +40,19 @@ describe('Precompile: Ed25519Verifier.verify()', (): void => {
         // Initialize keyring for ed25519 signatures
         keyring = new Keyring({ type: 'ed25519' });
 
-        gasLimit = 10000000;
+        // Read the EVM block gas limit from chain instead of hard-coding it. The runtime derives
+        // `WeightPerGas` from `BLOCK_GAS_LIMIT`, so the gas cost of a given amount of calldata
+        // changes whenever that constant moves (it was raised 75M -> 180M). A hard-coded limit that
+        // used to be plenty then becomes a silent out-of-gas on the calldata-heavy cases. Frontier
+        // reports the configured `BlockGasLimit` as the block `gasLimit` over the eth RPC, so any
+        // finalized block carries the current value. Using the full block limit is safe here:
+        // successful calls only pay for gas actually used, and the revert tests just need enough
+        // gas to reach the on-chain check rather than dying out-of-gas first.
+        const latestBlock = await provider.getBlock('finalized');
+        if (latestBlock === null || latestBlock.gasLimit <= 0n) {
+            throw new Error('could not read EVM block gas limit from chain');
+        }
+        gasLimit = latestBlock.gasLimit;
     }, 90_000);
 
     afterAll(async () => {
@@ -115,7 +127,7 @@ describe('Precompile: Ed25519Verifier.verify()', (): void => {
             // Call the precompile
             const result = await contract.verify(messageHex, signatureHex, publicKeyHex, {
                 gasPrice,
-                gasLimit: 20000000, // Higher gas limit for longer message
+                gasLimit,
             });
 
             expect(result).toBe(true);
@@ -324,7 +336,7 @@ describe('Precompile: Ed25519Verifier.verify()', (): void => {
             await expect(
                 contract.verify(messageHex, signatureHex, publicKeyHex, {
                     gasPrice,
-                    gasLimit: 75_000_000,
+                    gasLimit,
                 }),
             ).rejects.toThrow(/Value is too large for length/);
         }, 120_000);

--- a/cli/src/test/blockchain-tests/precompiles/sr25519-verifier.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/sr25519-verifier.test.ts
@@ -15,7 +15,7 @@ describe('Precompile: Sr25519Verifier.verify()', (): void => {
     let alith: any;
     let api: ApiPromise;
     let gasPrice: bigint;
-    let gasLimit: number;
+    let gasLimit: bigint;
     let keyring: Keyring;
 
     beforeAll(async () => {
@@ -40,7 +40,19 @@ describe('Precompile: Sr25519Verifier.verify()', (): void => {
         // Initialize keyring for sr25519 signatures
         keyring = new Keyring({ type: 'sr25519' });
 
-        gasLimit = 10000000;
+        // Read the EVM block gas limit from chain instead of hard-coding it. The runtime derives
+        // `WeightPerGas` from `BLOCK_GAS_LIMIT`, and that cap is profile-gated (180M prod, 60M
+        // fast/devnet), so a hard-coded limit can exceed the block cap or fall short on the
+        // calldata-heavy cases. Frontier reports the configured `BlockGasLimit` as the block
+        // `gasLimit` over the eth RPC, so any finalized block carries the current value. Using the
+        // full block limit is safe here: successful calls only pay for gas actually used, and the
+        // revert tests just need enough gas to reach the on-chain check rather than dying
+        // out-of-gas first.
+        const latestBlock = await provider.getBlock('finalized');
+        if (latestBlock === null || latestBlock.gasLimit <= 0n) {
+            throw new Error('could not read EVM block gas limit from chain');
+        }
+        gasLimit = latestBlock.gasLimit;
     }, 90_000);
 
     afterAll(async () => {
@@ -115,7 +127,7 @@ describe('Precompile: Sr25519Verifier.verify()', (): void => {
             // Call the precompile
             const result = await contract.verify(messageHex, signatureHex, publicKeyHex, {
                 gasPrice,
-                gasLimit: 20000000, // Higher gas limit for longer message
+                gasLimit,
             });
 
             expect(result).toBe(true);
@@ -293,7 +305,7 @@ describe('Precompile: Sr25519Verifier.verify()', (): void => {
             await expect(
                 contract.verify(messageHex, signatureHex, publicKeyHex, {
                     gasPrice,
-                    gasLimit: 75_000_000,
+                    gasLimit,
                 }),
             ).rejects.toThrow(/Value is too large for length/);
         }, 120_000);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -429,20 +429,27 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
     }
 }
 
-/// EVM gas available per block. Raised from 75_000_000 (2.4x) so that large
-/// cross-chain operations — e.g. verifying + decoding a Sepolia transaction — fit
-/// within a single block, which they previously could not.
+/// EVM gas available per block. The prod value was raised from 75_000_000 (2.4x)
+/// so that large cross-chain operations — e.g. verifying + decoding a Sepolia
+/// transaction — fit within a single (15s) block, which they previously could not.
 ///
-/// Kept UNIFORM across all profiles (not macro-gated) so that `fast-runtime`
-/// and `devnet` can reproduce the same oversized transactions as prod in tests.
+/// Macro-gated to track `WEIGHT_MILLISECS_PER_BLOCK`. `WeightPerGas` is derived as
+/// `NORMAL_DISPATCH_RATIO * WEIGHT_MILLISECS_PER_BLOCK * WEIGHT_REF_TIME_PER_MILLIS
+/// / BLOCK_GAS_LIMIT` (see below). The compute budget (`WEIGHT_MILLISECS_PER_BLOCK`)
+/// is itself profile-gated (5000/1666/1666 ms), so leaving this cap uniform made the
+/// derived gas->weight price diverge per profile (~20_833 ref_time/gas in prod vs
+/// ~6_941 under fast/devnet). That skew inflated EVM gas estimates ~2.9x on
+/// fast/devnet, which silently broke fee/funding assumptions calibrated against
+/// prod (e.g. accounts funded by the bridge example scripts ran out of gas).
 ///
-/// `WeightPerGas` is derived from this together with `WEIGHT_MILLISECS_PER_BLOCK`
-/// (see below). Because the compute budget is profile-gated while this limit is
-/// not, the derived gas->weight price intentionally differs per profile:
-/// ~20_833 ref_time/gas in prod vs ~6_941 under fast/devnet. That divergence is
-/// expected and acceptable — `fast-runtime` validates behavior, not prod weight
-/// calibration.
-const BLOCK_GAS_LIMIT: u64 = 180_000_000;
+/// Scaling the cap by the same prod:devnet:fast ratio (≈ 180M × 1666/5000 = 60M)
+/// keeps `WeightPerGas` ~constant (~20_833) across all profiles, so precompile gas
+/// costs and fee estimates match prod everywhere. This does lower the fast/devnet
+/// block gas *ceiling* to 60M; that does not reduce reproducible compute (the
+/// binding constraint there is the profile-gated block *weight*, unchanged), only
+/// the maximum single-tx calldata size — which is far above any real cross-chain
+/// payload and still clears the 3 MB precompile size-limit tests.
+const BLOCK_GAS_LIMIT: u64 = prod_devnet_fast!(180_000_000, 60_000_000, 60_000_000);
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 /// The maximum storage growth per block in bytes.
 const MAX_STORAGE_GROWTH: u64 = 400 * 1024;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -184,8 +184,23 @@ pub fn native_version() -> sp_version::NativeVersion {
 }
 
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
-/// We allow for 2000ms of compute with a 6 second average block time.
-pub const WEIGHT_MILLISECS_PER_BLOCK: u64 = 2000;
+/// Per-block compute budget: the wall-clock milliseconds of execution the
+/// runtime allows per block. This is distinct from the slot time
+/// `MILLISECS_PER_BLOCK` and must stay a fraction of it, leaving headroom for
+/// block import (every node re-executes the block), gossip and propagation.
+///
+/// It is gated per profile so the duty cycle (compute budget / block time)
+/// stays ~33%, matching Polkadot's 2s/6s relay-chain convention:
+///   - prod   (15s block): 5000ms -> 33%
+///   - devnet ( 5s block): 1666ms -> 33%
+///   - fast   ( 5s block): 1666ms -> 33%
+///
+/// History: this was previously a flat 2000ms (the stock node-template default,
+/// whose comment referenced a 6s block). On Creditcoin's 15s prod block that
+/// was only ~13% — conservative. But it MUST remain macro-gated: a flat 5000ms
+/// would be 100% of a 5s `fast-runtime`/`devnet` slot, starving block import
+/// and stalling the chain. See also `BLOCK_GAS_LIMIT` below.
+pub const WEIGHT_MILLISECS_PER_BLOCK: u64 = prod_devnet_fast!(5_000, 1_666, 1_666);
 pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
     WEIGHT_MILLISECS_PER_BLOCK * WEIGHT_REF_TIME_PER_MILLIS,
     u64::MAX,
@@ -414,7 +429,20 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
     }
 }
 
-const BLOCK_GAS_LIMIT: u64 = 75_000_000;
+/// EVM gas available per block. Raised from 75_000_000 (2.4x) so that large
+/// cross-chain operations — e.g. verifying + decoding a Sepolia transaction — fit
+/// within a single block, which they previously could not.
+///
+/// Kept UNIFORM across all profiles (not macro-gated) so that `fast-runtime`
+/// and `devnet` can reproduce the same oversized transactions as prod in tests.
+///
+/// `WeightPerGas` is derived from this together with `WEIGHT_MILLISECS_PER_BLOCK`
+/// (see below). Because the compute budget is profile-gated while this limit is
+/// not, the derived gas->weight price intentionally differs per profile:
+/// ~20_833 ref_time/gas in prod vs ~6_941 under fast/devnet. That divergence is
+/// expected and acceptable — `fast-runtime` validates behavior, not prod weight
+/// calibration.
+const BLOCK_GAS_LIMIT: u64 = 180_000_000;
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 /// The maximum storage growth per block in bytes.
 const MAX_STORAGE_GROWTH: u64 = 400 * 1024;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -429,27 +429,21 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
     }
 }
 
-/// EVM gas available per block. The prod value was raised from 75_000_000 (2.4x)
-/// so that large cross-chain operations — e.g. verifying + decoding a Sepolia
-/// transaction — fit within a single (15s) block, which they previously could not.
+/// EVM gas available per block. Held UNIFORM at 75_000_000 across all profiles by
+/// requirement — this is the value external tooling and integrators calibrate against,
+/// so it must not vary per profile.
 ///
-/// Macro-gated to track `WEIGHT_MILLISECS_PER_BLOCK`. `WeightPerGas` is derived as
+/// `WeightPerGas` is NOT held constant; it is derived from this cap together with the
+/// (profile-gated) compute budget as
 /// `NORMAL_DISPATCH_RATIO * WEIGHT_MILLISECS_PER_BLOCK * WEIGHT_REF_TIME_PER_MILLIS
-/// / BLOCK_GAS_LIMIT` (see below). The compute budget (`WEIGHT_MILLISECS_PER_BLOCK`)
-/// is itself profile-gated (5000/1666/1666 ms), so leaving this cap uniform made the
-/// derived gas->weight price diverge per profile (~20_833 ref_time/gas in prod vs
-/// ~6_941 under fast/devnet). That skew inflated EVM gas estimates ~2.9x on
-/// fast/devnet, which silently broke fee/funding assumptions calibrated against
-/// prod (e.g. accounts funded by the bridge example scripts ran out of gas).
-///
-/// Scaling the cap by the same prod:devnet:fast ratio (≈ 180M × 1666/5000 = 60M)
-/// keeps `WeightPerGas` ~constant (~20_833) across all profiles, so precompile gas
-/// costs and fee estimates match prod everywhere. This does lower the fast/devnet
-/// block gas *ceiling* to 60M; that does not reduce reproducible compute (the
-/// binding constraint there is the profile-gated block *weight*, unchanged), only
-/// the maximum single-tx calldata size — which is far above any real cross-chain
-/// payload and still clears the 3 MB precompile size-limit tests.
-const BLOCK_GAS_LIMIT: u64 = prod_devnet_fast!(180_000_000, 60_000_000, 60_000_000);
+/// / BLOCK_GAS_LIMIT` (see below). Because `WEIGHT_MILLISECS_PER_BLOCK` is gated
+/// (5000/1666/1666 ms) while this cap is fixed, the derived gas->weight price varies
+/// per profile — ~50_000 ref_time/gas in prod vs ~16_660 under fast/devnet — which is
+/// exactly what keeps a full 75M-gas block consistent with each profile's normal
+/// dispatch weight budget (3.75e12 in prod, 1.2495e12 under fast/devnet). Deviating
+/// from the derived value would desync the gas and weight limits and cause
+/// "block weight exceeded" drops.
+const BLOCK_GAS_LIMIT: u64 = 75_000_000;
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 /// The maximum storage growth per block in bytes.
 const MAX_STORAGE_GROWTH: u64 = 400 * 1024;


### PR DESCRIPTION
We were under-utilizing our 15 second blocks, treating them as if they were limited to 6 seconds.

This pr fixes that, allowing USC readability to process 2.4x larger transactions without failing.