### PR TITLE
chore: bump Ubuntu references to 26.04

### DIFF
--- a/.github/provision-github-runner.sh
+++ b/.github/provision-github-runner.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 mkdir actions-runner
 pushd actions-runner || exit 1
 
-curl -L https://github.com/actions/runner/releases/download/v2.329.0/actions-runner-linux-x64-2.329.0.tar.gz > runner.tar.gz
+curl -L https://github.com/actions/runner/releases/download/v2.335.1/actions-runner-linux-x64-2.335.1.tar.gz > runner.tar.gz
 
 tar xzf ./runner.tar.gz
 sudo ./bin/installdependencies.sh

--- a/.github/provision-github-runner.sh
+++ b/.github/provision-github-runner.sh
@@ -11,8 +11,11 @@ tar xzf ./runner.tar.gz
 sudo ./bin/installdependencies.sh
 # for 3rd party dependencies and building the code
 sudo apt install curl gnupg -y
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+# apt-key is removed in Ubuntu 26.04, so use the signed-by keyring pattern instead.
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/yarn.gpg
+sudo chmod a+r /etc/apt/keyrings/yarn.gpg
+echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 sudo apt-get update
 sudo apt install -y build-essential clang curl gcc git-lfs jq \
     libpq-dev libssl-dev pipx pkg-config protobuf-compiler \

--- a/.github/provision-linode-vm.sh
+++ b/.github/provision-linode-vm.sh
@@ -42,7 +42,7 @@ while [ -z "$IP_ADDRESS" ]; do
     # All SSH logins should be via the `ubuntu@` user. For more info see:
     # https://www.linode.com/community/questions/21290/how-to-pass-multiple-ssh-public-keys-with-linode-cli-linodes-create
     linode-cli linodes create --json \
-        --image 'linode/ubuntu24.04' --region "$LINODE_REGION" \
+        --image 'linode/ubuntu26.04' --region "$LINODE_REGION" \
         --type "$LINODE_VM_SIZE" --label "$LC_RUNNER_VM_NAME" \
         --root_pass "$(uuidgen)" --backups_enabled false --booted true --private_ip false \
         --tags "$VM_KIND" --tags "keep_until_$KEEP_UNTIL" \

--- a/.github/workflows/audit-automation.yml
+++ b/.github/workflows/audit-automation.yml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   usc-audit:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     strategy:
       matrix:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -18,6 +18,12 @@ concurrency:
 
 permissions: read-all
 
+# Ubuntu 26.04 ships GCC 15, whose libstdc++ no longer transitively includes
+# <cstdint>. The bundled RocksDB 8.1.1 headers (librocksdb-sys 0.11.0+8.1.1)
+# use uint64_t without including it, so force-include cstdint when compiling C/C++.
+env:
+  CXXFLAGS: "-include cstdint"
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   deploy-runner-build-creditcoin-for-testing-benchmarks:

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -30,6 +30,12 @@ name: Reusable workflow to build a native client
         required: false
         type: boolean
 
+# Ubuntu 26.04 ships GCC 15, whose libstdc++ no longer transitively includes
+# <cstdint>. The bundled RocksDB 8.1.1 headers (librocksdb-sys 0.11.0+8.1.1)
+# use uint64_t without including it, so force-include cstdint when compiling C/C++.
+env:
+  CXXFLAGS: "-include cstdint"
+
 jobs:
   build-creditcoin-node:
     runs-on: ${{ fromJSON(inputs.runs-on) }}

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -19,6 +19,12 @@ name: Reusable workflow to build WASM runtime
 
 permissions: read-all
 
+# Ubuntu 26.04 ships GCC 15, whose libstdc++ no longer transitively includes
+# <cstdint>. The bundled RocksDB 8.1.1 headers (librocksdb-sys 0.11.0+8.1.1)
+# use uint64_t without including it, so force-include cstdint when compiling C/C++.
+env:
+  CXXFLAGS: "-include cstdint"
+
 jobs:
   build-wasm-runtime:
     runs-on: ${{ fromJSON(inputs.runs-on) }}

