### PR TITLE
fix(attestation): guard per-stash aggregate bond solvency on unregister (#17)

### DIFF
--- a/pallets/attestation/src/impls.rs
+++ b/pallets/attestation/src/impls.rs
@@ -5,7 +5,7 @@ use frame_support::{
 };
 use log::debug;
 use sp_runtime::{
-    traits::{CheckedAdd, Zero},
+    traits::{CheckedAdd, Saturating, Zero},
     ArithmeticError,
 };
 use sp_staking::StakingInterface;
@@ -314,6 +314,20 @@ impl<T: Config> Pallet<T> {
                 value += ledger.active;
                 ledger.active = Zero::zero();
             }
+
+            // Aggregate solvency guard. The ledger is per-stash but a stash can back
+            // multiple attestors (across chains), so unlocking `bond.min(active)` for the
+            // attestor being removed here must not leave the *remaining* still-registered
+            // attestors collectively undercollateralized — a situation that arises once an
+            // operator raises a chain's `MinBondRequirement` after registration. The
+            // attestor being removed is still present in [`Attestors`] at this point, so it
+            // is excluded from the requirement. Checked before any storage write so a
+            // failure cleanly aborts the unbond.
+            let required = Self::required_bond_for_stash(&stash, Some((chain_key, &attestor_id)));
+            ensure!(
+                ledger.active >= required,
+                Error::<T>::InsufficientRemainingBond
+            );
 
             // Note: in case there is no current era it is fine to bond one era more.
             if let Some(chunk) = ledger
@@ -840,6 +854,37 @@ impl<T: Config> Pallet<T> {
 
     pub fn attestor_is_registered(chain_key: ChainKey, address: &T::AccountId) -> bool {
         Attestors::<T>::contains_key(chain_key, address)
+    }
+
+    /// Aggregate collateral a stash must keep bonded to back all of its still-registered
+    /// attestors, summed across every supported chain using each chain's *current*
+    /// [`MinBondRequirement`]. A single stash can back multiple attestors (the second and
+    /// later registrations top up the shared ledger via `bond_extra`) and those attestors
+    /// may span different chains with different requirements, so the requirement is a sum
+    /// rather than `count * single_min_bond`.
+    ///
+    /// `exclude` lets a collateral-reducing path discount an attestor that is being removed
+    /// in the same call but whose [`Attestors`] entry has not been deleted yet.
+    pub(crate) fn required_bond_for_stash(
+        stash: &T::AccountId,
+        exclude: Option<(ChainKey, &T::AccountId)>,
+    ) -> BalanceOf<T> {
+        let mut required: BalanceOf<T> = Zero::zero();
+        for chain_key in T::SupportedChains::supported_chains() {
+            let min_bond = Self::min_bond_requirement(chain_key);
+            for (attestor_id, attestor) in Attestors::<T>::iter_prefix(chain_key) {
+                if attestor.stash != *stash {
+                    continue;
+                }
+                if let Some((ex_chain, ex_id)) = exclude {
+                    if ex_chain == chain_key && *ex_id == attestor_id {
+                        continue;
+                    }
+                }
+                required = required.saturating_add(min_bond);
+            }
+        }
+        required
     }
 
     pub fn last_digest(chain_key: ChainKey) -> Option<Digest> {

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -842,6 +842,11 @@ pub mod pallet {
         AttestorAlreadyIdle,
         /// A voluntary chill is already scheduled for this attestor.
         AttestorChillAlreadyScheduled,
+        /// Reducing this stash's active bond would leave its remaining still-registered
+        /// attestors collectively undercollateralized relative to the current per-chain
+        /// `MinBondRequirement`. Can occur after an operator raises `MinBondRequirement`
+        /// for a chain that the stash still backs with one or more attestors.
+        InsufficientRemainingBond,
     }
 
     #[pallet::hooks]

--- a/pallets/attestation/src/tests.rs
+++ b/pallets/attestation/src/tests.rs
@@ -601,6 +601,80 @@ fn registering_dergegistering_multiple_attestor_increases_decreases_locked_balan
     })
 }
 
