### PR TITLE
feat(write-ability): core (protocol) fee — storage, governance extrinsic, EVM exposure

### DIFF
--- a/pallets/supported-chains/src/benchmarking.rs
+++ b/pallets/supported-chains/src/benchmarking.rs
@@ -81,4 +81,22 @@ mod benchmarks {
             true,
         )
     }
+
+    #[benchmark]
+    fn set_core_fee() {
+        // Setup
+        let root_origin = <T as frame_system::Config>::RuntimeOrigin::root();
+        // In mock.rs we set up a single supported chain with chain_key 1
+        let chain_key: ChainKey = 1;
+
+        #[extrinsic_call]
+        _(
+            root_origin as <T as frame_system::Config>::RuntimeOrigin,
+            chain_key,
+            // ERC20-denominated is the encoding worst case (Some(H160) vs None); must be
+            // non-zero: the extrinsic rejects Some(H160::zero()) with ZeroCoreFeeToken.
+            Some(H160::repeat_byte(0x02)),
+            sp_core::U256::from(1_000_000_000_000_000_000u128),
+        )
+    }
 }

--- a/pallets/supported-chains/src/lib.rs
+++ b/pallets/supported-chains/src/lib.rs
@@ -34,7 +34,7 @@ pub mod pallet {
     use supported_chains_primitives::{
         chain_removal_listener::ChainRemovalListener,
         provider::{OnRegisterChainProvider as OnChainRegisteredProvider, SupportedChainsProvider},
-        SupportedChain, WriteAbilityConfig,
+        CoreFeeConfig, SupportedChain, WriteAbilityConfig,
     };
 
     /// The in-code storage version.
@@ -77,6 +77,7 @@ pub mod pallet {
         fn remove_chain() -> Weight;
         fn set_outbox_factory_addr() -> Weight;
         fn set_write_ability_config() -> Weight;
+        fn set_core_fee() -> Weight;
     }
 
     #[pallet::storage]
@@ -122,6 +123,19 @@ pub mod pallet {
         Hasher = Blake2_128Concat,
         Key = ChainKey,
         Value = WriteAbilityConfig,
+        QueryKind = OptionQuery,
+    >;
+
+    /// Per-chain USC write-ability core (protocol) fee, charged by the Outbox on every
+    /// `publishMessage`. Read live by the EVM through the chain-info precompile
+    /// (`get_core_fee(uint64)`), so a governance change takes effect on the next publish with no
+    /// contract redeploys. No entry (or a zero amount) means no fee is charged.
+    #[pallet::storage]
+    #[pallet::getter(fn core_fee)]
+    pub type CoreFees<T> = StorageMap<
+        Hasher = Blake2_128Concat,
+        Key = ChainKey,
+        Value = CoreFeeConfig,
         QueryKind = OptionQuery,
     >;
 
@@ -229,6 +243,15 @@ pub mod pallet {
             write_ability_chain_key: [u8; 32],
             message_attestation_enabled: bool,
         },
+
+        /// The USC write-ability core (protocol) fee for a supported chain has been set.
+        /// `token: None` means the fee is denominated in native CTC; `Some(address)` an ERC20
+        /// (attestcoin). A zero `amount` disables the fee.
+        CoreFeeSet {
+            chain_key: ChainKey,
+            token: Option<H160>,
+            amount: sp_core::U256,
+        },
     }
 
     #[pallet::error]
@@ -253,6 +276,11 @@ pub mod pallet {
         /// The write-ability chain key is all zero bytes. It is bound into every `messageHash`, so a
         /// zero key would break cross-chain attestation; rejected to fail loudly at configuration time.
         ZeroWriteAbilityChainKey,
+
+        /// The core-fee token is `Some(H160::zero())`. On the EVM side the zero address means
+        /// "native currency", which this config expresses as `None` — a zero ERC20 address is
+        /// always a misconfiguration and would make the Outbox `transferFrom` the zero address.
+        ZeroCoreFeeToken,
     }
 
     #[pallet::call]
@@ -359,6 +387,8 @@ pub mod pallet {
 
             WriteAbilityConfigs::<T>::remove(chain_key);
 
+            CoreFees::<T>::remove(chain_key);
+
             SupportedChains::<T>::remove(chain_key);
 
             // Notify event listeners
@@ -442,6 +472,42 @@ pub mod pallet {
 
             Ok(())
         }
+
+        /// Sets the USC write-ability core (protocol) fee for a supported chain, charged by that
+        /// chain's Outbox on every `publishMessage`. `token: None` denominates the fee in native
+        /// CTC (paid via `msg.value`); `Some(address)` in an ERC20 on Creditcoin's EVM
+        /// (attestcoin, pulled via `transferFrom`). A zero `amount` disables the fee. Only
+        /// accounts in the Operators membership (or root) can call this extrinsic.
+        ///
+        /// The value is read live by the EVM through the chain-info precompile
+        /// (`get_core_fee(uint64)`), so changes take effect on the next publish without any
+        /// contract redeploys — including a later native→attestcoin denomination switch.
+        #[pallet::call_index(4)]
+        #[pallet::weight(T::WeightInfo::set_core_fee())]
+        pub fn set_core_fee(
+            origin: OriginFor<T>,
+            chain_key: ChainKey,
+            token: Option<H160>,
+            amount: sp_core::U256,
+        ) -> DispatchResult {
+            T::OperatorsOrigin::ensure_origin(origin)?;
+
+            ensure!(
+                SupportedChains::<T>::contains_key(chain_key),
+                Error::<T>::ChainNotSupported
+            );
+            ensure!(token != Some(H160::zero()), Error::<T>::ZeroCoreFeeToken);
+
+            CoreFees::<T>::insert(chain_key, CoreFeeConfig { token, amount });
+
+            Self::deposit_event(Event::CoreFeeSet {
+                chain_key,
+                token,
+                amount,
+            });
+
+            Ok(())
+        }
     }
 
     impl<T: Config> SupportedChainsProvider for Pallet<T> {
@@ -472,6 +538,10 @@ pub mod pallet {
 
         fn get_outbox_factory_address(chain_key: ChainKey) -> Option<H160> {
             OutboxFactories::<T>::get(chain_key)
+        }
+
+        fn get_core_fee(chain_key: ChainKey) -> Option<CoreFeeConfig> {
+            CoreFees::<T>::get(chain_key)
         }
     }
 }

--- a/pallets/supported-chains/src/tests.rs
+++ b/pallets/supported-chains/src/tests.rs
@@ -1,17 +1,17 @@
 use crate::{
-    self as pallet, mock, mock::SupportedChain, mock::*, Error, OutboxFactories, SupportedChains,
-    WriteAbilityConfigs,
+    self as pallet, mock, mock::SupportedChain, mock::*, CoreFees, Error, OutboxFactories,
+    SupportedChains, WriteAbilityConfigs,
 };
 use attestor_primitives::ChainEncodingVersion;
 use frame_support::{assert_noop, assert_ok};
 use rstest::rstest;
-use sp_core::H160;
+use sp_core::{H160, U256};
 use sp_runtime::{traits::BadOrigin, BuildStorage};
-use supported_chains_primitives::WriteAbilityConfig;
 use supported_chains_primitives::{
     provider::SupportedChainsProvider, MATURITY_EVM_FINALIZED, MATURITY_EVM_LATEST,
     MATURITY_EVM_SAFE, MATURITY_FIXED_DELAY, MATURITY_FIXED_DELAY_10,
 };
+use supported_chains_primitives::{CoreFeeConfig, WriteAbilityConfig};
 
 #[test]
 fn register_chain_works() {
@@ -874,5 +874,173 @@ fn genesis_seeds_outbox_factories() {
             <SupportedChain as SupportedChainsProvider>::get_outbox_factory_address(1),
             Some(address)
         );
+    });
+}
+
+#[test]
+fn set_core_fee_works_native() {
+    ExtBuilder.build_and_execute(|| {
+        System::set_block_number(1);
+
+        let chain_key = 1;
+        let amount = U256::from(1_000_000_000_000_000_000u128); // 1 CTC
+
+        assert_eq!(CoreFees::<Test>::get(chain_key), None);
+
+        // token: None = fee denominated in native CTC.
+        assert_ok!(SupportedChain::set_core_fee(
+            RuntimeOrigin::root(),
+            chain_key,
+            None,
+            amount,
+        ));
+
+        assert_eq!(
+            CoreFees::<Test>::get(chain_key),
+            Some(CoreFeeConfig {
+                token: None,
+                amount
+            })
+        );
+
+        System::assert_last_event(
+            crate::Event::CoreFeeSet {
+                chain_key,
+                token: None,
+                amount,
+            }
+            .into(),
+        );
+    });
+}
+
+#[test]
+fn set_core_fee_works_erc20_and_overwrites() {
+    ExtBuilder.build_and_execute(|| {
+        System::set_block_number(1);
+
+        let chain_key = 1;
+        let token = H160::repeat_byte(0x22);
+        let amount = U256::from(5u64);
+
+        assert_ok!(SupportedChain::set_core_fee(
+            RuntimeOrigin::root(),
+            chain_key,
+            None,
+            U256::from(1u64),
+        ));
+        // The planned native -> attestcoin denomination switch is exactly this overwrite: one
+        // governance call, no migration.
+        assert_ok!(SupportedChain::set_core_fee(
+            RuntimeOrigin::root(),
+            chain_key,
+            Some(token),
+            amount,
+        ));
+
+        assert_eq!(
+            CoreFees::<Test>::get(chain_key),
+            Some(CoreFeeConfig {
+                token: Some(token),
+                amount
+            })
+        );
+    });
+}
+
+#[test]
+fn set_core_fee_should_error_when_not_signed() {
+    ExtBuilder.build_and_execute(|| {
+        assert_noop!(
+            SupportedChain::set_core_fee(RuntimeOrigin::none(), 1, None, U256::from(1u64)),
+            BadOrigin
+        );
+    });
+}
+
+#[test]
+fn set_core_fee_should_error_when_not_signed_by_operator() {
+    ExtBuilder.build_and_execute(|| {
+        let chain_key = 1;
+        let amount = U256::from(1u64);
+
+        assert_noop!(
+            SupportedChain::set_core_fee(RuntimeOrigin::signed(2), chain_key, None, amount),
+            BadOrigin
+        );
+
+        assert_ok!(SupportedChain::set_core_fee(
+            RuntimeOrigin::signed(OPERATOR_ACCOUNT),
+            chain_key,
+            None,
+            amount,
+        ));
+
+        assert_eq!(
+            CoreFees::<Test>::get(chain_key),
+            Some(CoreFeeConfig {
+                token: None,
+                amount
+            })
+        );
+    });
+}
+
+#[test]
+fn set_core_fee_should_error_when_chain_is_not_supported() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+
+        assert_noop!(
+            SupportedChain::set_core_fee(RuntimeOrigin::root(), 1, None, U256::from(1u64)),
+            Error::<Test>::ChainNotSupported
+        );
+
+        assert_eq!(CoreFees::<Test>::get(1), None);
+    });
+}
+
+#[test]
+fn set_core_fee_should_error_when_token_is_zero_address() {
+    ExtBuilder.build_and_execute(|| {
+        System::set_block_number(1);
+
+        // Some(zero) is always a misconfiguration: address(0) means "native" on the EVM side and
+        // must be expressed as None here — an Outbox transferFrom(address(0)) would be broken.
+        assert_noop!(
+            SupportedChain::set_core_fee(
+                RuntimeOrigin::root(),
+                1,
+                Some(H160::zero()),
+                U256::from(1u64),
+            ),
+            Error::<Test>::ZeroCoreFeeToken
+        );
+
+        assert_eq!(CoreFees::<Test>::get(1), None);
+    });
+}
+
+#[test]
+fn remove_chain_clears_core_fee() {
+    ExtBuilder.build_and_execute(|| {
+        System::set_block_number(1);
+
+        let chain_key = 1;
+        assert_ok!(SupportedChain::set_core_fee(
+            RuntimeOrigin::root(),
+            chain_key,
+            None,
+            U256::from(7u64),
+        ));
+        assert!(CoreFees::<Test>::get(chain_key).is_some());
+
+        assert_ok!(SupportedChain::remove_chain(
+            RuntimeOrigin::root(),
+            chain_key,
+            true
+        ));
+
+        assert_eq!(CoreFees::<Test>::get(chain_key), None);
     });
 }