--- a/.github/workflows/chainspec.yml
+++ b/.github/workflows/chainspec.yml
@@ -85,7 +85,7 @@ jobs:
       matrix:
         chainspec: [devnet, testnet]
     name: integration-test-chainspec-${{ matrix.chainspec }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/check-prover.yml
+++ b/.github/workflows/check-prover.yml
@@ -43,7 +43,7 @@ jobs:
             chainKey: 3
 
     name: CK ${{ matrix.chainKey }} / ${{ matrix.proverUrl }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -119,7 +119,7 @@ jobs:
   compare-proofs-sepolia:
     needs:
       - check-for
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Setup
         run: |
@@ -177,7 +177,7 @@ jobs:
   compare-proofs-ethereum:
     needs:
       - check-for
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Setup
         run: |

--- a/.github/workflows/check-runtime-changes.yml
+++ b/.github/workflows/check-runtime-changes.yml
@@ -18,7 +18,7 @@ permissions: read-all
 
 jobs:
   check-version:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
         with:
@@ -29,7 +29,7 @@ jobs:
           ./.github/check-version.sh "remotes/origin/$GITHUB_BASE_REF" "$GITHUB_SHA"
   # dangerous conditions that will brick the blockchain
   danger-will-brick-the-blockchain:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions: read-all
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   should-run:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       archiver: ${{ steps.filter.outputs.archiver }}
       attestor_cli_testing: ${{ steps.filter.outputs.attestor_cli_testing }}
@@ -149,7 +149,7 @@ jobs:
     if: github.base_ref == 'usc-dev'
     needs:
       - build-creditcoin-node-for-testing-ci
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
       - name: Install Node Dependencies
@@ -213,7 +213,7 @@ jobs:
       - build-creditcoin-node-for-testing-ci
       - should-run
     if: ${{ needs.should-run.outputs.attestor_network_testing == 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -587,7 +587,7 @@ jobs:
       - build-creditcoin-node-for-testing-ci
       - should-run
     if: ${{ needs.should-run.outputs.integration_test_cli == 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -621,7 +621,7 @@ jobs:
       - build-creditcoin-node-for-testing-ci
       - trigger-integration-test-cli
       - regenerate-metadata
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
         with:
@@ -732,7 +732,7 @@ jobs:
       - build-creditcoin-node-for-testing-ci
       - should-run
     if: ${{ needs.should-run.outputs.integration_test_blockchain == 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -907,7 +907,7 @@ jobs:
       - build-creditcoin-node-for-testing-ci
       - should-run
     if: ${{ needs.should-run.outputs.docs_smart_contract == 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -1099,7 +1099,7 @@ jobs:
       - should-run
       - build-creditcoin-node-for-testing-ci
     if: ${{ needs.should-run.outputs.cc3_indexer == 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -1315,7 +1315,7 @@ jobs:
       - should-run
       - regenerate-metadata
     if: ${{ needs.should-run.outputs.attestor_cli_testing == 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -1445,7 +1445,7 @@ jobs:
       - should-run
       - build-creditcoin-node-for-testing-ci
     if: ${{ needs.should-run.outputs.regenerate_metadata == 'true' || needs.should-run.outputs.integration_test_cli == 'true' || needs.should-run.outputs.attestor_cli_testing == 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -1625,7 +1625,7 @@ jobs:
     if: ${{ needs.should-run.outputs.integration_test_blockchain == 'true' }}
     uses: gluwa/usc-testnet-bridge-examples/.github/workflows/loan-flow.yml@main
     with:
-      runs-on: "['ubuntu-24.04']"
+      runs-on: "['ubuntu-26.04']"
       source_chain_kind: "anvil"
       usc_kind: "local"
       checkout_repo: "gluwa/usc-testnet-bridge-examples"
@@ -1636,7 +1636,7 @@ jobs:
     needs:
       - should-run
       - build-creditcoin-node-for-testing-ci
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ permissions: read-all
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/create-devnet-release.yml
+++ b/.github/workflows/create-devnet-release.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   bump-version:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     # checkov:skip=CKV2_GHA_1:We need this for auto-commit
     permissions: write-all
     steps:

--- a/.github/workflows/deploy-runner.yml
+++ b/.github/workflows/deploy-runner.yml
@@ -40,7 +40,7 @@ jobs:
   deploy-runner:
     timeout-minutes: 15
     name: proxy=${{ inputs.proxy }} / ${{ inputs.secret }} / type=${{ inputs.proxy_type }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
   docker-test:
     needs:
       - docker-build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Download locally built docker image
         uses: actions/download-artifact@v8

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   generate-changelog:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Install
         shell: bash

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   setup:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       previous_release: ${{ steps.devnet-env.outputs.previous_release || steps.testnet-env.outputs.previous_release || steps.mainnet-env.outputs.previous_release }}
 
@@ -63,7 +63,7 @@ jobs:
   sanity:
     # note: github.{base_ref|head_ref} only available on pull requests
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
         with:
@@ -106,7 +106,7 @@ jobs:
           .github/check-for-broken-symlinks.sh
 
   rebase-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: github.base_ref == 'usc-dev'
     steps:
       - uses: actions/checkout@v7
@@ -151,7 +151,7 @@ jobs:
           git merge-base "${{ env.BRANCH_NAME }}" origin/usc-testnet --all
 
   merge-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: github.base_ref == 'usc-dev'
     steps:
       - uses: actions/checkout@v7
@@ -207,7 +207,7 @@ jobs:
           git log --merge
 
   target-branch-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Check the target branch of this PR
         run: |

--- a/.github/workflows/linode-cleaner.yml
+++ b/.github/workflows/linode-cleaner.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   linode-cleaner:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build:
     name: MegaLinter
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       # Git Checkout
       - name: Checkout Code

--- a/.github/workflows/proof-gen-api-server.yml
+++ b/.github/workflows/proof-gen-api-server.yml
@@ -17,6 +17,12 @@ concurrency:
 
 permissions: read-all
 
+# Ubuntu 26.04 ships GCC 15, whose libstdc++ no longer transitively includes
+# <cstdint>. The bundled RocksDB 8.1.1 headers (librocksdb-sys 0.11.0+8.1.1)
+# use uint64_t without including it, so force-include cstdint when compiling C/C++.
+env:
+  CXXFLAGS: "-include cstdint"
+
 jobs:
   integration-tests:
     runs-on: ubuntu-26.04

--- a/.github/workflows/proof-gen-api-server.yml
+++ b/.github/workflows/proof-gen-api-server.yml
@@ -19,7 +19,7 @@ permissions: read-all
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -117,7 +117,7 @@ jobs:
   exercise-scripts:
     needs:
       - build-everything
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -369,7 +369,7 @@ jobs:
   stress-test-sanity:
     needs:
       - build-everything
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/propose-mainnet-pr.yml
+++ b/.github/workflows/propose-mainnet-pr.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       last_ref: ${{ env.LAST_REF || 'usc-testnet' }}
       target_branch: ${{ env.TARGET_BRANCH || 'main' }}

--- a/.github/workflows/propose-testnet-pr.yml
+++ b/.github/workflows/propose-testnet-pr.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       last_ref: ${{ env.LAST_REF || github.ref_name }}
       target_branch: ${{ env.TARGET_BRANCH || 'usc-testnet' }}

--- a/.github/workflows/rebase-branch-and-propose-pr.yml
+++ b/.github/workflows/rebase-branch-and-propose-pr.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   open-new-pr:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     # checkov:skip=CKV2_GHA_1:We need this for auto-commit
     permissions: write-all
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions: read-all
 
 jobs:
   sanity-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       TAG_NAME: ${{ steps.identify-tag.outputs.TAG_NAME }}
     steps:
@@ -65,7 +65,7 @@ jobs:
           node dist/scripts/npm-semver-check.js "${{ env.TAG_NAME }}"
 
   setup:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: sanity-check
     outputs:
       build_options: ${{ steps.set-build-options.outputs.build_options}}
@@ -173,7 +173,7 @@ jobs:
       build-options: "${{ needs.setup.outputs.build_options }}"
       build-subwasm: true
       version-string: ${{ needs.sanity-check.outputs.TAG_NAME }}
-      runs-on: "['ubuntu-24.04']"
+      runs-on: "['ubuntu-26.04']"
 
   docker-build:
     needs:
@@ -190,7 +190,7 @@ jobs:
   create-release:
     permissions:
       contents: write
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs:
       - sanity-check
       - setup

--- a/.github/workflows/remove-runner.yml
+++ b/.github/workflows/remove-runner.yml
@@ -21,7 +21,7 @@ permissions: read-all
 
 jobs:
   remove-runner:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -18,7 +18,7 @@ permissions: read-all
 
 jobs:
   setup:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       target_chain: ${{ steps.testnet-env.outputs.target_chain || steps.mainnet-env.outputs.target_chain }}
       boot_node: ${{ steps.testnet-env.outputs.boot_node || steps.mainnet-env.outputs.boot_node }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   cargo-audit:
     if: github.base_ref == 'usc-dev'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -64,7 +64,7 @@ jobs:
           fi
 
   cargo-fmt:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -95,7 +95,7 @@ jobs:
           taplo format --check
 
   cargo-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -140,7 +140,7 @@ jobs:
           SKIP_WASM_BUILD=1 cargo check --features=runtime-benchmarks --release
 
   cargo-clippy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -178,7 +178,7 @@ jobs:
           args: --all-targets --all-features -- -D warnings -A clippy::manual_inspect
 
   cargo-machete:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -200,7 +200,7 @@ jobs:
         uses: bnjbvr/cargo-machete@main
 
   cargo-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,12 @@ concurrency:
 
 permissions: read-all
 
+# Ubuntu 26.04 ships GCC 15, whose libstdc++ no longer transitively includes
+# <cstdint>. The bundled RocksDB 8.1.1 headers (librocksdb-sys 0.11.0+8.1.1)
+# use uint64_t without including it, so force-include cstdint when compiling C/C++.
+env:
+  CXXFLAGS: "-include cstdint"
+
 jobs:
   cargo-audit:
     if: github.base_ref == 'usc-dev'

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -14,7 +14,7 @@ permissions: read-all
 
 jobs:
   checks:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
         with:
@@ -56,7 +56,7 @@ jobs:
           ./.github/check-bootnodes.sh
 
   npm-packages:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -94,7 +94,7 @@ jobs:
           creditcoin attestor --help
 
   solidity:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/shell-check.yml
+++ b/.github/workflows/shell-check.yml
@@ -20,7 +20,7 @@ permissions: read-all
 
 jobs:
   shell-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
       - name: Run ShellCheck

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -17,6 +17,12 @@ concurrency:
 
 permissions: read-all
 
+# Ubuntu 26.04 ships GCC 15, whose libstdc++ no longer transitively includes
+# <cstdint>. The bundled RocksDB 8.1.1 headers (librocksdb-sys 0.11.0+8.1.1)
+# use uint64_t without including it, so force-include cstdint when compiling C/C++.
+env:
+  CXXFLAGS: "-include cstdint"
+
 jobs:
   try-runtime:
     runs-on: ubuntu-26.04

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -19,7 +19,7 @@ permissions: read-all
 
 jobs:
   try-runtime:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/typescript-checks.yml
+++ b/.github/workflows/typescript-checks.yml
@@ -29,7 +29,7 @@ permissions: read-all
 jobs:
   execute-command:
     name: ${{ matrix.command }} / ${{ matrix.directory }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       matrix:
         directory:
@@ -68,7 +68,7 @@ jobs:
 
   deno-checks:
     name: ${{ matrix.command }} / ${{ matrix.directory }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       matrix:
         directory: [scripts/stress-test, scripts/usc-audit-automation]

--- a/.github/workflows/unit-test-cli.yml
+++ b/.github/workflows/unit-test-cli.yml
@@ -20,7 +20,7 @@ permissions: read-all
 
 jobs:
   unit-test-cli:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/validator-compatibility.yml
+++ b/.github/workflows/validator-compatibility.yml
@@ -54,7 +54,7 @@ jobs:
   # Discover the set of historical releases to test, as a JSON array of tags.
   # ---------------------------------------------------------------------------
   discover-versions:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       versions: ${{ steps.collect.outputs.versions }}
       count: ${{ steps.collect.outputs.count }}
@@ -134,7 +134,7 @@ jobs:
       git-lfs-checkout: true
       version-string: PR
       cache-key-name: build-creditcoin-node
-      runs-on: "['ubuntu-24.04']"
+      runs-on: "['ubuntu-26.04']"
     secrets: inherit
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -24,4 +24,4 @@ jobs:
       build-options: "--features devnet"
       build-subwasm: true
       version-string: ${{ github.sha }}
-      runs-on: "['ubuntu-24.04']"
+      runs-on: "['ubuntu-26.04']"

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,11 @@ RUN apt-get install -y --no-install-recommends \
 USER creditcoin
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | /bin/sh -s -- -y
 
+# Ubuntu 26.04 ships GCC 15, whose libstdc++ no longer transitively includes
+# <cstdint>. The bundled RocksDB 8.1.1 headers (librocksdb-sys 0.11.0+8.1.1)
+# use uint64_t without including it, so force-include cstdint when compiling C/C++.
+ENV CXXFLAGS="-include cstdint"
+
 COPY --chown=creditcoin:creditcoin . /creditcoin-node/
 # shellcheck source=/dev/null
 RUN source ~/.cargo/env && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3008,DL3009,DL3013,DL3016,SC3046,DL4006,SC1091,SC2086
-FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS runtime-base
+FROM ubuntu:26.04@sha256:b7f48194d4d8b763a478a621cdc81c27be222ba2206ca3ca6bc42b49685f3d9e AS runtime-base
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/actionlint.yml
+++ b/actionlint.yml
@@ -1,6 +1,9 @@
 ---
 self-hosted-runner:
   labels:
+    # ubuntu-26.04 is a valid hosted runner image but not yet in actionlint's
+    # built-in label list; whitelist it here so the runner-label check passes.
+    - ubuntu-26.04
     - proxy-attestor-chaos
     - proxy-attestator-network
     - proxy-benchmark


### PR DESCRIPTION
Updates all Ubuntu version references to **26.04** as requested.

### Changes
- **CI workflows** (`.github/workflows/*.yml`): all `runs-on: ubuntu-24.04` (incl. matrix `"['ubuntu-24.04']"`) → `ubuntu-26.04`.
- **Dockerfile**: `FROM ubuntu:24.04 AS runtime-base` → `ubuntu:26.04`.
- **Linode provisioning** (`.github/provision-linode-vm.sh`): `linode/ubuntu24.04` → `linode/ubuntu26.04`.

### Not changed (intentional)
- `ubuntu@` SSH user and `name: ubuntu` cloud-init user (usernames, not versions).
- `download.docker.com/linux/ubuntu` apt repo path (not a version).
- Non-Ubuntu base images (`postgres:18-alpine`, `denoland/deno`, `subquerynetwork/...`).

_Requested by @AtodorovGL via Slack._