+// Finding #17 regression: the bonding ledger is per-stash but a stash can back multiple
+// attestors. After an operator RAISES `MinBondRequirement`, removing one attestor must not
+// unlock so much collateral that the remaining still-registered attestor(s) drop below the
+// new aggregate requirement.
+#[test]
+fn unregistering_attestor_cannot_undercollateralize_remaining_after_min_bond_increase() {
+    ExtBuilder.build_and_execute(|| {
+        // STASH_3 backs two attestors at the default min bond.
+        let att1 = Attestor::new(STASH_3, ATTESTOR_1);
+        assert_ok!(Attestation::register_attestor(
+            att1.stash.clone(),
+            SUPPORTED_CHAIN_KEY,
+            att1.attestor_id,
+        ));
+        let att2 = Attestor::new(STASH_3, ATTESTOR_2);
+        assert_ok!(Attestation::register_attestor(
+            att2.stash.clone(),
+            SUPPORTED_CHAIN_KEY,
+            att2.attestor_id,
+        ));
+
+        let min_bond = MinBondRequirement::<Test>::get(SUPPORTED_CHAIN_KEY);
+        // Two attestors => ledger.active == 2 * min_bond.
+        let ledger = Attestation::ledger(STASH_3).expect("stash is bonded");
+        assert_eq!(ledger.active, min_bond * 2);
+
+        // Operator raises the per-chain min bond to 1.5x. Now a single remaining attestor
+        // requires `new_min_bond` (= 1.5 * min_bond) collateral, but unregistering one
+        // attestor would try to unlock `new_min_bond`, leaving active = 2*min_bond -
+        // 1.5*min_bond = 0.5*min_bond, which is below the requirement for the survivor.
+        let new_min_bond = min_bond + min_bond / 2;
+        assert_ok!(Attestation::set_min_bond_requirement(
+            RuntimeOrigin::signed(ALICE),
+            SUPPORTED_CHAIN_KEY,
+            new_min_bond,
+        ));
+
+        // The reducing operation must be rejected: the aggregate solvency guard fires.
+        assert_noop!(
+            Attestation::unregister_attestor(att2.stash.clone(), SUPPORTED_CHAIN_KEY, ATTESTOR_2),
+            Error::<Test>::InsufficientRemainingBond
+        );
+
+        // Collateral is fully retained and both attestors remain registered.
+        let ledger = Attestation::ledger(STASH_3).expect("stash is still bonded");
+        assert_eq!(ledger.active, min_bond * 2);
+        assert!(ledger.unlocking.is_empty());
+        assert!(Attestation::attestor_is_registered(
+            SUPPORTED_CHAIN_KEY,
+            &ATTESTOR_1
+        ));
+        assert!(Attestation::attestor_is_registered(
+            SUPPORTED_CHAIN_KEY,
+            &ATTESTOR_2
+        ));
+
+        // Sanity: once the operator's requirement is back within what the stash can cover
+        // for the survivor, the same unregister succeeds (guard does not over-restrict).
+        assert_ok!(Attestation::set_min_bond_requirement(
+            RuntimeOrigin::signed(ALICE),
+            SUPPORTED_CHAIN_KEY,
+            min_bond,
+        ));
+        assert_ok!(Attestation::unregister_attestor(
+            att2.stash,
+            SUPPORTED_CHAIN_KEY,
+            ATTESTOR_2
+        ));
+        // Survivor (ATTESTOR_1) stays fully collateralized at the current requirement.
+        let ledger = Attestation::ledger(STASH_3).expect("stash is still bonded");
+        assert!(ledger.active >= MinBondRequirement::<Test>::get(SUPPORTED_CHAIN_KEY));
+    })
+}
+
 #[test]
 fn attestor_should_be_able_to_toggle_status() {
     ExtBuilder.build_and_execute(|| {


### PR DESCRIPTION
Audit finding #17 (Undercollateralized active attestor after MinBondRequirement increase), fixed on top of `attest_coin`.

### Problem
The bonding `AttestorLedger` is **per-stash**, but a stash can back multiple attestors (across multiple chains). `remove_attestor_and_emit_event` unlocks `bond.min(ledger.active)` when one attestor is unregistered. After an operator **raises** `MinBondRequirement`, a stash backing 2+ attestors could unregister one (and later withdraw) leaving the remaining active attestor(s) backed below the current minimum — no aggregate solvency check existed.

### Fix
Added helper `required_bond_for_stash(stash, exclude)` that sums `min_bond_requirement(chain)` over every still-registered attestor of the stash **across all supported chains** (per-chain minimums differ, so it must be a sum, not `count * single_min`). Wired a guard into `remove_attestor_and_emit_event` **before any storage write**:

```
ledger.active >= required_bond_for_stash(stash, exclude = (this_chain, this_attestor))
```

On failure → new `Error::InsufficientRemainingBond`, operation aborts (collateral retained, both attestors stay registered). `remove_attestor_and_emit_event` (the `unregister_attestor` path) is the only collateral-reducing entry point — `do_withdraw_unbonded` only consolidates already-unlocking chunks — so guarding it makes the invariant unbypassable.

### Test
`unregistering_attestor_cannot_undercollateralize_remaining_after_min_bond_increase`: stash backs 2 attestors at default min; operator raises min; unregister rejected; collateral retained. Sanity tail: lowering min back lets the same unregister succeed (guard doesn't over-restrict).

### Cross-chain note
Guard sums across chains. Residual (out of scope, safe direction): existing attestors aren't proactively topped-up when a minimum is raised — they simply can't trigger a reducing action until solvent. That's an operator-policy question, not a solvency-leak path.

### Verification
- `cargo fmt -p pallet-attestation`: clean
- `cargo clippy -p pallet-attestation --all-targets -- -D warnings`: clean
- `cargo check -p pallet-attestation`: compiles; new test passes; 79-test regression subset green

Opened as **draft** against `attest_coin` for review. cc @gluwa/protocol