--- a/pallets/supported-chains/src/weights.rs
+++ b/pallets/supported-chains/src/weights.rs
@@ -176,4 +176,29 @@ impl<T: frame_system::Config> crate::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	/// Storage: `SupportedChains::SupportedChains` (r:1 w:0)
+	/// Proof: `SupportedChains::SupportedChains` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `System::Number` (r:1 w:0)
+	/// Proof: `System::Number` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `System::ExecutionPhase` (r:1 w:0)
+	/// Proof: `System::ExecutionPhase` (`max_values`: Some(1), `max_size`: Some(5), added: 500, mode: `MaxEncodedLen`)
+	/// Storage: `System::EventCount` (r:1 w:1)
+	/// Proof: `System::EventCount` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `System::Events` (r:1 w:1)
+	/// Proof: `System::Events` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SupportedChains::CoreFees` (r:0 w:1)
+	/// Proof: `SupportedChains::CoreFees` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	// NOTE: copied from `set_write_ability_config` (identical storage-access shape: one
+	// SupportedChains read + one map insert + event) pending regeneration via the BENCHMARKS
+	// workflow.
+	fn set_core_fee() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `369`
+		//  Estimated: `3834`
+		// Minimum execution time: 27_230_000 picoseconds.
+		Weight::from_parts(28_220_000, 0)
+			.saturating_add(Weight::from_parts(0, 3834))
+			.saturating_add(T::DbWeight::get().reads(5))
+			.saturating_add(T::DbWeight::get().writes(3))
+	}
 }

