### PR TITLE
test(cc3-indexer): fix flaky revert test by polling indexer for reversion completion

### DIFF
--- a/cli/src/test/cc3-indexer-tests/zz-handleEventRevertedAttestationChainTo.test.ts
+++ b/cli/src/test/cc3-indexer-tests/zz-handleEventRevertedAttestationChainTo.test.ts
@@ -1,8 +1,48 @@
 import { newApi, ApiPromise, KeyringPair } from '../../lib';
 import { getChainStatus } from '../../lib/chain/status';
 import { chain_Anvil3_Key } from '../blockchain-tests/pallets/supported-chains/consts';
-import { forElapsedBlocks } from '../utils';
+import { forElapsedBlocks, sleep } from '../utils';
 import { graphQLQuery } from './common';
+
+// Poll the indexer until the latest reversion for `chainKey` is fully applied
+// (status === 'complete'). Returns once settled or throws after the timeout so a
+// genuine indexer failure still surfaces as a test failure rather than a hang.
+async function waitForReversionComplete(chainKey: bigint, timeoutMs = 90_000, intervalMs = 2_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    let lastStatus = '<none>';
+
+    while (Date.now() < deadline) {
+        const response = await graphQLQuery(
+            `query {
+                revertedAttestationChainTos(
+                    filter: { chainKey: { equalTo: "${chainKey}" }},
+                    last: 1
+                ) {
+                    nodes {
+                        status
+                    }
+                }
+            }`,
+        );
+
+        const node = response?.data?.revertedAttestationChainTos?.nodes?.[0];
+        if (node) {
+            lastStatus = node.status;
+            if (node.status === 'complete') {
+                return;
+            }
+            if (node.status === 'failed') {
+                throw new Error(`Indexer reported reversion status 'failed' for chainKey=${chainKey}`);
+            }
+        }
+
+        await sleep(intervalMs);
+    }
+
+    throw new Error(
+        `Timed out after ${timeoutMs}ms waiting for reversion to complete for chainKey=${chainKey} (last status: ${lastStatus})`,
+    );
+}
 
 describe('handleEventRevertedAttestationChainTo()', () => {
     let api: ApiPromise;
@@ -64,7 +104,12 @@ describe('handleEventRevertedAttestationChainTo()', () => {
                 .sudo(api.tx.attestation.revertTo(chainKey, checkpointHeightToRevertTo))
                 .signAndSend(root, { nonce: await api.rpc.system.accountNextIndex(root.address) });
 
-            await forElapsedBlocks(api, { minBlocks: 5, maxRetries: 15 });
+            // A fixed block wait races the indexer: the assertions below query the
+            // indexer's GraphQL state, which is populated asynchronously by
+            // `handleEventRevertedAttestationChainTo`. Poll until that handler has
+            // finished applying the reversion (status === 'complete') so the reads
+            // are deterministic regardless of how quickly the indexer catches up.
+            await waitForReversionComplete(chainKey);
         }, 120_000);
 
         it('graphQL returns known RevertedAttestationChainTo entity', async () => {


### PR DESCRIPTION
## Problem

The `zz-handleEventRevertedAttestationChainTo` integration test flakes (pass/fail with identical pallet + indexer code — see run history on `usc-dev` PRs).

The three failing assertions all query the **indexer's GraphQL state**:
- checkpoints above the revert height removed
- attestations above the revert height removed
- `AttestationChainData` rolled back to the revert checkpoint

That state is populated **asynchronously** by `handleEventRevertedAttestationChainTo` in the indexer. The test submits `revertTo(chainKey, 0)` and then waits a **fixed number of chain blocks** (`forElapsedBlocks`). If the indexer hasn't ingested the reversion block and run its handler within that window, the queries observe **stale pre-revert data** and the suite fails.

A previous attempt bumped the wait from 3 → 5 blocks (`df6b7b323`) and it still flakes, because the correct thing to wait on is the **indexer's progress**, not the chain's block height.

## Root cause is not the pallet

The pallet revert path (`do_revert_to`) and the indexer removal helpers (`remove_attestations_above_height`, `remove_checkpoints_above_height`) are correct. The async checkpoint-bucket pruner (`prune_checkpoints_impl`) is not even involved for the revert-to-genesis case (everything sits in bucket 0, cleared synchronously in `do_revert_to`). This is purely a test/indexer timing race.

## Fix

Replace the fixed block wait with a poll that blocks until the indexer reports the reversion applied:

```ts
await waitForReversionComplete(chainKey);
```

`waitForReversionComplete` polls `revertedAttestationChainTos` until the latest node reports `status === 'complete'` — which the handler sets **only after** attestation + checkpoint cleanup and the chain-data update all succeed (mappingHandlers.ts). It throws on `status === 'failed'` and on timeout, so a genuine indexer bug still surfaces as a test failure rather than a hang.

## Verification

- `yarn check-format` (prettier) clean
- `yarn lint` clean
- `yarn build` clean
- CI will re-run `cc3-indexer-testing` against this branch.

## Note

Supersedes #1156, which normalized the wrong side of a pivot comparison and was a no-op (correctly flagged by Bugbot). #1156 will be closed.
