### PR TITLE
fix(prover-check): skip empty blocks instead of failing on 422

### DIFF
--- a/cli/src/scripts/prover-check.ts
+++ b/cli/src/scripts/prover-check.ts
@@ -39,8 +39,23 @@ function writeToDisk(dirPath: string, proofData: any) {
 
 async function getProofForBlock(apiUrl: string, chainKey: number, blockNumber: bigint) {
     const url = `${apiUrl}/api/v1/proof/${chainKey}/${blockNumber}/0`;
-    // NOTE: throws an exception in case of errors
-    return axios.get(url);
+    try {
+        // NOTE: throws an exception in case of errors
+        return await axios.get(url);
+    } catch (error) {
+        // The prover returns HTTP 422 with code 'EmptyBlockTxProof' for blocks
+        // that contain no transactions; there is no tx proof to verify, so we
+        // treat this as a skip rather than a hard failure. Any other error is
+        // re-thrown so genuine problems still surface and fail the run.
+        if (
+            axios.isAxiosError(error) &&
+            error.response?.status === 422 &&
+            error.response?.data?.code === 'EmptyBlockTxProof'
+        ) {
+            return null;
+        }
+        throw error;
+    }
 }
 
 const fetchCheckpoints = (
@@ -163,6 +178,10 @@ async function main(
         console.log(`... get proof for source chain block ${blockNumber}`);
         await sleep(sleepTime); // rate-limit
         const response = await getProofForBlock(proverBaseUrl, chainKey, blockNumber);
+        if (response === null) {
+            console.log('    ... skipping verification. Empty block, no tx proof available');
+            continue;
+        }
         const proofData = response.data as proofProvider.ContinuityResponse;
         if (proofData.txBytes === undefined) {
             console.log('    ... skipping verification. No transactions in block');


### PR DESCRIPTION
## Problem

The `Check Prover` job [failed](https://github.com/gluwa/creditcoin3/actions/runs/28341144821/job/83955710791) on `cc3-devnet` (CK 1). Root cause:

The prover endpoint `/api/v1/proof/{chainKey}/{block}/0` now returns **HTTP 422** with body:

```json
{ "code": "EmptyBlockTxProof", "message": "block 11157959 is empty; tx proof unavailable (use a continuity-only proof)", "retriable": false }
```

for blocks that contain no transactions. Previously such blocks returned `200` with `txBytes === undefined`, which the script already handled by skipping. Now `axios.get` throws before reaching that guard, killing the whole run.

## Fix

- In `getProofForBlock`, catch the specific `422` / `EmptyBlockTxProof` response and return `null`.
- In the verification loop, skip the block when the response is `null` (mirrors the existing "no transactions in block" skip).
- All other errors are re-thrown, so genuine failures still fail the run.

## Verification

- `yarn check-format` ✅
- `yarn lint` ✅
- `yarn build` ✅
