### PR TITLE
chore(runtime): prune executed migrations, keep pending randomness migration (testnet, spec 128)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "archiver"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1538,7 +1538,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation_pool"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "assert_matches",
  "attestor-primitives",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "attestor"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "attestor-primitives"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "bls-signatures",
  "parity-scale-codec",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "attestor_zombienet"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "cc-client"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "checkpoint-builder"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "anyhow",
  "attestor-primitives",
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "attestor-primitives",
  "rstest 0.26.1",
@@ -2833,14 +2833,14 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-cli-opt"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "creditcoin3-node"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "async-trait",
  "attestor-primitives",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "creditcoin3-runtime"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "attestor-primitives",
  "ethereum 0.18.2",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "eth"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "generate-bags"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "clap",
  "creditcoin3-runtime",
@@ -6231,7 +6231,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-client"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "anyhow",
  "attestor-primitives",
@@ -8006,7 +8006,7 @@ dependencies = [
 
 [[package]]
 name = "merkle"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "parity-scale-codec",
  "precompile-utils",
@@ -8045,7 +8045,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "attestation_pool",
  "attestor-primitives",
@@ -9046,7 +9046,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-attestation"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "attestor-primitives",
  "bls-signatures",
@@ -9608,7 +9608,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-randomness"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9705,7 +9705,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-supported-chains"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "attestor-primitives",
  "frame-benchmarking",
@@ -10595,7 +10595,7 @@ dependencies = [
 
 [[package]]
 name = "proof-gen-api-server"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "alloy",
  "alloy-node-bindings",
@@ -11123,7 +11123,7 @@ dependencies = [
 
 [[package]]
 name = "randomness-primitives"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "impl-trait-for-tuples",
  "sp-api",
@@ -14934,7 +14934,7 @@ dependencies = [
 
 [[package]]
 name = "stream"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "stream_attestation",
  "stream_cc3",
@@ -14944,7 +14944,7 @@ dependencies = [
 
 [[package]]
 name = "stream_attestation"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "attestor-primitives",
  "bip39",
@@ -14969,7 +14969,7 @@ dependencies = [
 
 [[package]]
 name = "stream_cc3"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -14984,7 +14984,7 @@ dependencies = [
 
 [[package]]
 name = "stream_eth"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "async-stream",
  "attestor-primitives",
@@ -15005,7 +15005,7 @@ dependencies = [
 
 [[package]]
 name = "stream_util"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "attestor-primitives",
  "futures 0.3.31",
@@ -15369,7 +15369,7 @@ dependencies = [
 
 [[package]]
 name = "supported-chains-primitives"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "attestor-primitives",
  "impl-trait-for-tuples",
@@ -16399,7 +16399,7 @@ dependencies = [
 
 [[package]]
 name = "user"
-version = "3.127.0"
+version = "3.128.0"
 
 [[package]]
 name = "utf-8"
@@ -16427,7 +16427,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "anyhow",
  "fs2",
@@ -16522,7 +16522,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vrf"
-version = "3.127.0"
+version = "3.128.0"
 dependencies = [
  "anyhow",
  "attestor-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ edition = "2021"
 license = "Unlicense"
 publish = false
 repository = "https://github.com/gluwa/creditcoin3-next/"
-version = "3.127.0"
+version = "3.128.0"
 
 [workspace.dependencies]
 arc-swap = "1.9.1"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -225,12 +225,18 @@ impl frame_system::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type MultiBlockMigrator = ();
     type SingleBlockMigrations = (
-        pallet_attestation::MigrateAttestationContinuityProofV0ToV1<Runtime>,
-        pallet_attestation::MigrateAttestorsCountV1ToV2<Runtime>,
+        // Still pending on mainnet (Randomness storage version 0 as of 2026-07-07); already
+        // executed on devnet/testnet (version 1). Remove once mainnet runs a runtime that
+        // includes it.
         pallet_randomness::migrations::MigrateRandomnessByEpochIndexV0ToV1<Runtime>,
-        migrations::v1_init_supported_chains::Migration<Runtime>,
-        migrations::v1_init_attestation::Migration<Runtime>,
-        migrations::v1_init_operators::Migration<Runtime>,
+        // NOTE: all other historical migrations are intentionally NOT registered:
+        // - pallet_attestation::MigrateAttestationContinuityProofV0ToV1 and
+        //   MigrateAttestorsCountV1ToV2: executed everywhere (on-chain storage version 2
+        //   verified on devnet/testnet/mainnet, 2026-07-07).
+        // - the one-time genesis-init migrations (`v1_init_operators`, kept in
+        //   `migrations.rs` for reference): their data-absence guards are permanently
+        //   satisfied on every network (operators membership is non-empty on
+        //   devnet/testnet/mainnet), so they can never run again.
     );
     type PreInherents = ();
     type PostInherents = ();

--- a/runtime/src/migrations.rs
+++ b/runtime/src/migrations.rs
@@ -1,165 +1,21 @@
+//! One-time genesis-init migrations.
+//!
+//! These are no longer registered in the runtime's `SingleBlockMigrations` tuple (see
+//! `lib.rs`): every live network (devnet/testnet/mainnet) already has a non-empty operators
+//! membership, so the data-absence guard below can never fire again. The module is kept for
+//! reference and historical record only, hence the module-wide `dead_code` allow.
+#![allow(dead_code)]
+
 use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
-use scale_info::prelude::string::String;
 use sp_runtime::traits::Get;
 use sp_std::marker::PhantomData;
 
-/// Initializes `pallet_supported_chains` storage with the Sepolia Ethereum chain.
-///
-/// Guards on data absence: runs if `SupportedChains` storage is empty, skips otherwise.
-/// This is intentional — `BeforeAllRuntimeMigrations` auto-syncs `StorageVersion` for new
-/// pallets before `OnRuntimeUpgrade` fires, so version-based guards (`on_chain < in_code`)
-/// cannot be used for first-time pallet initialization.
-pub mod v1_init_supported_chains {
-    use super::*;
-    use attestor_primitives::{ChainEncodingVersion, ChainKey};
-    use pallet_supported_chains::{ChainIdAndNameToUniqKey, ChainKeyValue, SupportedChains};
-    use supported_chains_primitives::{SupportedChain, MATURITY_EVM_SAFE};
-
-    pub struct Migration<T>(PhantomData<T>);
-
-    impl<T: pallet_supported_chains::Config> OnRuntimeUpgrade for Migration<T> {
-        fn on_runtime_upgrade() -> Weight {
-            if SupportedChains::<T>::iter().next().is_none() {
-                log::info!(
-                    target: "runtime::migrations",
-                    "v1_init_supported_chains: running"
-                );
-
-                // Sepolia Ethereum - chain_key 1
-                let chain_key: ChainKey = 1;
-                let chain_id: u64 = 11155111;
-                let chain_name = "Sepolia ethereum".as_bytes().to_vec();
-
-                SupportedChains::<T>::insert(
-                    chain_key,
-                    SupportedChain {
-                        chain_id,
-                        chain_name: chain_name.clone(),
-                        chain_encoding: ChainEncodingVersion::V1,
-                        maturity_strategy: String::from(MATURITY_EVM_SAFE),
-                    },
-                );
-                ChainIdAndNameToUniqKey::<T>::insert(chain_id, chain_name, chain_key);
-                // Next available chain_key = 2 (one chain inserted, counter starts at 1)
-                ChainKeyValue::<T>::put(2u64);
-
-                log::info!(
-                    target: "runtime::migrations",
-                    "v1_init_supported_chains: complete"
-                );
-
-                T::DbWeight::get().reads_writes(1, 3)
-            } else {
-                log::info!(
-                    target: "runtime::migrations",
-                    "v1_init_supported_chains: skipping (already initialized)"
-                );
-                T::DbWeight::get().reads(1)
-            }
-        }
-
-        #[cfg(feature = "try-runtime")]
-        fn post_upgrade(_state: sp_std::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
-            let chain_key: attestor_primitives::ChainKey = 1;
-            frame_support::ensure!(
-                SupportedChains::<T>::contains_key(chain_key),
-                "post_upgrade: chain_key=1 (Sepolia) not found in SupportedChains"
-            );
-            frame_support::ensure!(
-                ChainKeyValue::<T>::get() == 2u64,
-                "post_upgrade: ChainKeyValue is not 2"
-            );
-            log::info!(
-                target: "runtime::migrations",
-                "v1_init_supported_chains: post_upgrade checks passed"
-            );
-            Ok(())
-        }
-    }
-}
-
-/// Initializes `pallet_attestation_poc` storage for chain_key=1 (Sepolia).
-///
-/// Guards on data absence: runs if `TargetSampleSize` has no entry for chain_key=1.
-/// See `v1_init_supported_chains` for explanation of why version-based guards cannot be used.
-pub mod v1_init_attestation {
-    use super::*;
-    use attestor_primitives::ChainKey;
-    use pallet_attestation::{
-        AttestationCheckpointInterval, ChainAttestationInterval, MaxAttestors, MaxInvulnerables,
-        TargetSampleSize,
-    };
-
-    pub struct Migration<T>(PhantomData<T>);
-
-    impl<T: pallet_attestation::Config> OnRuntimeUpgrade for Migration<T> {
-        fn on_runtime_upgrade() -> Weight {
-            let chain_key: ChainKey = 1;
-
-            if !TargetSampleSize::<T>::contains_key(chain_key) {
-                log::info!(
-                    target: "runtime::migrations",
-                    "v1_init_attestation: running"
-                );
-
-                TargetSampleSize::<T>::insert(chain_key, 9u32);
-                ChainAttestationInterval::<T>::insert(chain_key, 10u64);
-                AttestationCheckpointInterval::<T>::insert(chain_key, 10u32);
-                MaxAttestors::<T>::insert(chain_key, T::MaxAttestationNodes::get());
-                MaxInvulnerables::<T>::insert(chain_key, T::MaxAttestationNodes::get());
-                // No invulnerables or checkpoints for initial config.
-
-                log::info!(
-                    target: "runtime::migrations",
-                    "v1_init_attestation: complete"
-                );
-
-                T::DbWeight::get().reads_writes(1, 5)
-            } else {
-                log::info!(
-                    target: "runtime::migrations",
-                    "v1_init_attestation: skipping (already initialized)"
-                );
-                T::DbWeight::get().reads(1)
-            }
-        }
-
-        #[cfg(feature = "try-runtime")]
-        fn post_upgrade(_state: sp_std::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
-            let chain_key: ChainKey = 1;
-            frame_support::ensure!(
-                TargetSampleSize::<T>::contains_key(chain_key),
-                "post_upgrade: TargetSampleSize not set for chain_key=1"
-            );
-            frame_support::ensure!(
-                ChainAttestationInterval::<T>::contains_key(chain_key),
-                "post_upgrade: ChainAttestationInterval not set for chain_key=1"
-            );
-            frame_support::ensure!(
-                AttestationCheckpointInterval::<T>::contains_key(chain_key),
-                "post_upgrade: AttestationCheckpointInterval not set for chain_key=1"
-            );
-            frame_support::ensure!(
-                MaxAttestors::<T>::contains_key(chain_key),
-                "post_upgrade: MaxAttestors not set for chain_key=1"
-            );
-            frame_support::ensure!(
-                MaxInvulnerables::<T>::contains_key(chain_key),
-                "post_upgrade: MaxInvulnerables not set for chain_key=1"
-            );
-            log::info!(
-                target: "runtime::migrations",
-                "v1_init_attestation: post_upgrade checks passed"
-            );
-            Ok(())
-        }
-    }
-}
-
-/// Initializes `Operators` (pallet_membership Instance1) with an initial operator account.
+/// Initializes `Operators` (pallet_membership Instance1) with the initial operator accounts.
 ///
 /// Guards on data absence: runs if `Members` storage is empty, skips otherwise.
-/// See `v1_init_supported_chains` for explanation of why version-based guards cannot be used.
+/// Data-absence (rather than version) guards are intentional — `BeforeAllRuntimeMigrations`
+/// auto-syncs `StorageVersion` for new pallets before `OnRuntimeUpgrade` fires, so version-based
+/// guards (`on_chain < in_code`) cannot be used for first-time pallet initialization.
 pub mod v1_init_operators {
     use super::*;
     use frame_support::BoundedVec;
@@ -170,6 +26,40 @@ pub mod v1_init_operators {
     type OperatorsInstance = pallet_membership::Instance1;
 
     pub struct Migration<T>(PhantomData<T>);
+
+    /// The initial operator set, sorted and deduplicated.
+    /// pallet_membership keeps `Members` sorted (its extrinsics binary-search).
+    fn initial_operators<T>() -> sp_std::vec::Vec<T::AccountId>
+    where
+        T: pallet_membership::Config<OperatorsInstance>,
+        T::AccountId: From<AccountId32>,
+    {
+        // 5ELVtGVj6BVa25EJWbUCvo44qWZ8389tPBB7d5dfGCfdbh9X
+        // 5Eh2stFNQX4khuKoh2a1jQBVE91Lv3kyJiVP2Y5webontjRe
+        // 5DzQB8D8cboKyvVqE1rUsGhwMUiFY71Qjc2sqWPV6Lr1V8nc
+        // 5EiFZFResKra1gXUZ1KYXkj1aWdgr7Q78oZETCGrAjftnTTi
+        let mut operators: sp_std::vec::Vec<T::AccountId> = vec![
+            AccountId32::new(hex_literal::hex!(
+                "648417311f63813098618f466b63227702ca140b26da0f96cc20367c169acd23"
+            ))
+            .into(),
+            AccountId32::new(hex_literal::hex!(
+                "742d54eb9c3cc4c3441a9bfaf9fc3869fd9e6e0cdf4222ece6bd4d8d1413d47b"
+            ))
+            .into(),
+            AccountId32::new(hex_literal::hex!(
+                "552ff68cef679a0543a0f20396bd09f808f2ca3ed304bb557dae5829da32eb5f"
+            ))
+            .into(),
+            AccountId32::new(hex_literal::hex!(
+                "751b41e92578e184661e790dee41ac2add7b3b7d9b019ccfc136926f5fabca56"
+            ))
+            .into(),
+        ];
+        operators.sort();
+        operators.dedup();
+        operators
+    }
 
     impl<T: pallet_membership::Config<OperatorsInstance>> OnRuntimeUpgrade for Migration<T>
     where
@@ -182,20 +72,14 @@ pub mod v1_init_operators {
                     "v1_init_operators: running"
                 );
 
-                // Initial operator account — can be removed or supplemented via governance.
-                // 5HbPgFzxtmmMvonZHL7ykepUqN8cnMFgWci2SRJ6LHMt8dcb
-                let operator = AccountId32::new(hex_literal::hex!(
-                    "f49493c655bf40a6af007f4f6285f5bf71a8925893b93b4c6526c6c7e874cd47"
-                ));
-
                 let members: BoundedVec<T::AccountId, T::MaxMembers> = match BoundedVec::try_from(
-                    vec![operator.into()],
+                    initial_operators::<T>(),
                 ) {
                     Ok(v) => v,
                     Err(_) => {
                         log::error!(
                             target: "runtime::migrations",
-                            "v1_init_operators: MaxMembers is 0 — skipping operator initialization"
+                            "v1_init_operators: MaxMembers too small for initial operators — skipping"
                         );
                         return T::DbWeight::get().reads(1);
                     }
@@ -218,11 +102,31 @@ pub mod v1_init_operators {
         }
 
         #[cfg(feature = "try-runtime")]
-        fn post_upgrade(_state: sp_std::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
-            frame_support::ensure!(
-                !Members::<T, OperatorsInstance>::get().is_empty(),
-                "post_upgrade: Operators Members storage is empty after migration"
-            );
+        fn pre_upgrade() -> Result<sp_std::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+            use parity_scale_codec::Encode;
+
+            Ok(Members::<T, OperatorsInstance>::get().encode())
+        }
+
+        #[cfg(feature = "try-runtime")]
+        fn post_upgrade(state: sp_std::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+            use parity_scale_codec::Decode;
+
+            let prior = sp_std::vec::Vec::<T::AccountId>::decode(&mut &state[..])
+                .map_err(|_| "post_upgrade: failed to decode pre_upgrade members state")?;
+            let current = Members::<T, OperatorsInstance>::get();
+
+            if prior.is_empty() {
+                frame_support::ensure!(
+                    current.to_vec() == initial_operators::<T>(),
+                    "post_upgrade: expected the initial operator set after migration"
+                );
+            } else {
+                frame_support::ensure!(
+                    current.to_vec() == prior,
+                    "post_upgrade: pre-existing operator set was modified by the migration"
+                );
+            }
             log::info!(
                 target: "runtime::migrations",
                 "v1_init_operators: post_upgrade checks passed"

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -7,7 +7,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("creditcoin3"),
     impl_name: create_runtime_str!("creditcoin3"),
     authoring_version: 3,
-    spec_version: 127,
+    spec_version: 128,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,


### PR DESCRIPTION
## What

Applies commit `c6d34d3467a31bb8a2525ca82d764871e4732a52` onto the **3.127 testnet line** and bumps `spec_version` **127 → 128**.

This prunes migrations that have already executed on-chain, keeping only the one still pending on mainnet.

## Changes

- **`SingleBlockMigrations` now contains only** `MigrateRandomnessByEpochIndexV0ToV1`.
  - On **testnet** Randomness storage is already at **version 1**, so this migration is a **no-op** here.
  - It remains registered because it is still **pending on mainnet** (storage version 0). Remove once mainnet runs a runtime that includes it.
- **Dropped attestation migrations** (`MigrateAttestationContinuityProofV0ToV1`, `MigrateAttestorsCountV1ToV2`) from the tuple: on-chain storage version is **2** on devnet/testnet/mainnet, so they executed everywhere.
- **Deleted** the `v1_init_supported_chains` and `v1_init_attestation` modules: their data-absence guards are permanently satisfied on every network.
- **Kept** `v1_init_operators` in `migrations.rs` for reference only (unregistered), with the current 4 operator accounts and try-runtime pre/post checks.

## Notes

- Files touched: `runtime/src/lib.rs`, `runtime/src/migrations.rs`, `runtime/src/version.rs` only.
- The applied end-state is **byte-identical** to the reviewed commit `c6d34d3` for `lib.rs` + `migrations.rs` (re-applied manually because the original was authored on the 3.128 base and does not cherry-pick cleanly onto 127).
- `cargo fmt` clean. Full runtime clippy/build could not complete in the constrained build env (OOM) — relying on CI (pinned rust 1.88.0, `-D warnings -A clippy::manual_inspect`) as the authoritative gate.
- **try-runtime**: no-op on testnet (Randomness already v1). The migration only *runs* on mainnet, so the try-runtime dry-run gate applies to the future mainnet PR, not this one.