--- a/precompiles/chain-info/src/lib.rs
+++ b/precompiles/chain-info/src/lib.rs
@@ -6,7 +6,7 @@ use frame_support::{
     dispatch::{GetDispatchInfo, PostDispatchInfo},
     sp_runtime::traits::Dispatchable,
 };
-use sp_core::{Encode, H160, H256};
+use sp_core::{Encode, H160, H256, U256};
 use sp_std::vec::Vec;
 
 use attestor_primitives::{ChainId, ChainKey};
@@ -15,7 +15,7 @@ use pallet_attestation::{
     LastDigest, Pallet as PalletAttestationPoc, CHECKPOINT_BUCKET_SIZE,
 };
 use pallet_evm::AddressMapping;
-use pallet_supported_chains::{OutboxFactories, SupportedChains};
+use pallet_supported_chains::{CoreFees, OutboxFactories, SupportedChains};
 use precompile_utils::{prelude::*, solidity::Codec};
 
 // Gas cost constants
@@ -60,6 +60,18 @@ impl ChainInfoResult {
 #[derive(Debug, Clone, PartialEq, Eq, Default, Codec)]
 pub struct OutboxFactoryResult {
     pub factory_addr: Address,
+    pub exists: bool,
+}
+
+/// USC write-ability core (protocol) fee for a chain, read live from pallet storage so the
+/// Outbox charges the current governance-set value on every `publishMessage` without redeploys.
+/// `token == address(0)` denominates the fee in native CTC (`msg.value`); any other address is an
+/// ERC20 on this EVM (attestcoin, pulled via `transferFrom`). `exists == false` (or a zero
+/// `amount`) means no fee is configured — the Outbox charges nothing.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Codec)]
+pub struct CoreFeeResult {
+    pub token: Address,
+    pub amount: U256,
     pub exists: bool,
 }
 
@@ -187,6 +199,38 @@ where
             }),
             None => Ok(OutboxFactoryResult {
                 factory_addr: Address(H160::zero()),
+                exists: false,
+            }),
+        }
+    }
+
+    #[precompile::public("get_core_fee(uint64)")]
+    #[precompile::view]
+    fn get_core_fee(
+        handle: &mut impl PrecompileHandle,
+        chain_key: ChainKey,
+    ) -> EvmResult<CoreFeeResult> {
+        let maybe_fee = CoreFees::<Runtime>::get(chain_key);
+
+        handle.record_db_read::<Runtime>(
+            maybe_fee
+                .as_ref()
+                .map(|fee| fee.encoded_size())
+                .unwrap_or_default(),
+        )?;
+
+        match maybe_fee {
+            Some(fee) => Ok(CoreFeeResult {
+                // `token: None` (native CTC) surfaces as address(0) — the conventional "native"
+                // sentinel on the EVM side. The extrinsic rejects Some(H160::zero()), so a zero
+                // token here always means native, never a broken ERC20 config.
+                token: Address(fee.token.unwrap_or_default()),
+                amount: fee.amount,
+                exists: true,
+            }),
+            None => Ok(CoreFeeResult {
+                token: Address(H160::zero()),
+                amount: U256::zero(),
                 exists: false,
             }),
         }

--- a/precompiles/chain-info/src/tests.rs
+++ b/precompiles/chain-info/src/tests.rs
@@ -3,8 +3,8 @@ use crate::{
         Account::{Alice, Precompile},
         *,
     },
-    BoundsCheckResult, ChainInfo, ChainInfoResult, HashResult, HeightHashResult, HeightResult,
-    OutboxFactories, OutboxFactoryResult,
+    BoundsCheckResult, ChainInfo, ChainInfoResult, CoreFeeResult, CoreFees, HashResult,
+    HeightHashResult, HeightResult, OutboxFactories, OutboxFactoryResult,
 };
 
 use attestor_primitives::{AttestationCheckpoint, AttestationData, SignedAttestation};
