### PR TITLE
feat(DO-2217): add Docker Scout CI/CD gate and weekly Slack report

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -39,11 +39,14 @@ jobs:
           docker build -f scripts/stress-test/Dockerfile -t ${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }} --sbom=true --provenance=mode=max .
           docker images
 
-      # DO-2217: informational only — never fails the build. See DO-2104 for the org-wide compliance initiative.
+      # DO-2217: informational only — never fails the build (continue-on-error backs up exit-code:false
+      # in case the action itself errors, e.g. on an empty dockerhub-user during PR runs). See DO-2104
+      # for the org-wide compliance initiative. Runs unconditionally: local CVE scanning needs no
+      # DockerHub credentials — only org-policy evaluation does, and dockerhub-user/password are empty
+      # (not missing) on PR runs since docker-build doesn't inherit secrets there, which the action
+      # treats as "skip login, scan locally".
       - name: Docker Scout - CVE scan (${{ github.repository }})
-        if: env.DOCKER_PUSH_USERNAME
-        env:
-          DOCKER_PUSH_USERNAME: ${{ secrets.DOCKER_PUSH_USERNAME }}
+        continue-on-error: true
         uses: docker/scout-action@v1
         with:
           command: cves
@@ -53,9 +56,7 @@ jobs:
           exit-code: false
 
       - name: Docker Scout - CVE scan (${{ github.repository }}:indexer-for-${{ inputs.version-string }})
-        if: env.DOCKER_PUSH_USERNAME
-        env:
-          DOCKER_PUSH_USERNAME: ${{ secrets.DOCKER_PUSH_USERNAME }}
+        continue-on-error: true
         uses: docker/scout-action@v1
         with:
           command: cves
@@ -65,9 +66,7 @@ jobs:
           exit-code: false
 
       - name: Docker Scout - CVE scan (${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }})
-        if: env.DOCKER_PUSH_USERNAME
-        env:
-          DOCKER_PUSH_USERNAME: ${{ secrets.DOCKER_PUSH_USERNAME }}
+        continue-on-error: true
         uses: docker/scout-action@v1
         with:
           command: cves

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -39,6 +39,43 @@ jobs:
           docker build -f scripts/stress-test/Dockerfile -t ${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }} --sbom=true --provenance=mode=max .
           docker images
 
+      # DO-2217: informational only — never fails the build. See DO-2104 for the org-wide compliance initiative.
+      - name: Docker Scout - CVE scan (${{ github.repository }})
+        if: env.DOCKER_PUSH_USERNAME
+        env:
+          DOCKER_PUSH_USERNAME: ${{ secrets.DOCKER_PUSH_USERNAME }}
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: local://${{ github.repository }}:${{ inputs.version-string }}
+          dockerhub-user: ${{ secrets.DOCKER_PUSH_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PUSH_PASSWORD }}
+          exit-code: false
+
+      - name: Docker Scout - CVE scan (${{ github.repository }}:indexer-for-${{ inputs.version-string }})
+        if: env.DOCKER_PUSH_USERNAME
+        env:
+          DOCKER_PUSH_USERNAME: ${{ secrets.DOCKER_PUSH_USERNAME }}
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: local://${{ github.repository }}:indexer-for-${{ inputs.version-string }}
+          dockerhub-user: ${{ secrets.DOCKER_PUSH_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PUSH_PASSWORD }}
+          exit-code: false
+
+      - name: Docker Scout - CVE scan (${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }})
+        if: env.DOCKER_PUSH_USERNAME
+        env:
+          DOCKER_PUSH_USERNAME: ${{ secrets.DOCKER_PUSH_USERNAME }}
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: local://${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }}
+          dockerhub-user: ${{ secrets.DOCKER_PUSH_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PUSH_PASSWORD }}
+          exit-code: false
+
       - name: Export docker image into a file
         run: |
           mkdir -p "${{ runner.temp }}/gluwa/"

