### PR TITLE
refactor(DO-2217): weekly Scout report via Penguin Patrol docker-scout-report

### DIFF
--- a/.github/workflows/docker-scout-weekly-report.yml
+++ b/.github/workflows/docker-scout-weekly-report.yml
@@ -104,6 +104,6 @@ jobs:
           set -euo pipefail
           MESSAGE="${REPORT}
           Full org dashboard: https://scout.docker.com/reports/org/gluwa/overview"
-          PAYLOAD=$(jq -n --arg title "Weekly Docker Scout Report — creditcoin3" --arg channel "#noti-docker-scout" --arg msg "$MESSAGE" \
-            '{alertTitle: $title, channel_name: $channel, message: $msg}')
+          PAYLOAD=$(jq -n --arg title "Weekly Docker Scout Report — creditcoin3" --arg msg "$MESSAGE" \
+            '{alertTitle: $title, alertName: "github-action", channel_name: "#noti-docker-scout", message: $msg}')
           curl -sf -X POST "$WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD"

--- a/.github/workflows/docker-scout-weekly-report.yml
+++ b/.github/workflows/docker-scout-weekly-report.yml
@@ -83,7 +83,23 @@ jobs:
             fi
 
             quickview=$(docker scout quickview "gluwa/creditcoin3@${digest}" 2>&1 || true)
