### PR TITLE
fix(indexer): remove Attestors entity on unregister to sync GraphQL with chain

### DIFF
--- a/cc3-indexer/schema.graphql
+++ b/cc3-indexer/schema.graphql
@@ -126,7 +126,10 @@ type Attestors @entity {
 
     lastUpdateBlockNumber: BigInt!
     """
-    0 - Active, 1 - Idle, 2 - Waiting, 3 - Leaving (matches runtime AttestorStatus enum)
+    0 - Active, 1 - Idle, 2 - Waiting, 3 - Leaving (matches runtime AttestorStatus enum).
+    4 - Unregistered: indexer-only status set when the attestor is purged from chain storage on
+    unregister. The entity is retained (not deleted) so historical MapAttestationAttestor rows keep
+    a resolvable `attestor` relation; consumers should filter out status = 4 to match chain state.
     """
     status: Int! # this-is-expected
     blsPublicKey: String!

--- a/cc3-indexer/src/mappings/mappingHandlers.ts
+++ b/cc3-indexer/src/mappings/mappingHandlers.ts
@@ -285,11 +285,10 @@ export async function handleEventAttestorUnregistered(event: SubstrateEvent): Pr
 
     const id = `${blockNumber}-${event.idx}`;
     const attestorEntity = await checkAndGetAttestor(id, attestor.toString(), chainKeyNumber);
-    attestorEntity.lastUpdateBlockNumber = blockNumber;
-    // Unregistering an attestor removes it from storage on chain, here we just set it to Idle status to keep history of the attestor in the db.
-    attestorEntity.status = RuntimeAttestorStatus.idle;
-
-    await Promise.all([attestorUnregistered.save(), attestorEntity.save()]);
+    // Unregistering an attestor removes it from storage on chain (Attestors::<T>::remove), so we
+    // delete the Attestors entity here to keep the GraphQL list in sync with chain state. The
+    // unregistration history is preserved separately in the AttestorUnregistered entity.
+    await Promise.all([attestorUnregistered.save(), Attestors.remove(attestorEntity.id)]);
 }
 
 export async function handleEventInvulnerableRegistered(event: SubstrateEvent): Promise<void> {

--- a/cc3-indexer/src/mappings/mappingHandlers.ts
+++ b/cc3-indexer/src/mappings/mappingHandlers.ts
@@ -44,6 +44,11 @@ const RuntimeAttestorStatus = {
     idle: 1,
     waiting: 2,
     leaving: 3,
+    // Indexer-only status: the attestor has been unregistered and purged from chain storage
+    // (Attestors::<T>::remove). We keep the Attestors entity so historical MapAttestationAttestor
+    // rows can still resolve their non-nullable `attestor` relation, but flag it as unregistered so
+    // the GraphQL `attestors` list can filter it out to stay in sync with chain state.
+    unregistered: 4,
 } as const;
 
 export async function handleEventAttestorsElected(event: SubstrateEvent): Promise<void> {
@@ -285,10 +290,15 @@ export async function handleEventAttestorUnregistered(event: SubstrateEvent): Pr
 
     const id = `${blockNumber}-${event.idx}`;
     const attestorEntity = await checkAndGetAttestor(id, attestor.toString(), chainKeyNumber);
-    // Unregistering an attestor removes it from storage on chain (Attestors::<T>::remove), so we
-    // delete the Attestors entity here to keep the GraphQL list in sync with chain state. The
-    // unregistration history is preserved separately in the AttestorUnregistered entity.
-    await Promise.all([attestorUnregistered.save(), Attestors.remove(attestorEntity.id)]);
+    // Unregistering an attestor purges it from storage on chain (Attestors::<T>::remove). We do NOT
+    // delete the Attestors entity, because historical MapAttestationAttestor rows reference it via a
+    // non-nullable `attestor: Attestors!` relation; deleting the row would leave those maps with an
+    // unresolvable foreign key. Instead we flag the attestor as `unregistered` so it can be filtered
+    // out of the GraphQL `attestors` list while preserving referential integrity. The unregistration
+    // history is also preserved separately in the AttestorUnregistered entity.
+    attestorEntity.status = RuntimeAttestorStatus.unregistered;
+    attestorEntity.lastUpdateBlockNumber = blockNumber;
+    await Promise.all([attestorUnregistered.save(), attestorEntity.save()]);
 }
 
 export async function handleEventInvulnerableRegistered(event: SubstrateEvent): Promise<void> {

--- a/cli/src/test/cc3-indexer-tests/handleEventAttestorUnregistered.test.ts
+++ b/cli/src/test/cc3-indexer-tests/handleEventAttestorUnregistered.test.ts
@@ -99,12 +99,13 @@ describe('handleEventAttestorUnregistered()', () => {
             expect(foundMatch).toEqual(true);
         });
 
-        it('graphQL returns known Attestor entity', async () => {
+        it('graphQL no longer returns the unregistered Attestor entity', async () => {
+            // Unregistering removes the attestor from chain storage, so the indexer deletes the
+            // Attestors entity to keep the GraphQL list in sync with chain state.
             const response = await graphQLQuery(
                 `query { attestors(orderBy: LAST_UPDATE_BLOCK_NUMBER_ASC, last: 10) { nodes { id, attestorId, stashId, chainKey, lastUpdateBlockNumber, status, blsPublicKey } } }`,
             );
             expect(response.data.attestors.nodes).toBeTruthy();
-            expect(response.data.attestors.nodes.length).toBeGreaterThanOrEqual(1);
 
             let foundMatch = false;
             for (const node of response.data.attestors.nodes) {
@@ -112,10 +113,9 @@ describe('handleEventAttestorUnregistered()', () => {
 
                 if (node.attestorId === attestor.address) {
                     foundMatch = true;
-                    expect(node.status).toEqual(1); // State after unregistration is Idle
                 }
             }
-            expect(foundMatch).toEqual(true);
+            expect(foundMatch).toEqual(false);
         });
     });
 });

--- a/cli/src/test/cc3-indexer-tests/handleEventAttestorUnregistered.test.ts
+++ b/cli/src/test/cc3-indexer-tests/handleEventAttestorUnregistered.test.ts
@@ -99,23 +99,20 @@ describe('handleEventAttestorUnregistered()', () => {
             expect(foundMatch).toEqual(true);
         });
 
-        it('graphQL no longer returns the unregistered Attestor entity', async () => {
-            // Unregistering removes the attestor from chain storage, so the indexer deletes the
-            // Attestors entity to keep the GraphQL list in sync with chain state.
+        it('graphQL flags the unregistered Attestor entity as unregistered (status 4)', async () => {
+            // Unregistering purges the attestor from chain storage, but the indexer keeps the
+            // Attestors entity (so historical MapAttestationAttestor relations still resolve) and
+            // flags it with the indexer-only `unregistered` status (4). Consumers filter out
+            // status = 4 to match chain state.
             const response = await graphQLQuery(
                 `query { attestors(orderBy: LAST_UPDATE_BLOCK_NUMBER_ASC, last: 10) { nodes { id, attestorId, stashId, chainKey, lastUpdateBlockNumber, status, blsPublicKey } } }`,
             );
             expect(response.data.attestors.nodes).toBeTruthy();
 
-            let foundMatch = false;
-            for (const node of response.data.attestors.nodes) {
-                expect(BigInt(node.lastUpdateBlockNumber)).toBeGreaterThan(0n);
-
-                if (node.attestorId === attestor.address) {
-                    foundMatch = true;
-                }
-            }
-            expect(foundMatch).toEqual(false);
+            const matches = response.data.attestors.nodes.filter((node: any) => node.attestorId === attestor.address);
+            expect(matches.length).toEqual(1);
+            expect(matches[0].status).toEqual(4); // unregistered
+            expect(BigInt(matches[0].lastUpdateBlockNumber)).toBeGreaterThan(0n);
         });
     });
 });

