### PR TITLE
Reduce Check-Prover volume by 10x

### DIFF
--- a/.github/workflows/check-prover.yml
+++ b/.github/workflows/check-prover.yml
@@ -211,7 +211,7 @@ jobs:
 
           # Pick one txHash discovered by prover-check (files are written as
           # <PROOF_DIR>/<headerNumber>/<txHash>.txt).
-          TX_FILE=$(find "$PROOF_DIR" -type f -name '*.txt' | head -n 1)
+          TX_FILE=$(find "$PROOF_DIR" -type f -name '*.txt' -print -quit)
           if [ -z "$TX_FILE" ]; then
             echo "No proof files found in $PROOF_DIR; nothing to submit"; exit 1
           fi

--- a/.github/workflows/check-prover.yml
+++ b/.github/workflows/check-prover.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Execute prover-check.ts on checkpoint boundaries
         working-directory: ./cli
         env:
-          GO_BACK_BLOCKS: '3600'
+          GO_BACK_BLOCKS: '360'
           SLEEP_TIME: '500'
         run: |
           node dist/scripts/prover-check.js \
@@ -91,7 +91,7 @@ jobs:
         working-directory: ./cli
         env:
           # LAST_SOURCE_BLOCK: '1000000'
-          GO_BACK_BLOCKS: '4000'
+          GO_BACK_BLOCKS: '400'
           STEP_THROUGH_BLOCKS: '7'
           SLEEP_TIME: '500'
         run: |


### PR DESCRIPTION
see https://gluwa.slack.com/archives/C03MQ532BGA/p1784224440874889 although I don't think that's the root cause of the problem described in this thread.

Example of passing execution:
https://github.com/gluwa/creditcoin3/actions/runs/29564459759