-            report="${report}*${label}* (\`${tag}\`)\n\`\`\`\n${quickview}\n\`\`\`\n"
+
+            # Compact digest: pull the Target-row counts and policy status out of the quickview
+            # table rather than posting the whole thing (Slack caps a section block at 3000 chars).
+            target=$(echo "$quickview" | grep -m1 'Target')
+            crit=$(echo "$target" | grep -oE '[0-9]+C' | head -1 | tr -d C)
+            high=$(echo "$target" | grep -oE '[0-9]+H' | head -1 | tr -d H)
+            med=$(echo "$target"  | grep -oE '[0-9]+M' | head -1 | tr -d M)
+            low=$(echo "$target"  | grep -oE '[0-9]+L' | head -1 | tr -d L)
+            unk=$(echo "$target"  | grep -oE '[0-9]+\?' | head -1 | tr -d '?')
+            pstatus=$(echo "$quickview" | grep -m1 'Policy status' | grep -oE 'PASSED|FAILED')
+            pratio=$(echo "$quickview"  | grep -m1 'Policy status' | grep -oE '[0-9]+/[0-9]+')
+
+            counts="Critical ${crit:-?} · High ${high:-?} · Medium ${med:-?} · Low ${low:-?}"
+            [ -n "$unk" ] && counts="${counts} · Unknown ${unk}"
+            echo "$quickview" | grep -q 'Updated base image' && counts="${counts} · base image update available"
+
+            report="${report}*${label}* (\`${tag}\`) — Policy ${pstatus:-UNKNOWN} (${pratio:-n/a})\n${counts}\n\n"
           done
 
           {

--- a/.github/workflows/docker-scout-weekly-report.yml
+++ b/.github/workflows/docker-scout-weekly-report.yml
@@ -92,12 +92,17 @@ jobs:
             echo "SCOUT_EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # gluwa/penguin-patrol-message is a private action — public repos can never resolve
+      # actions from a private repo (hard GitHub platform rule, independent of any org
+      # sharing setting), so we replicate its webhook POST directly instead. Same pattern
+      # already used by attestor-operator (no GitHub Actions there) for the same reason.
       - name: Report to Penguin Patrol
-        uses: gluwa/penguin-patrol-message@v1
-        with:
-          webhook-url: ${{ secrets.PENGUIN_PATROL_WEBHOOK_URL }}
-          alert-title: "Weekly Docker Scout Report — creditcoin3"
-          channel: "#noti-docker-scout"
-          message: |
-            ${{ steps.scout.outputs.report }}
-            Full org dashboard: https://scout.docker.com/reports/org/gluwa/overview
+        env:
+          WEBHOOK_URL: ${{ secrets.PENGUIN_PATROL_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          MESSAGE="${{ steps.scout.outputs.report }}
+          Full org dashboard: https://scout.docker.com/reports/org/gluwa/overview"
+          PAYLOAD=$(jq -n --arg title "Weekly Docker Scout Report — creditcoin3" --arg channel "#noti-docker-scout" --arg msg "$MESSAGE" \
+            '{alertTitle: $title, channel_name: $channel, message: $msg}')
+          curl -sf -X POST "$WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD"

--- a/.github/workflows/docker-scout-weekly-report.yml
+++ b/.github/workflows/docker-scout-weekly-report.yml
@@ -86,20 +86,22 @@ jobs:
 
             # Compact digest: pull the Target-row counts and policy status out of the quickview
             # table rather than posting the whole thing (Slack caps a section block at 3000 chars).
-            target=$(echo "$quickview" | grep -m1 'Target')
-            crit=$(echo "$target" | grep -oE '[0-9]+C' | head -1 | tr -d C)
-            high=$(echo "$target" | grep -oE '[0-9]+H' | head -1 | tr -d H)
-            med=$(echo "$target"  | grep -oE '[0-9]+M' | head -1 | tr -d M)
-            low=$(echo "$target"  | grep -oE '[0-9]+L' | head -1 | tr -d L)
-            unk=$(echo "$target"  | grep -oE '[0-9]+\?' | head -1 | tr -d '?')
-            pstatus=$(echo "$quickview" | grep -m1 'Policy status' | grep -oE 'PASSED|FAILED')
-            pratio=$(echo "$quickview"  | grep -m1 'Policy status' | grep -oE '[0-9]+/[0-9]+')
+            # Every grep is guarded with `|| true` because a no-match (e.g. an image with no
+            # Unknown count) returns exit 1, which would abort the step under `set -euo pipefail`.
+            target=$(echo "$quickview" | grep -m1 'Target' || true)
+            crit=$(echo "$target" | grep -oE '[0-9]+C' | head -1 | tr -d C || true)
+            high=$(echo "$target" | grep -oE '[0-9]+H' | head -1 | tr -d H || true)
+            med=$(echo "$target"  | grep -oE '[0-9]+M' | head -1 | tr -d M || true)
+            low=$(echo "$target"  | grep -oE '[0-9]+L' | head -1 | tr -d L || true)
+            unk=$(echo "$target"  | grep -oE '[0-9]+\?' | head -1 | tr -d '?' || true)
+            pstatus=$(echo "$quickview" | grep -m1 'Policy status' | grep -oE 'PASSED|FAILED' || true)
+            pratio=$(echo "$quickview"  | grep -m1 'Policy status' | grep -oE '[0-9]+/[0-9]+' || true)
 
-            counts="Critical ${crit:-?} · High ${high:-?} · Medium ${med:-?} · Low ${low:-?}"
-            [ -n "$unk" ] && counts="${counts} · Unknown ${unk}"
-            echo "$quickview" | grep -q 'Updated base image' && counts="${counts} · base image update available"
+            line="*${label}* (\`${tag}\`) — Policy ${pstatus:-UNKNOWN} (${pratio:-n/a}) · Critical ${crit:-?} · High ${high:-?} · Medium ${med:-?} · Low ${low:-?}"
+            if [ -n "$unk" ]; then line="${line} · Unknown ${unk}"; fi
+            if echo "$quickview" | grep -q 'Updated base image'; then line="${line} · base image update available"; fi
 
-            report="${report}*${label}* (\`${tag}\`) — Policy ${pstatus:-UNKNOWN} (${pratio:-n/a})\n${counts}\n\n"
+            report="${report}${line}\n\n"
           done
 
           {

--- a/.github/workflows/docker-scout-weekly-report.yml
+++ b/.github/workflows/docker-scout-weekly-report.yml
@@ -61,7 +61,10 @@ jobs:
             echo "null|null"
           }
 
-          report=""
+          # Collect the RAW quickview text per image into a JSON array. All parsing and
+          # Slack formatting now lives in Penguin Patrol's docker-scout-report parser, so
+          # this workflow just resolves images and forwards their quickview output.
+          images='[]'
           for entry in "main|exact|latest" "indexer|prefix|indexer-for-" "proof-gen-stress-test|prefix|proof-gen-stress-test-for-"; do
             label="${entry%%|*}"
             rest="${entry#*|}"
@@ -73,60 +76,37 @@ jobs:
             digest="${resolved##*|}"
 
             if [ -z "$tag" ] || [ "$tag" = "null" ]; then
-              report="${report}*${label}*: no published tag found matching \`${pattern}*\` (searched up to 10 pages)\n"
-              continue
+              tag=""
+              qv="no published tag found matching ${pattern}* (searched up to 10 pages)"
+            elif [ -z "$digest" ] || [ "$digest" = "null" ]; then
+              qv="matched tag ${tag} but Docker Hub returned no digest, skipping scan"
+            else
+              qv=$(docker scout quickview "gluwa/creditcoin3@${digest}" 2>&1 || true)
             fi
 
-            if [ -z "$digest" ] || [ "$digest" = "null" ]; then
-              report="${report}*${label}* (\`${tag}\`): matched but Docker Hub returned no digest, skipping scan\n"
-              continue
-            fi
-
-            quickview=$(docker scout quickview "gluwa/creditcoin3@${digest}" 2>&1 || true)
-
-            # Compact digest: pull the Target-row counts and policy status out of the quickview
-            # table rather than posting the whole thing (Slack caps a section block at 3000 chars).
-            # Every grep is guarded with `|| true` because a no-match (e.g. an image with no
-            # Unknown count) returns exit 1, which would abort the step under `set -euo pipefail`.
-            target=$(echo "$quickview" | grep -m1 'Target' || true)
-            crit=$(echo "$target" | grep -oE '[0-9]+C' | head -1 | tr -d C || true)
-            high=$(echo "$target" | grep -oE '[0-9]+H' | head -1 | tr -d H || true)
-            med=$(echo "$target"  | grep -oE '[0-9]+M' | head -1 | tr -d M || true)
-            low=$(echo "$target"  | grep -oE '[0-9]+L' | head -1 | tr -d L || true)
-            unk=$(echo "$target"  | grep -oE '[0-9]+\?' | head -1 | tr -d '?' || true)
-            pstatus=$(echo "$quickview" | grep -m1 'Policy status' | grep -oE 'PASSED|FAILED' || true)
-            pratio=$(echo "$quickview"  | grep -m1 'Policy status' | grep -oE '[0-9]+/[0-9]+' || true)
-
-            line="*${label}* (\`${tag}\`) — Policy ${pstatus:-UNKNOWN} (${pratio:-n/a}) · Critical ${crit:-?} · High ${high:-?} · Medium ${med:-?} · Low ${low:-?}"
-            if [ -n "$unk" ]; then line="${line} · Unknown ${unk}"; fi
-            if echo "$quickview" | grep -q 'Updated base image'; then line="${line} · base image update available"; fi
-
-            report="${report}${line}\n\n"
+            images=$(printf '%s' "$images" | jq -c --arg label "$label" --arg tag "$tag" --arg qv "$qv" \
+              '. + [{label: $label, tag: $tag, quickview: $qv}]')
           done
 
-          {
-            echo "report<<SCOUT_EOF"
-            echo -e "$report"
-            echo "SCOUT_EOF"
-          } >> "$GITHUB_OUTPUT"
+          # Compact single-line JSON — avoids echo mangling and keeps the step output clean.
+          echo "images=$images" >> "$GITHUB_OUTPUT"
 
       # gluwa/penguin-patrol-message is a private action — public repos can never resolve
-      # actions from a private repo (hard GitHub platform rule, independent of any org
-      # sharing setting), so we replicate its webhook POST directly instead. Same pattern
-      # already used by attestor-operator (no GitHub Actions there) for the same reason.
+      # actions from a private repo (hard GitHub platform rule), so we POST the webhook
+      # directly. The payload is structured (alertName=docker-scout-report + raw per-image
+      # quickview); Penguin Patrol parses and formats it. IMAGES is passed via env (not inline
+      # ${{ }}) so the raw quickview text is never interpreted by the shell.
       - name: Report to Penguin Patrol
         env:
           WEBHOOK_URL: ${{ secrets.PENGUIN_PATROL_WEBHOOK_URL }}
-          REPORT: ${{ steps.scout.outputs.report }}
+          IMAGES: ${{ steps.scout.outputs.images }}
         run: |
           set -euo pipefail
-          MESSAGE="${REPORT}
-          Full org dashboard: https://scout.docker.com/reports/org/gluwa/overview"
-          PAYLOAD=$(jq -n --arg title "Weekly Docker Scout Report — creditcoin3" --arg msg "$MESSAGE" \
-            '{alertTitle: $title, alertName: "github-action", channel_name: "#noti-docker-scout", message: $msg}')
+          PAYLOAD=$(jq -n --argjson images "$IMAGES" \
+            '{alertName: "docker-scout-report", alertTitle: "Weekly Docker Scout Report — creditcoin3", channel_name: "#noti-docker-scout", images: $images}')
           HTTP=$(curl -s -o /tmp/pp_resp.txt -w '%{http_code}' -X POST "$WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD")
           if [ "$HTTP" -ge 400 ]; then
             echo "Penguin Patrol webhook rejected (HTTP $HTTP):"; cat /tmp/pp_resp.txt; echo
             exit 1
           fi
-          echo "Posted weekly Scout digest to Penguin Patrol (HTTP $HTTP)."
+          echo "Posted weekly Scout report to Penguin Patrol (HTTP $HTTP)."

--- a/.github/workflows/docker-scout-weekly-report.yml
+++ b/.github/workflows/docker-scout-weekly-report.yml
@@ -106,4 +106,7 @@ jobs:
           Full org dashboard: https://scout.docker.com/reports/org/gluwa/overview"
           PAYLOAD=$(jq -n --arg title "Weekly Docker Scout Report — creditcoin3" --arg msg "$MESSAGE" \
             '{alertTitle: $title, alertName: "github-action", channel_name: "#noti-docker-scout", message: $msg}')
-          curl -sf -X POST "$WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD"
+          HTTP=$(curl -s -o /tmp/pp_resp.txt -w '%{http_code}' -X POST "$WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD")
+          echo "webhook HTTP status: $HTTP"
+          echo "----- webhook response body -----"; cat /tmp/pp_resp.txt; echo; echo "---------------------------------"
+          [ "$HTTP" -lt 400 ] || { echo "webhook rejected (HTTP $HTTP)"; exit 1; }

--- a/.github/workflows/docker-scout-weekly-report.yml
+++ b/.github/workflows/docker-scout-weekly-report.yml
@@ -125,6 +125,8 @@ jobs:
           PAYLOAD=$(jq -n --arg title "Weekly Docker Scout Report — creditcoin3" --arg msg "$MESSAGE" \
             '{alertTitle: $title, alertName: "github-action", channel_name: "#noti-docker-scout", message: $msg}')
           HTTP=$(curl -s -o /tmp/pp_resp.txt -w '%{http_code}' -X POST "$WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD")
-          echo "webhook HTTP status: $HTTP"
-          echo "----- webhook response body -----"; cat /tmp/pp_resp.txt; echo; echo "---------------------------------"
-          [ "$HTTP" -lt 400 ] || { echo "webhook rejected (HTTP $HTTP)"; exit 1; }
+          if [ "$HTTP" -ge 400 ]; then
+            echo "Penguin Patrol webhook rejected (HTTP $HTTP):"; cat /tmp/pp_resp.txt; echo
+            exit 1
+          fi
+          echo "Posted weekly Scout digest to Penguin Patrol (HTTP $HTTP)."

--- a/.github/workflows/docker-scout-weekly-report.yml
+++ b/.github/workflows/docker-scout-weekly-report.yml
@@ -99,9 +99,10 @@ jobs:
       - name: Report to Penguin Patrol
         env:
           WEBHOOK_URL: ${{ secrets.PENGUIN_PATROL_WEBHOOK_URL }}
+          REPORT: ${{ steps.scout.outputs.report }}
         run: |
           set -euo pipefail
-          MESSAGE="${{ steps.scout.outputs.report }}
+          MESSAGE="${REPORT}
           Full org dashboard: https://scout.docker.com/reports/org/gluwa/overview"
           PAYLOAD=$(jq -n --arg title "Weekly Docker Scout Report — creditcoin3" --arg channel "#noti-docker-scout" --arg msg "$MESSAGE" \
             '{alertTitle: $title, channel_name: $channel, message: $msg}')


### PR DESCRIPTION
Reworks the weekly Docker Scout report so this repo no longer parses/formats the message itself. It now runs \`docker scout quickview\` per image and POSTs the **raw** text as a structured payload (\`alertName: docker-scout-report\`); all parsing + Slack formatting lives in the shared Penguin Patrol service.

Fixes the failures seen on the previous approach:
- One Slack section block per image (was one giant block → hit Slack's 3000-char limit → \`invalid_blocks\` 502).
- No fragile per-repo bash parsing; payload built with \`jq -c\`, passed via env (no shell interpolation of scout text).

**⚠ Do NOT merge until the Penguin Patrol \`docker-scout-report\` parser is deployed** (penguin-patrol PR #8883, merged to main, pending Azure Function deploy). If this merges first, the scheduled run will POST an alert type prod doesn't yet know.

Verified end-to-end locally against a local \`func start\` of Penguin Patrol (posted to #temporary-bot-test, HTTP 200).

Related: DO-2217.