### PR TITLE
chore: replace rpc.ccnext-devnet with rpc.cc3-devnet RPC URL

### DIFF
--- a/attestor/scripts/README.md
+++ b/attestor/scripts/README.md
@@ -41,7 +41,7 @@ on the target chain.
 EX:
 ```sh
 MNEMONIC="//Alice"
-SOURCE_CHAIN="wss://rpc.ccnext-devnet.creditcoin.network"
+SOURCE_CHAIN="wss://rpc.cc3-devnet.creditcoin.network"
 DESTINATION_CHAIN="ws://127.0.0.1:9944"
 CHAIN_KEY_ON_SOURCE=2
 CHAIN_KEY_ON_DESTINATION=2

--- a/cc3-indexer/.env
+++ b/cc3-indexer/.env
@@ -1,6 +1,6 @@
 # Target host.docker.interal for development
 # ENDPOINT=ws://host.docker.internal:9944/
-ENDPOINT=wss://rpc.ccnext-devnet.creditcoin.network
+ENDPOINT=wss://rpc.cc3-devnet.creditcoin.network
 
 # Chain id is the genesis hash of the chain
 CHAIN_ID=0xbdb995ee19296026814960ba3b983e8e05784644baf0a5676eb2b5759203ec27

--- a/cc3-indexer/.env.develop
+++ b/cc3-indexer/.env.develop
@@ -1,2 +1,2 @@
-ENDPOINT=wss://rpc.ccnext-devnet.creditcoin.network
+ENDPOINT=wss://rpc.cc3-devnet.creditcoin.network
 CHAIN_ID=0xe15b47ca0430f2fd354570abd7598d24c333c463cdf3dd9fff43d95ab81d0d5d

--- a/proof-gen-api-server/README.md
+++ b/proof-gen-api-server/README.md
@@ -46,7 +46,7 @@ cargo run -p proof-gen-api-server -- \
 ```bash
 cargo run -p proof-gen-api-server -- \
   --cc3-key "//Alice" \
-  --cc3-rpc-url wss://rpc.ccnext-devnet.creditcoin.network \
+  --cc3-rpc-url wss://rpc.cc3-devnet.creditcoin.network \
   --eth-rpc-url https://anvil.ccnext-devnet.creditcoin.network
 ```
 


### PR DESCRIPTION
## Summary

Replaces all references to the legacy RPC endpoint `rpc.ccnext-devnet.creditcoin.network` with the current `rpc.cc3-devnet.creditcoin.network`.

Requested by Alex Todorov.

## Changes

- `attestor/scripts/README.md` — `SOURCE_CHAIN` example
- `cc3-indexer/.env` — `ENDPOINT`
- `cc3-indexer/.env.develop` — `ENDPOINT`
- `proof-gen-api-server/README.md` — `--cc3-rpc-url` example

## Notes

Scoped to the `rpc.` subdomain as requested. The `anvil.ccnext-devnet.creditcoin.network` references (a different subdomain) were left untouched.
