### PR TITLE
fix(cc3-indexer): flush store before deletions to remove same-block entities

### DIFF
--- a/cc3-indexer/src/mappings/mappingHandlers.ts
+++ b/cc3-indexer/src/mappings/mappingHandlers.ts
@@ -46,6 +46,30 @@ const RuntimeAttestorStatus = {
     leaving: 3,
 } as const;
 
+/**
+ * Flush pending store writes to the database before performing deletions.
+ *
+ * SubQuery buffers entity `.save()` calls in an in-memory store cache and only
+ * persists them to the DB between blocks. Read APIs such as `getByFields` resolve
+ * against persisted data, so an entity created earlier *in the same block* is not
+ * visible to a subsequent delete query and would survive a deletion pass.
+ *
+ * This bites the attestation-revert path: when a `commitAttestation` and a
+ * `revertTo` land in the same block, the freshly-created attestation is not seen
+ * by `remove_attestations_above_height` and is never deleted. Flushing first makes
+ * the pending writes visible so the delete queries see (and remove) them.
+ *
+ * `flush()` lives on the store cache in `@subql/node` but is not declared on the
+ * public `@subql/types` `Store` interface, so it is accessed via a guarded cast
+ * and no-ops if unavailable (never breaks indexing).
+ */
+async function flushStore(): Promise<void> {
+    const maybeFlush = (store as unknown as { flush?: () => Promise<void> }).flush;
+    if (typeof maybeFlush === 'function') {
+        await maybeFlush.call(store);
+    }
+}
+
 export async function handleEventAttestorsElected(event: SubstrateEvent): Promise<void> {
     logger.info(`New Attestors Elected event found at block ${event.block.block.header.number.toString()}`);
 
@@ -197,6 +221,9 @@ export async function handleSupportedChainRemoved(event: SubstrateEvent): Promis
         whoId: from.toString(),
     });
     await chainRemoved.save();
+
+    // Flush pending in-block writes so deletions below see same-block entities.
+    await flushStore();
 
     const supportedChain = await SupportedChain.getByFields([['chainKey', '=', chainKeyStr]], { limit: 1 });
     if (isEmpty(supportedChain)) {
@@ -1318,6 +1345,9 @@ export async function handleAuthorizedAttestorRemoved(event: SubstrateEvent): Pr
         attestorId: attestor.toString(),
     });
 
+    // Flush pending in-block writes so the deletion below sees same-block entities.
+    await flushStore();
+
     // Remove the authorized attestor entry
     const removeAuthorizedAttestor = AuthorizedAttestors.remove(`${chainKeyNumber.toString()}-${attestor.toString()}`);
 
