### PR TITLE
chore: replace anvil.ccnext-devnet RPC with free public Sepolia endpoint

### DIFF
--- a/attestor/scripts/MultiTransfer.js
+++ b/attestor/scripts/MultiTransfer.js
@@ -3,7 +3,7 @@ const experimental = require('@ethersproject/experimental');
 
 // Define default and devnet provider URLs
 const DEFAULT_PROVIDER_URL = "http://127.0.0.1:8141";
-const DEVNET_PROVIDER_URL = "https://anvil.ccnext-devnet.creditcoin.network";
+const DEVNET_PROVIDER_URL = "https://ethereum-sepolia-rpc.publicnode.com";
 
 function getRandomEthAddress() {
   return ethers.Wallet.createRandom().address;

--- a/attestor/scripts/Transfer.js
+++ b/attestor/scripts/Transfer.js
@@ -2,7 +2,7 @@ const ethers = require("ethers");
 
 // Define default and devnet provider URLs
 const DEFAULT_PROVIDER_URL = process.env.ETH_RPC_URL || "http://127.0.0.1:8545";
-const DEVNET_PROVIDER_URL = "https://anvil.ccnext-devnet.creditcoin.network";
+const DEVNET_PROVIDER_URL = "https://ethereum-sepolia-rpc.publicnode.com";
 
 function getRandomEthAddress() {
   return ethers.Wallet.createRandom().address;

--- a/proof-gen-api-server/README.md
+++ b/proof-gen-api-server/README.md
@@ -47,7 +47,7 @@ cargo run -p proof-gen-api-server -- \
 cargo run -p proof-gen-api-server -- \
   --cc3-key "//Alice" \
   --cc3-rpc-url wss://rpc.cc3-devnet.creditcoin.network \
-  --eth-rpc-url https://anvil.ccnext-devnet.creditcoin.network
+  --eth-rpc-url https://ethereum-sepolia-rpc.publicnode.com
 ```
 
 ## Continuity & Merkle Proof Endpoints (Internal Draft)

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -10,7 +10,7 @@ const fetch = globalThis.fetch || require('node-fetch');
 
 // Constants
 const DEFAULT_SOURCE_RPC_URL = process.env.ETH_RPC_URL || 'http://127.0.0.1:8545';
-const DEVNET_SOURCE_RPC_URL = 'https://anvil.ccnext-devnet.creditcoin.network';
+const DEVNET_SOURCE_RPC_URL = 'https://ethereum-sepolia-rpc.publicnode.com';
 const DEFAULT_CC3_WS_URL = 'ws://localhost:9944';
 const DEFAULT_CC3_HTTP_URL = 'http://localhost:9944';
 // Well-known Anvil development account #0 private key (public, not a secret)


### PR DESCRIPTION
## Summary

Removes all references to `https://anvil.ccnext-devnet.creditcoin.network` and replaces them with the free public Sepolia RPC endpoint `https://ethereum-sepolia-rpc.publicnode.com`.

Requested by @atodorov-gluwa.

## Changes

- `attestor/scripts/Transfer.js` — `DEVNET_PROVIDER_URL`
- `attestor/scripts/MultiTransfer.js` — `DEVNET_PROVIDER_URL`
- `scripts/utils.js` — `DEVNET_SOURCE_RPC_URL`
- `proof-gen-api-server/README.md` — devnet example `--eth-rpc-url`

The chosen endpoint (`ethereum-sepolia-rpc.publicnode.com`) is already used elsewhere in the repo (`scripts/usc-audit-automation/config-testnet.json`), keeping the free Sepolia RPC consistent across the codebase.