### PR TITLE
Add test-against-fork CI with latest released binary

### DIFF
--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -358,7 +358,7 @@ jobs:
           name: live-sync-creditcoin-logs
           path: "*.log"
 
-  test-against-fork:
+  test-against-fork-current-release:
     needs:
       - setup
       - setup-self-hosted
@@ -469,10 +469,138 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test-against-fork-logs
+          name: test-against-fork-current-release-logs
           path: "*.log"
 
       - name: Kill creditcoin3-node
+        if: always()
+        run: |
+          killall -9 creditcoin3-node
+
+  test-against-fork-latest-release:
+    needs:
+      - setup
+      - setup-self-hosted
+      - build-sut
+      - fork-creditcoin
+      - deploy-github-runner
+      - test-against-fork-current-release
+    runs-on:
+      [self-hosted, "workflow-${{ github.run_id }}", "type-runtime-upgrade"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download creditcoin3-node from release ${{ needs.setup.outputs.release_tag }}
+        uses: i3h/download-release-asset@v1
+        with:
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          tag: ${{ needs.setup.outputs.release_tag }}
+          file: ${{ needs.setup.outputs.artifact_name }}
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Download creditcoin-fork.json
+        uses: actions/download-artifact@v8
+        with:
+          name: creditcoin-fork.json
+
+      - name: Start a local creditcoin3-node from the fork (latest release binary)
+        run: |
+          sudo apt-get update
+          sudo apt install -y unzip
+
+          unzip creditcoin-*-unknown-linux-gnu.zip
+          chmod a+x ./creditcoin3-node
+
+          ./creditcoin3-node --version
+          ./creditcoin3-node --chain ./creditcoin-fork.json --validator --alice --pruning archive \
+                            --unsafe-force-node-key-generation \
+                            --base-path /mnt/fork-data-latest-release >creditcoin3-node-with-forked-chain.log 2>&1 &
+
+      - name: Wait for blockchain to start
+        run: |
+          .github/wait-for-creditcoin.sh
+
+      - name: Install JS Dependencies
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: 'yarn'
+          cache-dependency-path: cli/yarn.lock
+      - working-directory: cli
+        run: |
+          npm install -g yarn
+          npm install -g node-gyp
+          yarn install
+          yarn build
+
+      - name: Download subwasm from release ${{ needs.setup.outputs.devnet_release_tag }}
+        uses: i3h/download-release-asset@v1
+        with:
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          tag: ${{ needs.setup.outputs.devnet_release_tag }}
+          file: subwasm
+          path: /usr/local/bin
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Download WASM runtime from current PR
+        id: download-wasm
+        uses: actions/download-artifact@v8
+        with:
+          name: creditcoin_node_runtime.compact.compressed.wasm-PR
+
+      - name: Upgrade WASM
+        working-directory: cli
+        run: |
+          sudo chmod a+x /usr/local/bin/subwasm
+          subwasm --version
+
+          node dist/scripts/runtimeUpgrade.js ws://127.0.0.1:9944  ../creditcoin3_runtime.compact.compressed.wasm //Alice 0
+        env:
+          # WARNING: always quote otherwise we get "2E+24" which can't parse
+          NEW_SUDO_BALANCE: "2000000000000000000000000"
+
+      - name: Is Creditcoin still there after 3 minutes
+        run: |
+          sleep 180
+          .github/wait-for-creditcoin.sh
+
+      - name: Check for errors
+        run: |
+          grep -vz "WASM backtrace:"   creditcoin3-node-with-forked-chain.log
+          grep -vz "Proposing failed:" creditcoin3-node-with-forked-chain.log
+
+      - name: Execute blockchain integration tests
+        working-directory: ./cli
+        run: |
+          yarn install
+          yarn test:blockchain
+        env:
+          BLOCKCHAIN_TESTS_GLOBAL_SETUP: "./runtimeUpgradeTestingAgainstFork.ts"
+          SKIP_ON_PURPOSE: "true"
+
+      - name: Configure testing environment
+        id: test-env
+        working-directory: ./cli
+        run: |
+          yarn install
+          # NOTE: `creditcoin-fork --base dev` so we have development accounts here
+          EVM_PRIVATE_KEY=$(node dist/test/blockchainSetup.js)
+
+          echo "url=http://127.0.0.1:9944" >> "$GITHUB_OUTPUT"
+          echo "private_key=$EVM_PRIVATE_KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: test-against-fork-latest-release-logs
+          path: "*.log"
+
+      - name: Kill creditcoin3-node
+        if: always()
         run: |
           killall -9 creditcoin3-node
 
@@ -490,7 +618,8 @@ jobs:
   remove-github-runner:
     needs:
       - deploy-github-runner
-      - test-against-fork
+      - test-against-fork-current-release
+      - test-against-fork-latest-release
     if: ${{ always() }}
     uses: ./.github/workflows/remove-runner.yml
     with:


### PR DESCRIPTION
Adds two new jobs to the `Runtime Upgrade` workflow that catch **reverse incompatibilities** — i.e. a new WASM runtime that cannot execute on an older node binary still running in production.

## What changes

The `setup` job now unconditionally resolves both the latest **testnet** and **mainnet** release tags (via `.github/extract-release-tag.sh`), regardless of which branch the PR targets.

Two new `test-against-fork-*-release` jobs are added **after** the existing `test-against-fork` job, running sequentially on the same `type-runtime-upgrade` self-hosted runner to avoid port-9944 / `/mnt` conflicts:

| Job | Node binary | Base path |
|-----|-------------|-----------|
| `test-against-fork` (existing) | Built from this PR | `/mnt/fork-data` |
| `test-against-fork-testnet-release` (**new**) | Latest testnet release (`3.128.0-testnet`) | `/mnt/fork-data-testnet-release` |
| `test-against-fork-mainnet-release` (**new**) | Latest mainnet release (`3.125.0-mainnet`) | `/mnt/fork-data-mainnet-release` |

Each new job:
1. Kills any lingering `creditcoin3-node` (safety cleanup from previous job)
2. Downloads the release binary via `i3h/download-release-asset`
3. Unzips and starts the node against the forked chainspec
4. Applies the PR WASM via `runtimeUpgrade.js`
5. Waits 3 min, checks for errors, runs blockchain integration tests
6. Kills the node

## Why

Testnet deploys a new WASM on the network before mainnet nodes are upgraded. If the new WASM introduces a host function or storage migration that the old mainnet binary can't handle, the chain stalls. These jobs surface that class of failure in CI before the PR merges.

Based on the approach in #1141.
