### PR TITLE
test(cc3-indexer): assert targeted removal on revert instead of blanket bound

### DIFF
--- a/cli/src/test/cc3-indexer-tests/zz-handleEventRevertedAttestationChainTo.test.ts
+++ b/cli/src/test/cc3-indexer-tests/zz-handleEventRevertedAttestationChainTo.test.ts
@@ -117,15 +117,16 @@ describe('handleEventRevertedAttestationChainTo()', () => {
             );
 
             expect(response.data.checkpoints.nodes).toBeTruthy();
+            // Assert the specific pre-revert checkpoint that existed above the revert
+            // height was removed. We intentionally do NOT assert that *every* remaining
+            // checkpoint is <= checkpointHeight: the chain keeps attesting after the
+            // revert, so new legitimate checkpoints above the revert height are indexed
+            // shortly afterwards and would race this assertion.
             expect(
                 response.data.checkpoints.nodes.some(
                     (node: { blockNumber: string }) => BigInt(node.blockNumber) === laterCheckpointHeight,
                 ),
             ).toEqual(false);
-
-            for (const node of response.data.checkpoints.nodes) {
-                expect(BigInt(node.blockNumber)).toBeLessThanOrEqual(checkpointHeightToRevertTo);
-            }
         });
 
         it('removes attestations above checkpointHeight', async () => {
@@ -145,10 +146,16 @@ describe('handleEventRevertedAttestationChainTo()', () => {
             );
 
             expect(response.data.attestations.nodes).toBeTruthy();
-
-            for (const node of response.data.attestations.nodes) {
-                expect(BigInt(node.headerNumber)).toBeLessThanOrEqual(checkpointHeightToRevertTo);
-            }
+            // Assert the specific attestation that existed above the revert height
+            // (at `laterCheckpointHeight`) was removed. We intentionally do NOT assert
+            // that every remaining attestation is <= checkpointHeight: post-revert the
+            // chain keeps attesting, so new legitimate attestations above the revert
+            // height get indexed and would race a blanket assertion.
+            expect(
+                response.data.attestations.nodes.some(
+                    (node: { headerNumber: string }) => BigInt(node.headerNumber) === laterCheckpointHeight,
+                ),
+            ).toEqual(false);
         });
 
         it('updates AttestationChainData to the reverted checkpoint', async () => {


### PR DESCRIPTION
## Problem

`zz-handleEventRevertedAttestationChainTo` flakes (pass/fail with identical pallet + indexer code across `usc-dev` PR runs).

Two of the three revert assertions used **blanket bounds**:

```ts
for (const node of response.data.checkpoints.nodes) {
    expect(BigInt(node.blockNumber)).toBeLessThanOrEqual(checkpointHeightToRevertTo);
}
// ...and the equivalent loop over attestations.headerNumber
```

These assert that **every** remaining indexed checkpoint/attestation is `<= checkpointHeight`. But the chain **keeps attesting after the revert** — the Anvil3 attestors are live throughout the suite. Right after `revertTo(0)` the chain produces blocks 1, 2, 3… which emit fresh `BlockAttested` / `CheckpointReached` events, and the indexer legitimately re-inserts checkpoints/attestations **above** the revert height. The blanket loops then fail on perfectly valid post-revert state.

This is why bumping the wait from 3 → 5 blocks (`df6b7b323`) didn't fix it: the chain never stops, so no fixed wait makes "all rows `<= 0`" hold.

## Fix (minimal, assertion-only)

Drop the two blanket `toBeLessThanOrEqual` loops. Instead assert the specific pre-revert entry that existed **above** the revert height was removed:

```ts
expect(
    response.data.checkpoints.nodes.some((n) => BigInt(n.blockNumber) === laterCheckpointHeight),
).toEqual(false);
// and the same for attestations.headerNumber
```

`laterCheckpointHeight` is captured in `beforeAll` from the second checkpoint that existed before the revert — so this checks the actual reversion invariant (the stale higher entry got pruned) without racing ongoing attestation. The `AttestationChainData` rollback assertions are unchanged.

No pallet or indexer changes — the handler (`handleEventRevertedAttestationChainTo`) and removal helpers are correct.

## Verification

- `yarn check-format` (prettier) clean
- `yarn lint` clean
- `yarn build` clean
- CI will re-run `cc3-indexer-testing`.

Supersedes #1156 (inert pivot no-op) and #1157 (indexer poll), both closed.