--- a/.github/workflows/docker-scout-weekly-report.yml
+++ b/.github/workflows/docker-scout-weekly-report.yml
@@ -1,0 +1,79 @@
+---
+name: Docker Scout Weekly Report
+
+"on":
+  schedule:
+    # every Monday at 09:00 EDT / 13:00 UTC
+    - cron: "0 13 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  scout-weekly-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Docker Scout CLI
+        run: curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
+
+      - name: Docker Hub login (Scout org policy evaluation)
+        env:
+          DOCKER_PUSH_USERNAME: ${{ secrets.DOCKER_PUSH_USERNAME }}
+          DOCKER_PUSH_PASSWORD: ${{ secrets.DOCKER_PUSH_PASSWORD }}
+        run: echo "$DOCKER_PUSH_PASSWORD" | docker login -u "$DOCKER_PUSH_USERNAME" --password-stdin
+
+      # Only the main image has a stable :latest tag (mainnet builds only).
+      # The indexer and proof-gen-stress-test images are only ever pushed with
+      # per-version tags, so we resolve each to its most-recently-pushed
+      # digest from Docker Hub before scanning — pinning to a sha rather than
+      # a moving tag name, same reasoning as the DO-2206 base image pin.
+      - name: Resolve current published digests and run Scout quickview
+        id: scout
+        run: |
+          set -euo pipefail
+
+          TAGS_JSON=$(curl -fsSL "https://hub.docker.com/v2/repositories/gluwa/creditcoin3/tags?page_size=100&ordering=last_updated")
+
+          resolve() {
+            local mode="$1" pattern="$2"
+            echo "$TAGS_JSON" | jq -r --arg p "$pattern" --arg m "$mode" '
+              ([.results[] | select(
+                if $m == "exact" then .name == $p else (.name | startswith($p)) end
+              )] | sort_by(.last_updated) | reverse | .[0]) // {} | "\(.name // "null")|\(.digest // "null")"'
+          }
+
+          report=""
+          for entry in "main|exact|latest" "indexer|prefix|indexer-for-" "proof-gen-stress-test|prefix|proof-gen-stress-test-for-"; do
+            label="${entry%%|*}"
+            rest="${entry#*|}"
+            mode="${rest%%|*}"
+            pattern="${rest#*|}"
+
+            resolved=$(resolve "$mode" "$pattern")
+            tag="${resolved%%|*}"
+            digest="${resolved##*|}"
+
+            if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+              report="${report}*${label}*: no published tag found matching \`${pattern}*\`\n"
+              continue
+            fi
+
+            quickview=$(docker scout quickview "gluwa/creditcoin3@${digest}" 2>&1 || true)
+            report="${report}*${label}* (\`${tag}\`)\n\`\`\`\n${quickview}\n\`\`\`\n"
+          done
+
+          {
+            echo "report<<SCOUT_EOF"
+            echo -e "$report"
+            echo "SCOUT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Report to Penguin Patrol
+        uses: gluwa/penguin-patrol-message@v1
+        with:
+          webhook-url: ${{ secrets.PENGUIN_PATROL_WEBHOOK_URL }}
+          alert-title: "Weekly Docker Scout Report — creditcoin3"
+          channel: "#noti-docker-scout"
+          message: |
+            ${{ steps.scout.outputs.report }}
+            Full org dashboard: https://scout.docker.com/reports/org/gluwa/overview

--- a/.github/workflows/docker-scout-weekly-report.yml
+++ b/.github/workflows/docker-scout-weekly-report.yml
@@ -32,14 +32,33 @@ jobs:
         run: |
           set -euo pipefail
 
-          TAGS_JSON=$(curl -fsSL "https://hub.docker.com/v2/repositories/gluwa/creditcoin3/tags?page_size=100&ordering=last_updated")
-
           resolve() {
+            # Paginates through Docker Hub tags (newest-first, per ordering=last_updated) until a
+            # tag matching the given pattern is found or MAX_PAGES is exhausted. A single 100-tag
+            # page can miss indexer/stress-test tags if enough other tags were pushed more recently.
+            # Prints "name|digest", or "null|null" if nothing matched.
             local mode="$1" pattern="$2"
-            echo "$TAGS_JSON" | jq -r --arg p "$pattern" --arg m "$mode" '
-              ([.results[] | select(
-                if $m == "exact" then .name == $p else (.name | startswith($p)) end
-              )] | sort_by(.last_updated) | reverse | .[0]) // {} | "\(.name // "null")|\(.digest // "null")"'
+            local url="https://hub.docker.com/v2/repositories/gluwa/creditcoin3/tags?page_size=100&ordering=last_updated"
+            local page=0 max_pages=10
+
+            while [ -n "$url" ] && [ "$url" != "null" ] && [ "$page" -lt "$max_pages" ]; do
+              page=$((page + 1))
+              local response
+              response=$(curl -fsSL "$url")
+
+              local match
+              match=$(echo "$response" | jq -r --arg p "$pattern" --arg m "$mode" '
+                [.results[] | select(if $m == "exact" then .name == $p else (.name | startswith($p)) end)] | .[0] // {} | "\(.name // "null")|\(.digest // "null")"')
+
+              if [ "${match%%|*}" != "null" ]; then
+                echo "$match"
+                return
+              fi
+
+              url=$(echo "$response" | jq -r '.next // empty')
+            done
+
+            echo "null|null"
           }
 
           report=""
@@ -54,7 +73,12 @@ jobs:
             digest="${resolved##*|}"
 
             if [ -z "$tag" ] || [ "$tag" = "null" ]; then
-              report="${report}*${label}*: no published tag found matching \`${pattern}*\`\n"
+              report="${report}*${label}*: no published tag found matching \`${pattern}*\` (searched up to 10 pages)\n"
+              continue
+            fi
+
+            if [ -z "$digest" ] || [ "$digest" = "null" ]; then
+              report="${report}*${label}* (\`${tag}\`): matched but Docker Hub returned no digest, skipping scan\n"
               continue
             fi
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,32 +32,6 @@ jobs:
       version-string: "latest"
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-docker-build']"
 
-  docker-scout:
-    needs:
-      - docker-build
-    runs-on: ubuntu-26.04
-    steps:
-      - name: Download locally built docker image
-        uses: actions/download-artifact@v8
-        with:
-          name: locally-built-docker-image
-          path: ${{ runner.temp }}/gluwa/
-
-      - name: Load locally built docker image
-        run: |
-          docker load --input ${{ runner.temp }}/${{ github.repository }}.tar
-          docker images
-
-      # DO-2217: informational only — never fails the build. See DO-2104 for the org-wide compliance initiative.
-      # docker-build doesn't inherit secrets on PR runs (so it never pushes here) — scan the
-      # locally-loaded image straight from the build artifact instead, no DockerHub login needed.
-      - name: Docker Scout - CVE scan (${{ github.repository }})
-        uses: docker/scout-action@v1
-        with:
-          command: cves
-          image: local://${{ github.repository }}:latest
-          exit-code: false
-
   docker-test:
     needs:
       - docker-build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,32 @@ jobs:
       build-options: "BUILD_ARGS="
       version-string: "latest"
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-docker-build']"
-    secrets: inherit
+
+  docker-scout:
+    needs:
+      - docker-build
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Download locally built docker image
+        uses: actions/download-artifact@v8
+        with:
+          name: locally-built-docker-image
+          path: ${{ runner.temp }}/gluwa/
+
+      - name: Load locally built docker image
+        run: |
+          docker load --input ${{ runner.temp }}/${{ github.repository }}.tar
+          docker images
+
+      # DO-2217: informational only — never fails the build. See DO-2104 for the org-wide compliance initiative.
+      # docker-build doesn't inherit secrets on PR runs (so it never pushes here) — scan the
+      # locally-loaded image straight from the build artifact instead, no DockerHub login needed.
+      - name: Docker Scout - CVE scan (${{ github.repository }})
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: local://${{ github.repository }}:latest
+          exit-code: false
 
   docker-test:
     needs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,7 @@ jobs:
       build-options: "BUILD_ARGS="
       version-string: "latest"
       runs-on: "['self-hosted', 'workflow-${{ github.run_id }}', 'proxy-docker-build']"
+    secrets: inherit
 
   docker-test:
     needs:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -33,3 +33,4 @@ https://prover(.*)creditcoin.network/
 https://proof-gen-api(.*)creditcoin.network/
 https://nixos.wiki/wiki/flakes#Enable_flakes_temporarily
 https://opencollective.com/(.*)
+https://scout\.docker\.com/(.*)


### PR DESCRIPTION
## Summary
- Add informational (non-blocking) Docker Scout CVE scan steps to `build-docker.yml` for all 3 published images (main, indexer, proof-gen-stress-test) — `exit-code: false`, never fails the build
- Add `docker-scout-weekly-report.yml`: scheduled workflow (Mon 09:00 EDT + workflow_dispatch) that resolves each image's most-recently-pushed digest via the Docker Hub API (indexer/proof-gen-stress-test have no stable `:latest` tag), runs `docker scout quickview`, and posts the summary to `#noti-docker-scout` via `gluwa/penguin-patrol-message@v1`

## Notes
- Continuation of DO-2206, part of the DO-2104 org-wide Docker Scout compliance initiative
- Discovered while working this: `cc3-indexer/Dockerfile` and `scripts/stress-test/Dockerfile` use unpinned floating base images that DO-2206 never covered — follow-up DO-2231 opened, will land in this same PR before merge
- Requires before merge: PenguinPatrol bot invited to `#noti-docker-scout`, `PENGUIN_PATROL_WEBHOOK_URL` org secret confirmed available to this repo

Closes DO-2217

## Test plan
- [ ] Manually trigger `docker-scout-weekly-report.yml` via workflow_dispatch and confirm a message lands in #noti-docker-scout
- [ ] Confirm the new Scout steps in `build-docker.yml` run informationally on a PR build without blocking