### PR TITLE
feat(docker): pin base image sha256 digest + SBOM/provenance build options

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -26,17 +26,17 @@ jobs:
 
       - name: Build ${{ github.repository }} docker image
         run: |
-          docker build -t ${{ github.repository }}:${{ inputs.version-string }} --build-arg="${{ inputs.build-options }}" --sbom=true .
+          docker build -t ${{ github.repository }}:${{ inputs.version-string }} --build-arg="${{ inputs.build-options }}" --sbom=true --provenance=mode=max .
           docker images
 
       - name: Build ${{ github.repository }}:indexer-for-${{ inputs.version-string }} docker image
         run: |
-          tar --create --dereference --exclude-from=.dockerignore --exclude-from=cc3-indexer/.dockerignore . | docker build -f cc3-indexer/Dockerfile -t ${{ github.repository }}:indexer-for-${{ inputs.version-string }} --sbom=true -
+          tar --create --dereference --exclude-from=.dockerignore --exclude-from=cc3-indexer/.dockerignore . | docker build -f cc3-indexer/Dockerfile -t ${{ github.repository }}:indexer-for-${{ inputs.version-string }} --sbom=true --provenance=mode=max -
           docker images
 
       - name: Build ${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }} docker image
         run: |
-          docker build -f scripts/stress-test/Dockerfile -t ${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }} --sbom=true .
+          docker build -f scripts/stress-test/Dockerfile -t ${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }} --sbom=true --provenance=mode=max .
           docker images
 
       - name: Export docker image into a file

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -26,17 +26,17 @@ jobs:
 
       - name: Build ${{ github.repository }} docker image
         run: |
-          docker build -t ${{ github.repository }}:${{ inputs.version-string }} --build-arg="${{ inputs.build-options }}" .
+          docker build -t ${{ github.repository }}:${{ inputs.version-string }} --build-arg="${{ inputs.build-options }}" --sbom=true .
           docker images
 
       - name: Build ${{ github.repository }}:indexer-for-${{ inputs.version-string }} docker image
         run: |
-          tar --create --dereference --exclude-from=.dockerignore --exclude-from=cc3-indexer/.dockerignore . | docker build -f cc3-indexer/Dockerfile -t ${{ github.repository }}:indexer-for-${{ inputs.version-string }} -
+          tar --create --dereference --exclude-from=.dockerignore --exclude-from=cc3-indexer/.dockerignore . | docker build -f cc3-indexer/Dockerfile -t ${{ github.repository }}:indexer-for-${{ inputs.version-string }} --sbom=true -
           docker images
 
       - name: Build ${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }} docker image
         run: |
-          docker build -f scripts/stress-test/Dockerfile -t ${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }} .
+          docker build -f scripts/stress-test/Dockerfile -t ${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }} --sbom=true .
           docker images
 
       - name: Export docker image into a file

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3008,DL3009,DL3013,DL3016,SC3046,DL4006,SC1091,SC2086
-FROM ubuntu:24.04 AS runtime-base
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS runtime-base
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get upgrade -y && \


### PR DESCRIPTION
Cherry-picks from #1125 — the sha256 base image pin and SBOM/provenance build options only. Renovate config is intentionally left out of this PR.

### Commits (original author + logs preserved)
- `pin base image digest` — cherry-picked from `cc4f9700`, **amended** to keep only the `Dockerfile` `ubuntu:24.04@sha256:...` digest pin. The `renovate.json` / `renovate.yml` changes bundled in that original commit were dropped as out of scope.
- `add SBOM attestation to all three published image builds` — cherry-picked as-is from `640a4bfa` (`--sbom=true`).
- `use provenance mode=max per Docker Scout policy requirement` — cherry-picked as-is from `a1c6283a` (`--provenance=mode=max`).

### Files changed
- `Dockerfile` — pin runtime-base to `ubuntu:24.04@sha256:4fbb8e6a...`
- `.github/workflows/build-docker.yml` — add `--sbom=true --provenance=mode=max` to all three image builds

Source: https://github.com/gluwa/creditcoin3/pull/1125/commits