@@ -18,7 +18,8 @@ use precompile_utils::{
     testing::*,
 };
 
-use sp_core::{H160, H256};
+use sp_core::{H160, H256, U256};
+use supported_chains_primitives::CoreFeeConfig;
 
 fn precompiles() -> Precompiles<Runtime> {
     PrecompilesValue::get()
@@ -120,6 +121,89 @@ fn get_outbox_factory_address_works() {
                     },
                 )
                 .execute_returns(expected_result);
+        });
+}
+
+#[test]
+fn get_core_fee_works_native_and_erc20() {
+    let alice: H160 = Alice.into();
+
+    let amount = U256::from(1_000_000_000_000_000_000u128); // 1 CTC
+
+    ExtBuilder::default()
+        .with_balances(vec![(alice.into(), 300)])
+        .build()
+        .execute_with(|| {
+            // Native-denominated fee (token: None) surfaces as address(0).
+            CoreFees::<Runtime>::insert(
+                SUPPORTED_CHAIN_KEY,
+                CoreFeeConfig {
+                    token: None,
+                    amount,
+                },
+            );
+            precompiles()
+                .prepare_test(
+                    alice,
+                    Precompile,
+                    PCall::get_core_fee {
+                        chain_key: SUPPORTED_CHAIN_KEY,
+                    },
+                )
+                .execute_returns(CoreFeeResult {
+                    token: Address(H160::zero()),
+                    amount,
+                    exists: true,
+                });
+
+            // ERC20-denominated fee (the planned attestcoin switch) surfaces the token address.
+            let token = H160::repeat_byte(0x22);
+            CoreFees::<Runtime>::insert(
+                SUPPORTED_CHAIN_KEY,
+                CoreFeeConfig {
+                    token: Some(token),
+                    amount,
+                },
+            );
+            precompiles()
+                .prepare_test(
+                    alice,
+                    Precompile,
+                    PCall::get_core_fee {
+                        chain_key: SUPPORTED_CHAIN_KEY,
+                    },
+                )
+                .execute_returns(CoreFeeResult {
+                    token: Address(token),
+                    amount,
+                    exists: true,
+                });
+        });
+}
+
+#[test]
+fn get_core_fee_returns_default_when_not_set() {
+    let alice: H160 = Alice.into();
+
+    ExtBuilder::default()
+        .with_balances(vec![(alice.into(), 300)])
+        .build()
+        .execute_with(|| {
+            assert!(!CoreFees::<Runtime>::contains_key(SUPPORTED_CHAIN_KEY));
+
+            precompiles()
+                .prepare_test(
+                    alice,
+                    Precompile,
+                    PCall::get_core_fee {
+                        chain_key: SUPPORTED_CHAIN_KEY,
+                    },
+                )
+                .execute_returns(CoreFeeResult {
+                    token: Address(H160::zero()),
+                    amount: U256::zero(),
+                    exists: false,
+                });
         });
 }
 