--- a/cli/src/test/cc3-indexer-tests/handleEventAttestorUnregistered.test.ts
+++ b/cli/src/test/cc3-indexer-tests/handleEventAttestorUnregistered.test.ts
@@ -1,4 +1,5 @@
 import { newApi, ApiPromise, KeyringPair } from '../../lib';
+import { getChainStatus } from '../../lib/chain/status';
 import { forElapsedBlocks } from '../utils';
 import { randomFundedAccount } from '../integration-tests/helpers';
 import { chain_Anvil1_Key, chain_Anvil2_Key } from '../blockchain-tests/pallets/supported-chains/consts';
@@ -8,6 +9,7 @@ describe('handleEventAttestorUnregistered()', () => {
     let api: ApiPromise;
     let bob: KeyringPair;
     let attestor: any;
+    let startingBlock: bigint;
 
     beforeAll(async () => {
         ({ api } = await newApi((global as any).CREDITCOIN_API_URL));
@@ -63,6 +65,9 @@ describe('handleEventAttestorUnregistered()', () => {
             expect(foundMatch).toEqual(false);
 
             // NOTE: now remove it and observe GraphQL responses below
+            startingBlock = BigInt((await getChainStatus(api)).bestNumber);
+            expect(startingBlock).toBeGreaterThan(0n);
+
             await api.tx.attestation
                 .unregisterAttestor(chain_Anvil2_Key, attestor.address)
                 .signAndSend(bob, { nonce: await api.rpc.system.accountNextIndex(bob.address) });
@@ -105,14 +110,14 @@ describe('handleEventAttestorUnregistered()', () => {
             // flags it with the indexer-only `unregistered` status (4). Consumers filter out
             // status = 4 to match chain state.
             const response = await graphQLQuery(
-                `query { attestors(orderBy: LAST_UPDATE_BLOCK_NUMBER_ASC, last: 10) { nodes { id, attestorId, stashId, chainKey, lastUpdateBlockNumber, status, blsPublicKey } } }`,
+                `query { attestors(orderBy: LAST_UPDATE_BLOCK_NUMBER_ASC, last: 10, filter: {attestorId: {equalTo: "${attestor.address}"}}) { nodes { id, attestorId, stashId, chainKey, lastUpdateBlockNumber, status, blsPublicKey } } }`,
             );
             expect(response.data.attestors.nodes).toBeTruthy();
+            expect(response.data.attestors.nodes.length).toEqual(1);
 
-            const matches = response.data.attestors.nodes.filter((node: any) => node.attestorId === attestor.address);
-            expect(matches.length).toEqual(1);
-            expect(matches[0].status).toEqual(4); // unregistered
-            expect(BigInt(matches[0].lastUpdateBlockNumber)).toBeGreaterThan(0n);
+            const node = response.data.attestors.nodes[0];
+            expect(node.status).toEqual(4); // unregistered
+            expect(BigInt(node.lastUpdateBlockNumber)).toBeGreaterThan(startingBlock);
         });
     });
 });


### PR DESCRIPTION
## Problem

`unregisterAttestor` fully purges the attestor from chain storage via `Attestors::<T>::remove(chain_key, &attestor_id)` (`pallets/attestation/src/impls.rs:361`), but the indexer's `handleEventAttestorUnregistered` kept the `Attestors` entity and only flipped its `status` to `Idle`. As a result, unregistered attestors still appeared in the `attestors` GraphQL list, diverging from actual chain state.

## Fix

We cannot simply delete the `Attestors` entity: historical `MapAttestationAttestor` rows reference it via a **non-nullable** `attestor: Attestors!` relation, so removing the row would leave those maps with an unresolvable foreign key (and re-registration mints a new id, so old maps never re-link).

Instead, `handleEventAttestorUnregistered` now sets a new indexer-only `unregistered` status (`4`) on the `Attestors` entity (and bumps `lastUpdateBlockNumber`). This:

- keeps referential integrity for historical `MapAttestationAttestor` relations, and
- lets consumers filter out `status = 4` so the `attestors` list matches chain state.

The `AttestorUnregistered` history rows are still saved unchanged.

The integration test now asserts the entity is retained with `status = 4` after unregister.
