### PR TITLE
fix: inline Penguin Patrol webhook call in docker-scout weekly report

### DIFF
--- a/.github/workflows/docker-scout-weekly-report.yml
+++ b/.github/workflows/docker-scout-weekly-report.yml
@@ -93,11 +93,59 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Report to Penguin Patrol
-        uses: gluwa/penguin-patrol-message@v1
-        with:
-          webhook-url: ${{ secrets.PENGUIN_PATROL_WEBHOOK_URL }}
-          alert-title: "Weekly Docker Scout Report — creditcoin3"
-          channel: "#noti-docker-scout"
-          message: |
-            ${{ steps.scout.outputs.report }}
-            Full org dashboard: https://scout.docker.com/reports/org/gluwa/overview
+        # gluwa/penguin-patrol-message is a private repo; GitHub Actions cannot resolve
+        # cross-repo private actions without an org-level access grant. Inline the
+        # equivalent curl call so the workflow is self-contained.
+        env:
+          WEBHOOK_URL: ${{ secrets.PENGUIN_PATROL_WEBHOOK_URL }}
+          REPORT: ${{ steps.scout.outputs.report }}
+        run: |
+          set -euo pipefail
+
+          full_message="${REPORT}
+          Full org dashboard: https://scout.docker.com/reports/org/gluwa/overview"
+
+          payload=$(jq -n \
+            --arg alertName  "github-action" \
+            --arg alertTitle "Weekly Docker Scout Report — creditcoin3" \
+            --arg channel    "#noti-docker-scout" \
+            --arg message    "$full_message" \
+            --arg repo       "$GITHUB_REPOSITORY" \
+            --arg ref        "$GITHUB_REF" \
+            --arg sha        "$GITHUB_SHA" \
+            --arg runId      "$GITHUB_RUN_ID" \
+            --arg runAttempt "$GITHUB_RUN_ATTEMPT" \
+            --arg workflow   "$GITHUB_WORKFLOW" \
+            --arg actor      "$GITHUB_ACTOR" \
+            --arg serverUrl  "$GITHUB_SERVER_URL" \
+            '{
+              alertName:    $alertName,
+              alertTitle:   $alertTitle,
+              channel_name: $channel,
+              message:      $message,
+              metadata: {
+                repository: $repo,
+                ref:        $ref,
+                sha:        $sha,
+                runId:      $runId,
+                runAttempt: $runAttempt,
+                workflow:   $workflow,
+                actor:      $actor,
+                serverUrl:  $serverUrl
+              }
+            }')
+
+          http_code=$(curl -s -o /tmp/pp_response.txt -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "User-Agent: penguin-patrol-action/1.0" \
+            --data-binary "$payload" \
+            "$WEBHOOK_URL")
+
+          echo "Response: $(cat /tmp/pp_response.txt)"
+          echo "HTTP status: $http_code"
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "::error::Penguin Patrol webhook responded with status $http_code"
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

`gluwa/penguin-patrol-message` is a **private** repo. GitHub Actions cannot resolve cross-repo private actions without an explicit org-level access grant (the action repo's Settings → Actions → Access must be set to allow org-wide use, or the org policy must allow it). The runner bails out with:

```
Unable to resolve action `gluwa/penguin-patrol-message`, not found
```

before the job even starts.

## Fix

Replace the `uses: gluwa/penguin-patrol-message@v1` step with an equivalent `curl`/`jq` run step that posts the same JSON payload the action would have sent:

- `alertName`, `alertTitle`, `channel_name`, `message`
- `metadata` block (repo, ref, sha, runId, runAttempt, workflow, actor)

The `WEBHOOK_URL` secret is still passed via env, never echoed in logs. Non-2xx response → `exit 1` (same behaviour as the action).

## Alternative (no-code)

An org admin can grant `penguin-patrol-message` org-wide access: go to that repo's **Settings → Actions → Access** and set it to _"Accessible from repositories in the gluwa organization"_. If that's done, the original `uses:` line can be restored.

## Fixes

Closes the failure seen in run [29230809224](https://github.com/gluwa/creditcoin3/actions/runs/29230809224/job/86754422570).