--- a/precompiles/metadata/abi/chain_info.json
+++ b/precompiles/metadata/abi/chain_info.json
@@ -467,5 +467,41 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "chainKey",
+        "type": "uint64"
+      }
+    ],
+    "name": "get_core_fee",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "exists",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct CoreFeeResult",
+        "name": "result",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/precompiles/metadata/sol/chain_info.sol
+++ b/precompiles/metadata/sol/chain_info.sol
@@ -34,6 +34,17 @@ struct OutboxFactoryResult {
 }
 
 /**
+ * @dev get_core_fee result structure. `token == address(0)` denominates the fee in native CTC
+ * (paid via msg.value); any other address is an ERC20 on this EVM (attestcoin, pulled via
+ * transferFrom). `exists == false` (or a zero amount) means no fee is configured.
+ */
+struct CoreFeeResult {
+    address token;
+    uint256 amount;
+    bool exists;
+}
+
+/**
  * @dev Height result structure
  */
 struct HeightResult {
@@ -98,6 +109,15 @@ interface ChainInfoContract {
      * @return result outbox factory address if found
      */
     function get_outbox_factory_address(uint64 chainKey) external view returns (OutboxFactoryResult memory result);
+
+    /**
+     * @dev Get the USC write-ability core (protocol) fee for a given chainKey, charged by that
+     * chain's Outbox on every publishMessage. Governance-set; read live so fee changes take
+     * effect on the next publish without contract redeploys.
+     * @param chainKey The chain key for which to get the core fee
+     * @return result core fee (token + amount) if configured
+     */
+    function get_core_fee(uint64 chainKey) external view returns (CoreFeeResult memory result);
 
     /**
      * @dev Get attestation genesis height for a chain

--- a/primitives/supported-chains/src/lib.rs
+++ b/primitives/supported-chains/src/lib.rs
@@ -34,6 +34,26 @@ pub struct WriteAbilityConfig {
     pub message_attestation_enabled: bool,
 }
 
+/// Per-chain USC write-ability core (protocol) fee, charged by the Outbox on every
+/// `publishMessage`. Governance-set (operators/root) and read live by the EVM through the
+/// chain-info precompile, so changes take effect on the next publish without redeploys.
+///
+/// The denomination is part of the config rather than hardcoded: v1 launches with the fee in
+/// native CTC (`token: None`, paid via `msg.value`), and the planned switch to attestcoin is a
+/// single governance update (`token: Some(erc20)`, pulled via `transferFrom`) — no migration, no
+/// Outbox redeploy, no precompile change.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Encode, Decode, TypeInfo)]
+pub struct CoreFeeConfig {
+    /// Fee token: `None` = the chain's native currency (CTC, paid via `msg.value`);
+    /// `Some(address)` = an ERC20 on Creditcoin's EVM (attestcoin, pulled via `transferFrom`).
+    /// `Some(H160::zero())` is rejected at the extrinsic — the zero address means "native" on the
+    /// EVM side and must map to `None` here, never to an ERC20.
+    pub token: Option<sp_core::H160>,
+    /// Fee amount in the token's smallest units (wei for native CTC). Zero disables the fee while
+    /// keeping the entry (equivalent to no entry at all).
+    pub amount: sp_core::U256,
+}
+
 // Maturity strategy enum used for robustness in attestors
 #[derive(Debug, Clone)]
 pub enum MaturityStrategy {

--- a/primitives/supported-chains/src/provider.rs
+++ b/primitives/supported-chains/src/provider.rs
@@ -2,7 +2,7 @@ use attestor_primitives::{ChainEncodingVersion, ChainId, ChainKey};
 use sp_core::H160;
 use sp_std::vec::Vec;
 
-use crate::{SupportedChain, WriteAbilityConfig};
+use crate::{CoreFeeConfig, SupportedChain, WriteAbilityConfig};
 
 pub trait SupportedChainsProvider {
     fn is_chain_supported(chain_key: ChainKey) -> bool;
@@ -11,6 +11,7 @@ pub trait SupportedChainsProvider {
     fn get_supported_chain(chain_key: ChainKey) -> Option<SupportedChain>;
     fn get_write_ability_config(chain_key: ChainKey) -> Option<WriteAbilityConfig>;
     fn get_outbox_factory_address(chain_key: ChainKey) -> Option<H160>;
+    fn get_core_fee(chain_key: ChainKey) -> Option<CoreFeeConfig>;
 }
 
 pub trait OnRegisterChainProvider {


### PR DESCRIPTION
# feat(write-ability): core (protocol) fee — storage, governance extrinsic, EVM exposure

Runtime half of the write-ability **core fee** (V1 requirement per David): a flat,
governance-set protocol fee charged by the Outbox on every `publishMessage`. This PR adds the
Substrate storage + the chain-info precompile exposure; the contracts half (Outbox charging +
CcBridge/dApp value plumbing) follows in a separate PR.

## Design

**Token-aware from day one.** The research denominates the core fee in **attestcoin**
(`requirements/03-quotation-requirements.md`: "flat fee in attest coin"), but attestcoin is not
deployed anywhere yet. Rather than betting the storage shape on either answer, the denomination
is part of the config:

```rust
pub struct CoreFeeConfig {
    pub token: Option<H160>, // None = native CTC (msg.value); Some = ERC20 (attestcoin, transferFrom)
    pub amount: U256,        // smallest units; 0 = fee off
}
```

V1 launches with `token: None` (native CTC). The day attestcoin exists on Creditcoin's EVM, the
switch is **one `set_core_fee` call — no migration, no Outbox redeploy, no precompile change**.

**Read live, not cached.** The Outbox reads the fee through the chain-info precompile on every
publish, so a governance change takes effect on the next message. This directly answers the open
Slack questions: the fee is **stored Substrate-side** (pallet storage, operators/root-settable),
**charged at `publishMessage`** on Creditcoin L1, and in V1 it is literally **a CTC fee**.

## Changes

- `supported-chains-primitives`: `CoreFeeConfig` struct; `get_core_fee` on `SupportedChainsProvider`.
- `pallet-supported-chains`:
  - `CoreFees: StorageMap<ChainKey, CoreFeeConfig>` (new map — deliberately **not** a field on
    `WriteAbilityConfig`, so no V1→V2 migration on the heels of the just-shipped `MigrateV0ToV1`).
  - `set_core_fee(chain_key, token, amount)` extrinsic (call_index 4, `OperatorsOrigin`), with a
    `Some(H160::zero())` guard (`ZeroCoreFeeToken` — zero address means "native" and must be `None`).
  - `CoreFeeSet` event; `remove_chain` clears the entry.
  - Weights: copied from `set_write_ability_config` (identical storage-access shape) pending
    regeneration via the BENCHMARKS workflow; benchmark added.
- `pallet-evm-precompile-chain-info`: `get_core_fee(uint64) → (address token, uint256 amount, bool exists)`
  (`token == address(0)` ⇒ native CTC), plus `chain_info.sol` / `chain_info.json` metadata.

## Not in this PR (follow-up, contracts side)

- Outbox: `publishMessage` payable + fee check + transfer to recipient (+ ERC20 branch).
- Fee **recipient** decision (treasury vs burn vs configured address) — open question for David.
- CcBridge / dApp `value` plumbing + e2e (insufficient-fee revert, exact/excess fee, refund).
- Quoter surfacing the fee in quote breakdowns.

## Verification

- `cargo build --workspace`, clippy clean, fmt.
- Pallet tests: native + ERC20 set/overwrite (the denomination switch), origin guards
  (none/non-operator/operator/root), unsupported chain, zero-token guard, remove-chain cleanup.
- Precompile tests: native (`address(0)`) + ERC20 round-trip, default-when-unset.
- No storage migration needed (new map, `OptionQuery`).