@@ -1491,6 +1521,9 @@ function codecToBool(value: unknown): boolean {
 }
 
 async function remove_checkpoints_at_checkpoint_height(chainKey: bigint, checkpointHeight: bigint): Promise<void> {
+    // Flush pending in-block writes so the read below sees same-block entities.
+    await flushStore();
+
     const PAGE_SIZE = 100;
     const DELETE_BATCH_SIZE = 100;
     let offset = 0;
@@ -1527,6 +1560,9 @@ async function remove_checkpoints_at_checkpoint_height(chainKey: bigint, checkpo
 }
 
 async function remove_attestations_above_height(chainKey: bigint, revertHeight: bigint) {
+    // Flush pending in-block writes so the read below sees same-block entities.
+    await flushStore();
+
     // Max allowed reads in one call of getByFields is 100
     const PAGE_SIZE = 100;
     const DELETE_BATCH_SIZE = 100;
@@ -1571,6 +1607,9 @@ async function remove_attestations_above_height(chainKey: bigint, revertHeight: 
 }
 
 async function remove_checkpoints_above_height(chainKey: bigint, revertHeight: bigint) {
+    // Flush pending in-block writes so the read below sees same-block entities.
+    await flushStore();
+
     // Max allowed reads in one call of getByFields is 100
     const PAGE_SIZE = 100;
     const DELETE_BATCH_SIZE = 100;

--- a/cli/src/test/cc3-indexer-tests/zz-handleEventRevertedAttestationChainTo.test.ts
+++ b/cli/src/test/cc3-indexer-tests/zz-handleEventRevertedAttestationChainTo.test.ts
@@ -64,8 +64,8 @@ describe('handleEventRevertedAttestationChainTo()', () => {
                 .sudo(api.tx.attestation.revertTo(chainKey, checkpointHeightToRevertTo))
                 .signAndSend(root, { nonce: await api.rpc.system.accountNextIndex(root.address) });
 
-            await forElapsedBlocks(api, { minBlocks: 3 });
-        }, 60_000);
+            await forElapsedBlocks(api, { minBlocks: 5, maxRetries: 15 });
+        }, 120_000);
 
         it('graphQL returns known RevertedAttestationChainTo entity', async () => {
             const response = await graphQLQuery(


### PR DESCRIPTION
## Problem

The cc3-indexer's deletion paths can leave behind entities that were created **earlier in the same block**.

SubQuery buffers entity `.save()` writes in an in-memory store cache and only persists them to the DB between blocks. Delete helpers read the set to purge via `getByFields(...)`, which (at the pinned `@subql/types` version, especially with `orderBy`/`offset` pagination) does not reliably return not-yet-persisted, same-block writes. Those entities are never added to the delete list, so they survive.

### How it manifests (PR #1132 CI failure)

In `cc3-indexer-testing`, the integration test `zz-handleEventRevertedAttestationChainTo.test.ts` › *"removes attestations above checkpointHeight"* fails:

```
expect(received).toBeLessThanOrEqual(expected)
  Expected: <= 0n
  Received:    280n
```

The indexer runtime logs show, all within **block 355** on `chainKey=5` (Anvil3):

```
07:42:31.394  Block Attested event: chain_key=5, header_number=280   ← attestation 280 created + saved
07:42:31.401  New RevertedAttestationChainTo event found at block 355 ← revertTo(0) runs
07:42:31.487  Success: completed indexer handling of chain reversion  ← 280 NOT deleted
```

`commitAttestation` (header 280) and the sudo `revertTo(chainKey, 0)` land in the same block. `remove_attestations_above_height` runs the revert cleanup but doesn't see the just-created attestation 280, so it survives and the test fails.

> Note: this is a **latent indexer bug**, not something PR #1132 introduced. #1132 (runtime operator-migration port) only shifts genesis-block timing enough that these two extrinsics collapse into the same block, exposing the bug. Other branches happen to dodge it by landing them in separate blocks.

## Fix

Per the agreed approach: **for every handler that deletes storage items, flush the store first so any pending in-block writes are persisted, then delete.**

- Add a small guarded `flushStore()` helper. `flush()` exists on the store cache in `@subql/node` but isn't declared on the public `@subql/types` `Store` interface, so it's called via a guarded cast and **no-ops if unavailable** (never breaks indexing).
- Call `flushStore()` before every deletion pass:
  - `handleSupportedChainRemoved` (SupportedChain + AttestationChainData removal)
  - `handleAuthorizedAttestorRemoved` (AuthorizedAttestors removal)
  - `remove_checkpoints_at_checkpoint_height`
  - `remove_attestations_above_height`
  - `remove_checkpoints_above_height`

## Testing

- `prettier --check` passes on the changed file.
- Full `subql codegen`/`build`/`eslint` require project deps + a metadata source; CI's indexer jobs will validate. The clean confirmation is `cc3-indexer-testing` › "removes attestations above checkpointHeight" going green (and by extension, PR #1132 once rebased on this).

## Notes / follow-ups
- If `flush()` turns out not to be exposed at the pinned `@subql/node` 6.4.0, the helper safely no-ops and we should instead delete by deterministic id in the revert path (or bump `@subql/types`/`@subql/node`). Flagging so reviewers can confirm the flush is actually available at our version.
