### PR TITLE
fix(attestation): compare revert prune pivot against checkpoint bucket pivot

### DIFF
--- a/pallets/attestation/src/clear_or_revert.rs
+++ b/pallets/attestation/src/clear_or_revert.rs
@@ -158,11 +158,18 @@ impl<T: Config> Pallet<T> {
         // prevents us from looping and reading state until we max out the block's compute.
         let mut remaining_pivots = u32::from(MAX_CHECKPOINTS_CLEARED_PER_BLOCK * 2);
 
+        // `stop_height` is a raw block height, but `next_pivot`/`current_pivot` are
+        // bucket pivots (multiples of CHECKPOINT_BUCKET_SIZE). Compare like-for-like by
+        // normalizing the stop height to the pivot of the bucket that contains it,
+        // otherwise the loop bails immediately whenever `stop_height < CHECKPOINT_BUCKET_SIZE`
+        // and no post-revert checkpoints get pruned.
+        let stop_pivot = Self::compute_block_index_for(state.stop_height);
+
         while remaining_entries > 0 && remaining_pivots > 0 {
             let current_pivot = state.next_pivot;
 
-            // 1) If state.next_pivot > state.stop_height, then we are done clearing checkpoints.
-            if current_pivot > state.stop_height {
+            // 1) If current_pivot is past the bucket holding the last checkpoint, we are done.
+            if current_pivot > stop_pivot {
                 CheckpointPruningStates::<T>::remove(chain_key);
                 w = w.saturating_add(T::DbWeight::get().writes(1));
                 return w;


### PR DESCRIPTION
## Problem

`prune_checkpoints_impl` (the async checkpoint-bucket pruner used after `revert_to`) compared two values with **different units**:

- `current_pivot` / `next_pivot` are **bucket pivots** — multiples of `CHECKPOINT_BUCKET_SIZE` (1000).
- `stop_height` is a **raw block height** (the height of the last checkpoint before the revert).

```rust
// before
if current_pivot > state.stop_height { /* done */ }
```

When the last checkpoint sits below `CHECKPOINT_BUCKET_SIZE` — e.g. reverting to genesis in the integration test — `next_pivot` is initialized to `checkpoint_pivot + CHECKPOINT_BUCKET_SIZE = 1000`, and the very first iteration hits `1000 > stop_height` (e.g. `1000 > 200`), so the loop **returns immediately and prunes nothing**. Post-revert checkpoints and their bucket entries are left in storage.

## Fix

Normalize `stop_height` to the pivot of the bucket that contains it before comparing, so the loop drains every bucket up to and including the one holding the last checkpoint.

```rust
let stop_pivot = Self::compute_block_index_for(state.stop_height);
...
if current_pivot > stop_pivot { /* done */ }
```

## Impact / provenance

- This is a **pre-existing latent bug on `usc-dev`**, introduced by `f7741d63c` ("feat: usc dev branch up to date with cc3 dev", 2026-04-09) via a cc3-dev merge — not by any feature branch.
- CI (`ci.yml`, which runs `cc3-indexer-testing`) only triggers on `pull_request`, and the recent direct pushes to `usc-dev` never ran that suite to completion, so the bug went uncaught on the base branch.
- Surfaced by the failing integration test `zz-handleEventRevertedAttestationChainTo.test.ts` ("removes checkpoints above checkpointHeight", "removes attestations above checkpointHeight", "updates AttestationChainData to the reverted checkpoint").

## Verification

- `cargo fmt` clean.
- `cargo clippy -p pallet-attestation --all-targets -- -D warnings` clean.
- CI will re-run the `cc3-indexer-testing` integration suite against this branch.
