### PR TITLE
feat(write-ability): attestor-set-update voting — epoch reconciliation (P2-8 off-chain)

### DIFF
--- a/attestor/attestor/src/lib.rs
+++ b/attestor/attestor/src/lib.rs
@@ -394,9 +394,17 @@ impl Attestor {
         // only then), publish this attestor's EVM message-vote address on-chain so the destination
         // EOAValidator set can be built from it (audit P2-8). Best-effort and idempotent; the attestor
         // is already registered/attesting by now (see `register_bls` above), which the pallet requires.
+        // Non-fatal — a transient failure here is retried by the set-update proposer's poll (for
+        // OnChainValidator routes) rather than blocking startup or leaving the node silently omitted.
         if message_votes.is_some() {
-            tasks::write_ability::register_evm_address(&cc3, &write_ability_seed, chain_key)
-                .await?;
+            match tasks::write_ability::signing::MessageSigner::from_seed(&write_ability_seed) {
+                Ok(signer) => {
+                    tasks::write_ability::register_evm_address(&cc3, &signer, chain_key).await;
+                }
+                Err(err) => {
+                    tracing::error!(%err, "could not derive EVM signer for on-chain registration");
+                }
+            }
         }
 
         let shared = Arc::new(Shared {

--- a/attestor/attestor/src/lib.rs
+++ b/attestor/attestor/src/lib.rs
@@ -377,13 +377,16 @@ impl Attestor {
         // share the aggregator + active set. `mv_publish_rx` is the channel the p2p task drains to
         // publish our outgoing votes; a dummy (immediately-closed) receiver stands in when disabled
         // and is never polled (the p2p arm is guarded on `message_votes.is_some()`).
-        let (message_votes, mv_publish_rx, wa_reobs_rx) =
+        let (message_votes, mv_publish_rx, wa_reobs_rx, wa_set_update_rx) =
             match tasks::write_ability::build_state(&self.config.write_ability, &cc3).await {
-                Some((state, publish_rx, reobs_rx)) => (Some(state), publish_rx, reobs_rx),
+                Some((state, publish_rx, reobs_rx, set_update_rx)) => {
+                    (Some(state), publish_rx, reobs_rx, set_update_rx)
+                }
                 None => (
                     None,
                     mpsc::channel::<write_ability::envelope::MessageVote>(1).1,
                     mpsc::channel::<write_ability::envelope::ReobservationRequest>(1).1,
+                    mpsc::channel::<write_ability::envelope::SetUpdateVote>(1).1,
                 ),
             };
 
@@ -461,9 +464,16 @@ impl Attestor {
                 .with_chain_key(chain_key)
                 .build();
             set.spawn(async move {
-                tasks::p2p::run(shared, cfg, gossip_rx, peer_deactivated_rx, mv_publish_rx)
-                    .await
-                    .map(|_| "p2p")
+                tasks::p2p::run(
+                    shared,
+                    cfg,
+                    gossip_rx,
+                    peer_deactivated_rx,
+                    mv_publish_rx,
+                    wa_set_update_rx,
+                )
+                .await
+                .map(|_| "p2p")
             });
         }
 
@@ -497,8 +507,9 @@ impl Attestor {
         {
             let shared = shared.clone();
             let wa_cfg = self.config.write_ability;
+            let cc3 = cc3.clone();
             set.spawn(async move {
-                tasks::write_ability::run(shared, wa_cfg, write_ability_seed, wa_reobs_rx)
+                tasks::write_ability::run(shared, wa_cfg, write_ability_seed, wa_reobs_rx, cc3)
                     .await
                     .map(|_| "write_ability")
             });

--- a/attestor/attestor/src/tasks/p2p/mod.rs
+++ b/attestor/attestor/src/tasks/p2p/mod.rs
@@ -19,8 +19,10 @@ use tokio::sync::mpsc;
 
 use attestor_pool::Vote;
 use attestor_primitives::AttestorId;
-use write_ability::envelope::{MessageVote, ReobservationRequest};
-use write_ability::protocol::{message_votes_topic, reobservation_topic};
+use write_ability::envelope::{MessageVote, ReobservationRequest, SetUpdateVote};
+use write_ability::protocol::{
+    attestor_set_update_topic, message_votes_topic, reobservation_topic,
+};
 
 use crate::error::Error;
 use crate::shared::Shared;
@@ -66,6 +68,7 @@ pub async fn run(
     mut gossip_rx: mpsc::UnboundedReceiver<Vote>,
     mut peer_deactivated_rx: mpsc::UnboundedReceiver<AttestorId>,
     mut mv_publish_rx: mpsc::Receiver<MessageVote>,
+    mut set_update_publish_rx: mpsc::Receiver<SetUpdateVote>,
 ) -> Result<(), Error> {
     use futures::StreamExt as _;
 
@@ -133,6 +136,22 @@ pub async fn run(
             .behaviour_mut()
             .gossipsub
             .subscribe(reobs_topic)
+            .map_err(|e| Error::P2p(anyhow::anyhow!("{e}")))?;
+    }
+
+    // Attestor-set-update votes (P2-8) ride the same swarm on their own topic. We only *publish*
+    // these (the proposer produces them; the relayer consumes them). Subscribing is required to
+    // publish/propagate. Gated on message attestation like the topics above.
+    let set_update_topic = shared.message_votes.is_some().then(|| {
+        let t = libp2p::gossipsub::IdentTopic::new(attestor_set_update_topic(chain_key));
+        tracing::info!(topic = %t, "📫 subscribing to attestor-set-update gossip");
+        t
+    });
+    if let Some(set_update_topic) = &set_update_topic {
+        swarm
+            .behaviour_mut()
+            .gossipsub
+            .subscribe(set_update_topic)
             .map_err(|e| Error::P2p(anyhow::anyhow!("{e}")))?;
     }
 
@@ -328,6 +347,15 @@ pub async fn run(
                     if !try_publish_message_vote(&mut swarm, mv_topic, &vote) {
                         queue_message_vote_for_retry(&mut mv_retry_queue, vote);
                     }
+                }
+            }
+
+            // Outgoing — the proposer produced a signed attestor-set-update vote. Unlike message
+            // votes there is no retry queue: the proposer re-emits every poll while the set stays
+            // diverged, so a failed publish (e.g. no mesh peers yet) self-heals on the next cycle.
+            Some(vote) = set_update_publish_rx.recv(), if set_update_topic.is_some() => {
+                if let Some(set_update_topic) = &set_update_topic {
+                    try_publish_set_update_vote(&mut swarm, set_update_topic, &vote);
                 }
             }
 
@@ -809,6 +837,36 @@ fn try_publish_message_vote(
                 "✉️ message-vote publish failed — queueing for retry",
             );
             false
+        }
+    }
+}
+
+/// Publish an attestor-set-update vote. No retry queue — the proposer re-emits while the set stays
+/// diverged, so a transient publish failure (typically no mesh peers yet) is recovered next cycle.
+fn try_publish_set_update_vote(
+    swarm: &mut libp2p::Swarm<behavior::P2PBehavior>,
+    topic: &libp2p::gossipsub::IdentTopic,
+    vote: &SetUpdateVote,
+) {
+    match swarm
+        .behaviour_mut()
+        .gossipsub
+        .publish(topic.hash(), vote.encode_bytes())
+    {
+        Ok(_) => {
+            tracing::info!(
+                chain_key = vote.chain_key,
+                attestors = vote.new_attestors.len(),
+                "🗳️ gossiped attestor-set-update vote"
+            );
+        }
+        Err(libp2p::gossipsub::PublishError::Duplicate) => {}
+        Err(err) => {
+            tracing::warn!(
+                chain_key = vote.chain_key,
+                %err,
+                "🗳️ attestor-set-update publish failed — proposer will re-emit next cycle",
+            );
         }
     }
 }

--- a/attestor/attestor/src/tasks/p2p/mod.rs
+++ b/attestor/attestor/src/tasks/p2p/mod.rs
@@ -368,6 +368,7 @@ pub async fn run(
                     &mut swarm,
                     mv_topic.as_ref(),
                     reobs_topic.as_ref(),
+                    set_update_topic.as_ref(),
                     &mut pending_votes,
                     MAX_PENDING_PER_HEIGHT,
                     &mut ping_failures,
@@ -533,6 +534,7 @@ async fn handle_swarm(
     swarm: &mut libp2p::Swarm<behavior::P2PBehavior>,
     mv_topic: Option<&libp2p::gossipsub::IdentTopic>,
     reobs_topic: Option<&libp2p::gossipsub::IdentTopic>,
+    set_update_topic: Option<&libp2p::gossipsub::IdentTopic>,
     pending_votes: &mut PendingVotes,
     max_pending_per_height: usize,
     ping_failures: &mut std::collections::HashMap<libp2p::swarm::ConnectionId, u32>,
@@ -630,6 +632,7 @@ async fn handle_swarm(
             // message attestation is enabled.
             let is_message_vote = mv_topic.is_some_and(|t| message.topic == t.hash());
             let is_reobs = reobs_topic.is_some_and(|t| message.topic == t.hash());
+            let is_set_update = set_update_topic.is_some_and(|t| message.topic == t.hash());
             let decision = if is_message_vote {
                 handle_message_vote(shared, &message.data)
             } else if is_reobs {
@@ -639,6 +642,14 @@ async fn handle_swarm(
                     reobs_admission,
                     propagation_source,
                 )
+            } else if is_set_update {
+                // We subscribe to the attestor-set-update topic only to publish our proposer's own
+                // votes and keep the mesh propagating them — attestors do NOT aggregate set-update
+                // votes (the relayer does). Accept inbound frames so gossipsub keeps relaying, but
+                // take no action. Crucially, do not fall through to the block-attestation `Vote`
+                // decoder below: a SetUpdateVote SCALE payload would fail to decode and be Rejected,
+                // applying gossipsub penalties to peers relaying legitimate set-update votes (bugbot).
+                libp2p::gossipsub::MessageAcceptance::Accept
             } else {
                 let (acceptance, learned) = handle_vote_msg(
                     shared,

--- a/attestor/attestor/src/tasks/write_ability/ingest.rs
+++ b/attestor/attestor/src/tasks/write_ability/ingest.rs
@@ -135,6 +135,7 @@ mod tests {
             )),
             active_set: RwLock::new(active_set),
             publish_tx: tx,
+            set_update_publish_tx: tokio::sync::mpsc::channel(8).0,
             reobs_tx: tokio::sync::mpsc::channel(8).0,
             destination_chain_key: write_ability::protocol::chain_key_to_bytes32(CHAIN_KEY),
         }

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -41,7 +41,7 @@ use parking_lot::{Mutex, RwLock};
 use tokio::sync::mpsc;
 use zeroize::Zeroizing;
 
-use write_ability::envelope::{MessageVote, ReobservationRequest};
+use write_ability::envelope::{MessageVote, ReobservationRequest, SetUpdateVote};
 use write_ability::protocol::chain_key_to_bytes32;
 
 use crate::error::Error;
@@ -73,6 +73,9 @@ pub struct MessageVoteState {
     pub active_set: RwLock<HashSet<Address>>,
     /// Outgoing votes we produced, handed to the p2p task to publish on the message-vote topic.
     pub publish_tx: mpsc::Sender<MessageVote>,
+    /// Outgoing attestor-set-update votes (P2-8), handed to the p2p task to publish on the
+    /// set-update topic. Set by [`build_state`]; drained by the p2p task.
+    pub set_update_publish_tx: mpsc::Sender<SetUpdateVote>,
     /// Incoming reobservation requests the p2p task decoded off the reobservation topic, handed to
     /// the write-ability task to verify + re-sign. `try_send` from the swarm loop (best effort:
     /// shedding a request under a full buffer just means that stall recovers on the next request).
@@ -101,6 +104,7 @@ pub async fn build_state(
     Arc<MessageVoteState>,
     mpsc::Receiver<MessageVote>,
     mpsc::Receiver<ReobservationRequest>,
+    mpsc::Receiver<SetUpdateVote>,
 )> {
     if !cfg.enabled {
         return None;
@@ -127,10 +131,13 @@ pub async fn build_state(
         aggregator::VoteAggregator::new(threshold, cfg.max_tracked_messages, cfg.vote_ttl);
     let (publish_tx, publish_rx) = mpsc::channel(common::constants::CAPACITY_CHANNEL);
     let (reobs_tx, reobs_rx) = mpsc::channel(common::constants::CAPACITY_CHANNEL);
+    let (set_update_publish_tx, set_update_publish_rx) =
+        mpsc::channel(common::constants::CAPACITY_CHANNEL);
     let state = Arc::new(MessageVoteState {
         aggregator: Mutex::new(aggregator),
         active_set: RwLock::new(active_set),
         publish_tx,
+        set_update_publish_tx,
         reobs_tx,
         destination_chain_key,
     });
@@ -139,7 +146,7 @@ pub async fn build_state(
         threshold,
         "🧑‍🤝‍🧑 message-vote quorum configured"
     );
-    Some((state, publish_rx, reobs_rx))
+    Some((state, publish_rx, reobs_rx, set_update_publish_rx))
 }
 
 /// Register this attestor's write-ability EVM message-vote address on-chain (audit P2-8),
@@ -286,6 +293,7 @@ pub async fn run(
     cfg: Config,
     seed: Zeroizing<[u8; 32]>,
     reobs_rx: mpsc::Receiver<ReobservationRequest>,
+    cc3: Arc<cc_client::Client>,
 ) -> Result<(), Error> {
     let Some(state) = shared.message_votes.clone() else {
         tracing::info!("📭 message attestation disabled — parking write-ability task");
@@ -312,6 +320,31 @@ pub async fn run(
                 "OnChainValidator set but no destination_eth_rpc_url — attestor set will not hot-reload"
             );
             None
+        }
+        _ => None,
+    };
+
+    // Attestor-set-update proposer (P2-8): gossips a signed vote when the elected set (from the
+    // on-chain EVM-address registry) diverges from the destination validator's set, for the relayer
+    // to submit. Like `set_watcher` it is Outbox-independent, only meaningful for an OnChainValidator
+    // set, and derives its own EVM signer from `seed`.
+    let set_update_proposer = match (&cfg.attestor_set, cfg.destination_eth_rpc_url.as_ref()) {
+        (AttestorSet::OnChainValidator(validator), Some(url)) => {
+            match signing::MessageSigner::from_seed(&seed) {
+                Ok(proposer_signer) => Some(tokio::spawn(set_update::run_proposer(
+                    cc3.clone(),
+                    cfg.write_ability_chain_key,
+                    url.to_string(),
+                    *validator,
+                    proposer_signer,
+                    state.set_update_publish_tx.clone(),
+                    shared.token.clone(),
+                ))),
+                Err(err) => {
+                    tracing::error!(%err, "could not derive EVM signer for set-update proposer — disabling it");
+                    None
+                }
+            }
         }
         _ => None,
     };
@@ -453,6 +486,9 @@ pub async fn run(
                     if let Some(w) = &set_watcher {
                         w.abort();
                     }
+                    if let Some(p) = &set_update_proposer {
+                        p.abort();
+                    }
                     return Err(Error::WriteAbility(err));
                 };
                 produce_vote(&state, &shared.metrics, &signer, our_address, chain_key, indexed);
@@ -464,6 +500,9 @@ pub async fn run(
     reobs_worker.abort();
     if let Some(w) = set_watcher {
         w.abort();
+    }
+    if let Some(p) = set_update_proposer {
+        p.abort();
     }
     Ok(())
 }

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -150,28 +150,28 @@ pub async fn build_state(
 }
 
 /// Register this attestor's write-ability EVM message-vote address on-chain (audit P2-8),
-/// idempotently and best-effort.
+/// idempotently and fully best-effort. Returns `true` once the address is confirmed on-chain (or was
+/// already), `false` on any failure this attempt (so a caller can retry).
 ///
-/// Derives the EVM signing key from `seed`, proves possession over the pallet's registration digest
-/// (`cc3.evm_registration_digest`), and submits `set_attestor_evm_address` — but only when the
-/// on-chain value is missing or differs from ours, so a restart is a no-op. `chain_key` is the
-/// attestation chain key the attestor is registered under (the pallet keys the EVM address the same
-/// way). Failures are logged, never fatal: the attestor keeps attesting, and the destination
-/// `EOAValidator` set simply omits it until a later registration succeeds. Requires the attestor to
-/// already be registered on-chain (the pallet rejects a non-attestor), so call it after `attest`.
+/// Proves possession over the pallet's registration digest (`cc3.evm_registration_digest`) with the
+/// attestor's EVM `signer` and submits `set_attestor_evm_address` only when the on-chain value is
+/// missing or differs — so a restart is a no-op. `chain_key` is the attestation chain key the
+/// attestor is registered under (the pallet keys the EVM address the same way). **Never fatal**:
+/// every failure (including sign) is logged and returned as `false`; the attestor keeps attesting and
+/// the destination `EOAValidator` set omits it until a later attempt succeeds. Requires the attestor
+/// to already be registered on-chain (the pallet rejects a non-attestor), so call it after `attest`.
 pub async fn register_evm_address(
     cc3: &cc_client::Client,
-    seed: &[u8; 32],
+    signer: &signing::MessageSigner,
     chain_key: attestor_primitives::ChainKey,
-) -> Result<(), Error> {
-    let signer = signing::MessageSigner::from_seed(seed).map_err(Error::WriteAbility)?;
+) -> bool {
     let address = signer.address();
     let ours = sp_core::H160::from_slice(address.as_slice());
 
     match cc3.attestor_evm_address(chain_key).await {
         Ok(Some(existing)) if existing == ours => {
-            tracing::info!(evm_address = %address, "🔗 write-ability EVM address already registered on-chain — skipping");
-            return Ok(());
+            tracing::debug!(evm_address = %address, "🔗 write-ability EVM address already registered on-chain");
+            return true;
         }
         Ok(_) => {}
         Err(err) => {
@@ -180,23 +180,28 @@ pub async fn register_evm_address(
     }
 
     let digest = cc3.evm_registration_digest(chain_key);
-    let proof = signer
-        .sign(&B256::from(digest))
-        .map_err(Error::WriteAbility)?;
+    let proof = match signer.sign(&B256::from(digest)) {
+        Ok(p) => p,
+        Err(err) => {
+            tracing::error!(%err, "could not sign EVM registration digest — cannot register");
+            return false;
+        }
+    };
 
     match cc3.set_attestor_evm_address(chain_key, ours, proof).await {
         Ok(()) => {
             tracing::info!(evm_address = %address, "🔗 registered write-ability EVM address on-chain");
+            true
         }
         Err(err) => {
-            tracing::error!(
+            tracing::warn!(
                 %err,
                 evm_address = %address,
-                "failed to register write-ability EVM address on-chain — the destination EOAValidator set will omit this attestor until registration succeeds"
+                "failed to register write-ability EVM address on-chain — will retry; the destination EOAValidator set omits this attestor until it succeeds"
             );
+            false
         }
     }
-    Ok(())
 }
 
 /// Read the on-chain `WriteAbilityConfigs` entry for this `chain_key` and derive the effective

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -27,6 +27,7 @@ pub mod ingest;
 pub mod listener;
 pub mod reobservation;
 pub mod resolver;
+pub mod set_update;
 pub mod signing;
 
 use std::collections::HashSet;

--- a/attestor/attestor/src/tasks/write_ability/set_update.rs
+++ b/attestor/attestor/src/tasks/write_ability/set_update.rs
@@ -1,0 +1,226 @@
+//! Attestor-set-update proposer (write-ability P2-8, off-chain half).
+//!
+//! Every poll, this compares the destination `EOAValidator`'s current attestor set against the
+//! *elected* attestors that have registered a write-ability EVM address (the on-chain registry from
+//! the `set_attestor_evm_address` extrinsic). When they differ, the attestor signs the canonical
+//! update digest and gossips a [`SetUpdateVote`] on
+//! [`attestor_set_update_topic`](write_ability::protocol::attestor_set_update_topic).
+//!
+//! Attestors only **propose** (sign + gossip) — they do not submit on-chain. The relayer snoops the
+//! topic, aggregates a threshold of signatures, and calls `submitAttestorSetUpdate` (it already owns
+//! destination-chain delivery, gas, and nonce management). This mirrors the message-delivery flow
+//! exactly: attestors sign + gossip, relayer aggregates + delivers.
+//!
+//! Determinism is the crux: every attestor must sign over the **byte-identical** `newAttestors`
+//! array and nonce, or the relayer can't aggregate their signatures. We enforce a canonical
+//! (ascending) address ordering ([`canonical_attestor_order`]) and sign over the validator's current
+//! `attestorSetUpdateNonce` — if an update lands, the nonce bumps and stale in-flight votes are
+//! naturally rejected on-chain (the replay/rollback protection working as intended).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy::primitives::{Address, U256};
+use alloy::providers::{Provider, ProviderBuilder};
+use anyhow::{Context, Result};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use write_ability::abi::IVoteValidator;
+use write_ability::envelope::SetUpdateVote;
+use write_ability::hash::{attestor_set_update_digest, canonical_attestor_order};
+
+use super::signing::MessageSigner;
+
+/// How often to re-check whether the elected set diverged from the on-chain validator set. Set
+/// changes only happen on epoch rotation, so a slow poll keeps RPC load negligible while bounding
+/// how long a diverged set goes un-proposed.
+const SET_UPDATE_POLL_SECS: u64 = 60;
+
+/// Whether the destination validator's `current` set differs from our `candidate` set, compared as
+/// **sets** (order- and duplicate-insensitive) — the trigger to gossip an update. `candidate` is
+/// expected pre-canonicalized; the set comparison makes the decision robust regardless.
+#[must_use]
+pub fn set_needs_update(current: &[Address], candidate: &[Address]) -> bool {
+    use std::collections::BTreeSet;
+    let current: BTreeSet<&Address> = current.iter().collect();
+    let candidate: BTreeSet<&Address> = candidate.iter().collect();
+    current != candidate
+}
+
+/// Build a signed [`SetUpdateVote`]. `new_attestors` is canonicalized (sorted, de-duped) before
+/// hashing so every attestor signs identical bytes; `chain_id` is the destination `block.chainid`
+/// and `nonce` the validator's current `attestorSetUpdateNonce`.
+pub fn build_set_update_vote(
+    signer: &MessageSigner,
+    chain_key: u64,
+    new_attestors: &[Address],
+    chain_id: U256,
+    nonce: U256,
+) -> Result<SetUpdateVote> {
+    let canonical = canonical_attestor_order(new_attestors);
+    let digest = attestor_set_update_digest(&canonical, chain_id, nonce);
+    let signature = signer
+        .sign(&digest)
+        .context("sign attestor-set-update digest")?;
+    Ok(SetUpdateVote {
+        chain_key,
+        new_attestors: canonical.iter().map(|a| a.into_array()).collect(),
+        nonce: nonce.to_be_bytes::<32>(),
+        signer: signer.address().into_array(),
+        signature,
+    })
+}
+
+/// One proposal cycle: read the elected set's EVM addresses (registry) and the validator's current
+/// set/nonce/chain-id; if they diverge, return a signed vote to gossip, else `Ok(None)`.
+async fn propose_once(
+    cc3: &cc_client::Client,
+    chain_key: u64,
+    dest_rpc_url: &str,
+    validator: Address,
+    signer: &MessageSigner,
+) -> Result<Option<SetUpdateVote>> {
+    // Candidate = EVM addresses of the currently-elected attestors that have registered one.
+    let candidate: Vec<Address> = cc3
+        .active_attestor_evm_addresses(chain_key)
+        .await
+        .context("read elected attestors' EVM addresses")?
+        .into_iter()
+        .map(|h| Address::from_slice(h.as_bytes()))
+        .collect();
+    let candidate = canonical_attestor_order(&candidate);
+    if candidate.is_empty() {
+        // No elected attestor has registered an EVM address yet — nothing to propose. (Proposing an
+        // empty set would brick the validator.)
+        return Ok(None);
+    }
+
+    let provider = ProviderBuilder::new()
+        .on_builtin(dest_rpc_url)
+        .await
+        .map_err(|e| anyhow::anyhow!("connect destination chain RPC: {e}"))?;
+    let contract = IVoteValidator::new(validator, &provider);
+
+    let current = contract
+        .attestors()
+        .call()
+        .await
+        .context("read EOAValidator.attestors()")?
+        ._0;
+    if !set_needs_update(&current, &candidate) {
+        return Ok(None);
+    }
+
+    let nonce = contract
+        .attestorSetUpdateNonce()
+        .call()
+        .await
+        .context("read EOAValidator.attestorSetUpdateNonce()")?
+        ._0;
+    let chain_id = U256::from(
+        provider
+            .get_chain_id()
+            .await
+            .context("read destination chain id")?,
+    );
+
+    let vote = build_set_update_vote(signer, chain_key, &candidate, chain_id, nonce)?;
+    tracing::info!(
+        proposed = candidate.len(),
+        current = current.len(),
+        nonce = %nonce,
+        "🗳️ proposing attestor-set update — signing and gossiping"
+    );
+    Ok(Some(vote))
+}
+
+/// Watch for elected-vs-validator set divergence and gossip a signed update vote when it appears,
+/// until `token` fires. Best-effort: read/connection failures are logged and retried next tick.
+/// Connects to the destination chain per-poll for the same self-healing reason as
+/// [`super::attestor_set::watch`].
+#[allow(clippy::too_many_arguments)]
+pub async fn run_proposer(
+    cc3: Arc<cc_client::Client>,
+    chain_key: u64,
+    dest_rpc_url: String,
+    validator: Address,
+    signer: MessageSigner,
+    publish_tx: mpsc::Sender<SetUpdateVote>,
+    token: CancellationToken,
+) {
+    tracing::info!(%validator, "🗳️ attestor-set-update proposer online");
+    let mut tick = tokio::time::interval(Duration::from_secs(SET_UPDATE_POLL_SECS));
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            () = token.cancelled() => {
+                tracing::info!("🛑 attestor-set-update proposer exiting on cancel");
+                return;
+            }
+            _ = tick.tick() => {
+                match propose_once(&cc3, chain_key, &dest_rpc_url, validator, &signer).await {
+                    Ok(Some(vote)) => {
+                        // Bounded `try_send`: if the publish channel is full the vote is dropped and
+                        // re-proposed next tick (set changes persist until an update lands), so a
+                        // backed-up publisher never blocks this loop.
+                        if publish_tx.try_send(vote).is_err() {
+                            tracing::warn!("set-update vote publish channel full — will re-propose next tick");
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        tracing::warn!(%err, "attestor-set-update proposal cycle failed; will retry");
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::signing::recover_signer;
+    use super::*;
+    use alloy::primitives::address;
+
+    #[test]
+    fn set_needs_update_is_order_and_dup_insensitive() {
+        let a = address!("00000000000000000000000000000000000000aa");
+        let b = address!("00000000000000000000000000000000000000bb");
+        // Same members, different order / dups → no update needed.
+        assert!(!set_needs_update(&[a, b], &[b, a]));
+        assert!(!set_needs_update(&[a, b, a], &[b, a]));
+        // Added member → update needed.
+        let c = address!("00000000000000000000000000000000000000cc");
+        assert!(set_needs_update(&[a, b], &[a, b, c]));
+        // Removed member → update needed.
+        assert!(set_needs_update(&[a, b, c], &[a, b]));
+        // Empty vs non-empty.
+        assert!(set_needs_update(&[], &[a]));
+    }
+
+    #[test]
+    fn build_vote_signs_canonical_digest_and_recovers_to_signer() {
+        let signer = MessageSigner::from_seed(&[9u8; 32]).unwrap();
+        let a = address!("00000000000000000000000000000000000000cc");
+        let b = address!("00000000000000000000000000000000000000aa");
+        let chain_id = U256::from(11_155_111u64);
+        let nonce = U256::from(3u64);
+
+        let vote = build_set_update_vote(&signer, 2, &[a, b], chain_id, nonce).unwrap();
+
+        // Addresses are stored canonically (sorted), not in input order.
+        let canonical = canonical_attestor_order(&[a, b]);
+        let expected: Vec<[u8; 20]> = canonical.iter().map(|a| a.into_array()).collect();
+        assert_eq!(vote.new_attestors, expected);
+        assert_eq!(vote.signer, signer.address().into_array());
+        assert_eq!(vote.nonce, nonce.to_be_bytes::<32>());
+
+        // The signature recovers to our address over the digest the relayer will reconstruct.
+        let digest = attestor_set_update_digest(&canonical, chain_id, nonce);
+        let recovered = recover_signer(&digest, &vote.signature).unwrap();
+        assert_eq!(recovered, signer.address());
+    }
+}

--- a/attestor/attestor/src/tasks/write_ability/set_update.rs
+++ b/attestor/attestor/src/tasks/write_ability/set_update.rs
@@ -153,6 +153,12 @@ pub async fn run_proposer(
     let mut tick = tokio::time::interval(Duration::from_secs(SET_UPDATE_POLL_SECS));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
+    // Whether this attestor's own EVM address is confirmed registered on-chain. The startup
+    // registration in `lib.rs` is best-effort and one-shot; retry here each cycle until it lands so a
+    // transient RPC blip at startup can't silently omit us from the destination validator set forever
+    // (review P2-8 #2). Idempotent — `register_evm_address` no-ops once confirmed.
+    let mut self_registered = false;
+
     loop {
         tokio::select! {
             () = token.cancelled() => {
@@ -160,6 +166,10 @@ pub async fn run_proposer(
                 return;
             }
             _ = tick.tick() => {
+                if !self_registered {
+                    self_registered =
+                        super::register_evm_address(&cc3, &signer, chain_key).await;
+                }
                 match propose_once(&cc3, chain_key, &dest_rpc_url, validator, &signer).await {
                     Ok(Some(vote)) => {
                         // Bounded `try_send`: if the publish channel is full the vote is dropped and

--- a/attestor/attestor/src/tasks/write_ability/set_update.rs
+++ b/attestor/attestor/src/tasks/write_ability/set_update.rs
@@ -153,12 +153,6 @@ pub async fn run_proposer(
     let mut tick = tokio::time::interval(Duration::from_secs(SET_UPDATE_POLL_SECS));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
-    // Whether this attestor's own EVM address is confirmed registered on-chain. The startup
-    // registration in `lib.rs` is best-effort and one-shot; retry here each cycle until it lands so a
-    // transient RPC blip at startup can't silently omit us from the destination validator set forever
-    // (review P2-8 #2). Idempotent — `register_evm_address` no-ops once confirmed.
-    let mut self_registered = false;
-
     loop {
         tokio::select! {
             () = token.cancelled() => {
@@ -166,10 +160,15 @@ pub async fn run_proposer(
                 return;
             }
             _ = tick.tick() => {
-                if !self_registered {
-                    self_registered =
-                        super::register_evm_address(&cc3, &signer, chain_key).await;
-                }
+                // Ensure this attestor's own EVM address is registered on-chain, every cycle. The
+                // startup registration in `lib.rs` is best-effort and one-shot; re-checking here
+                // recovers not only from a transient startup RPC blip (review P2-8 #2) but also from
+                // the mapping later disappearing while the process runs — e.g. a chain-removal purge
+                // (bugbot: don't latch on first success). Idempotent and cheap: `register_evm_address`
+                // reads the on-chain value first and only submits an extrinsic when it is missing or
+                // stale, so a steady state is a single storage read per cycle.
+                super::register_evm_address(&cc3, &signer, chain_key).await;
+
                 match propose_once(&cc3, chain_key, &dest_rpc_url, validator, &signer).await {
                     Ok(Some(vote)) => {
                         // Bounded `try_send`: if the publish channel is full the vote is dropped and

--- a/attestor/attestor/tests/e2e_anvil.rs
+++ b/attestor/attestor/tests/e2e_anvil.rs
@@ -140,6 +140,7 @@ async fn outbox_publish_indexed_signed_and_reaches_quorum() {
         aggregator: Mutex::new(VoteAggregator::new(1, 1000, Duration::from_secs(60))),
         active_set: parking_lot::RwLock::new(active_set),
         publish_tx: tokio::sync::mpsc::channel(8).0,
+        set_update_publish_tx: tokio::sync::mpsc::channel(8).0,
         reobs_tx: tokio::sync::mpsc::channel(8).0,
         destination_chain_key: ck_b32,
     };

--- a/common/cc-client/src/lib.rs
+++ b/common/cc-client/src/lib.rs
@@ -659,6 +659,37 @@ impl Client {
         Ok(checkpoint.map(|c| (c.block_number, Digest::from_slice(&c.digest.0))))
     }
 
+    /// EVM message-vote addresses of the currently-active attestors for `chain_key` — the set the
+    /// destination `EOAValidator` should hold (audit P2-8). Reads `ActiveAttestors` and joins each
+    /// against its `AttestorEvmAddress` registration, skipping any active attestor that has not
+    /// registered an EVM address yet. Order is unspecified; callers canonicalize before hashing.
+    pub async fn active_attestor_evm_addresses(
+        &self,
+        chain_key: ChainKey,
+    ) -> Result<Vec<sp_core::H160>, Error> {
+        let storage = self.api().storage().at_latest().await?;
+
+        let active = storage
+            .fetch(&cc3::storage().attestation().active_attestors(chain_key))
+            .await?
+            .unwrap_or_default();
+
+        let mut out = Vec::with_capacity(active.len());
+        for attestor in active {
+            if let Some(addr) = storage
+                .fetch(
+                    &cc3::storage()
+                        .attestation()
+                        .attestor_evm_address(chain_key, attestor),
+                )
+                .await?
+            {
+                out.push(sp_core::H160(addr.0));
+            }
+        }
+        Ok(out)
+    }
+
     /// Check the clients membership in the attestor pallet
     pub async fn check_attestors_membership(&self, chain_key: u64) -> Result<bool, Error> {
         let storage_query = cc3::storage().attestation().active_attestors(chain_key);

--- a/common/write-ability/src/abi.rs
+++ b/common/write-ability/src/abi.rs
@@ -129,6 +129,17 @@ sol! {
         /// Quorum threshold (e.g. 2N/3 + 1). Mirrored locally so callers do not burn gas on
         /// transactions that are guaranteed to revert.
         function threshold() external view returns (uint256);
+
+        /// Monotonic nonce bound into the attestor-set-update digest (replay/rollback protection).
+        /// Attestors read it to sign the current update; it increments on each successful update.
+        function attestorSetUpdateNonce() external view returns (uint256);
+
+        /// Rotate the attestor set. `signatures` is the concatenation of 65-byte `(r,s,v)` ECDSA
+        /// signatures by the *current* set over the update digest (see
+        /// [`attestor_set_update_digest`](crate::hash::attestor_set_update_digest)); the contract
+        /// verifies threshold-many and swaps in `newAttestors`. Permissionless — the relayer submits
+        /// it once it has aggregated a threshold of gossiped signatures.
+        function submitAttestorSetUpdate(address[] memory newAttestors, bytes memory signatures) external;
     }
 
     #[sol(rpc)]

--- a/common/write-ability/src/envelope.rs
+++ b/common/write-ability/src/envelope.rs
@@ -78,6 +78,44 @@ impl ReobservationRequest {
     }
 }
 
+/// Vote an attestor gossips on [`attestor_set_update_topic`](crate::protocol::attestor_set_update_topic)
+/// proposing a new destination `EOAValidator` attestor set (write-ability P2-8).
+///
+/// Each attestor signs the update digest
+/// ([`attestor_set_update_digest`](crate::hash::attestor_set_update_digest)) over the canonical
+/// (sorted) `new_attestors`, the destination `chain_id`, and the current `attestor_set_update_nonce`.
+/// The relayer snoops the topic, collects a threshold of these, and submits `submitAttestorSetUpdate`
+/// on-chain. `new_attestors` and `nonce` are carried so the relayer can reconstruct the exact digest
+/// and calldata; `chain_id` is not carried (the relayer knows its own destination chain).
+#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode)]
+pub struct SetUpdateVote {
+    /// USC chain_key this vote is scoped to. Must match the gossipsub topic prefix.
+    pub chain_key: u64,
+    /// Proposed attestor set as 20-byte EVM addresses, in **canonical (ascending) order** — the
+    /// exact order hashed into the digest and submitted on-chain.
+    pub new_attestors: Vec<[u8; 20]>,
+    /// The `EOAValidator.attestorSetUpdateNonce` this vote was signed against (big-endian `U256`).
+    pub nonce: [u8; 32],
+    /// EVM address recovered from `signature` (published so the relayer can pre-filter against the
+    /// current set before paying for `ecrecover`).
+    pub signer: [u8; 20],
+    /// 65-byte ECDSA signature (`r || s || v`) over the update digest.
+    pub signature: [u8; 65],
+}
+
+impl SetUpdateVote {
+    /// Decode an incoming gossipsub payload (canonical SCALE, trailing bytes rejected).
+    pub fn decode_bytes(bytes: &[u8]) -> Result<Self, parity_scale_codec::Error> {
+        Self::decode_all(&mut &bytes[..])
+    }
+
+    /// Encode for publishing / fixtures.
+    #[must_use]
+    pub fn encode_bytes(&self) -> Vec<u8> {
+        self.encode()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/common/write-ability/src/hash.rs
+++ b/common/write-ability/src/hash.rs
@@ -44,6 +44,33 @@ pub fn message_hash(
     keccak256(&encoded)
 }
 
+/// Compute the attestor-set-update digest exactly as the `EOAValidator` recomputes it:
+/// `keccak256(abi.encode(newAttestors, chainId, nonce))`.
+///
+/// `new_attestors` MUST be in the exact order the relayer will submit on-chain (the contract hashes
+/// that order), so every attestor and the relayer agree on a **canonical** ordering — see
+/// `canonical_attestor_order`. `chain_id` is the destination chain's `block.chainid`, and `nonce`
+/// is the validator's current `attestorSetUpdateNonce` (replay/rollback protection).
+#[must_use]
+pub fn attestor_set_update_digest(new_attestors: &[Address], chain_id: U256, nonce: U256) -> B256 {
+    // Same head-of-tuple encoding as `message_hash`: `abi_encode_params` on the tuple reproduces
+    // Solidity `abi.encode(address[], uint256, uint256)` byte-for-byte.
+    let encoded = (new_attestors.to_vec(), chain_id, nonce).abi_encode_params();
+    keccak256(&encoded)
+}
+
+/// Canonical ordering for the attestor-set-update array: ascending by 20-byte address. All attestors
+/// (and the relayer) must order `newAttestors` identically or their signatures cover different bytes
+/// and cannot be aggregated. Sorting by the raw address bytes is deterministic and needs no shared
+/// state. Returns a de-duplicated, sorted copy.
+#[must_use]
+pub fn canonical_attestor_order(addrs: &[Address]) -> Vec<Address> {
+    let mut out = addrs.to_vec();
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,6 +106,47 @@ mod tests {
         let h1 = message_hash(m, e, d, 1, b"a");
         let h2 = message_hash(m, e, d, 1, b"b");
         assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn set_update_digest_is_deterministic_and_binds_nonce_and_chain() {
+        let addrs = [
+            address!("00000000000000000000000000000000000000aa"),
+            address!("00000000000000000000000000000000000000bb"),
+        ];
+        let base = attestor_set_update_digest(&addrs, U256::from(42u64), U256::from(7u64));
+        // Deterministic.
+        assert_eq!(
+            base,
+            attestor_set_update_digest(&addrs, U256::from(42u64), U256::from(7u64))
+        );
+        // Nonce-sensitive (rollback protection).
+        assert_ne!(
+            base,
+            attestor_set_update_digest(&addrs, U256::from(42u64), U256::from(8u64))
+        );
+        // Chain-id-sensitive (cross-chain isolation).
+        assert_ne!(
+            base,
+            attestor_set_update_digest(&addrs, U256::from(43u64), U256::from(7u64))
+        );
+        // Order-sensitive (why canonical ordering is mandatory).
+        let reversed = [addrs[1], addrs[0]];
+        assert_ne!(
+            base,
+            attestor_set_update_digest(&reversed, U256::from(42u64), U256::from(7u64))
+        );
+    }
+
+    #[test]
+    fn canonical_order_sorts_and_dedups() {
+        let a = address!("00000000000000000000000000000000000000aa");
+        let b = address!("00000000000000000000000000000000000000bb");
+        let c = address!("00000000000000000000000000000000000000cc");
+        let ordered = canonical_attestor_order(&[c, a, b, a]);
+        assert_eq!(ordered, vec![a, b, c]);
+        // Idempotent + order-independent: any permutation yields the same canonical vector.
+        assert_eq!(canonical_attestor_order(&[b, c, a]), ordered);
     }
 
     /// Differing creditcoin_chain_id must produce different hashes (replay protection).

--- a/common/write-ability/src/protocol.rs
+++ b/common/write-ability/src/protocol.rs
@@ -25,6 +25,17 @@ pub fn reobservation_topic(chain_key: u64) -> String {
     format!("{chain_key}/reobservation-requests/v1")
 }
 
+/// Build the gossipsub topic attestors publish **attestor-set-update** votes on for a given USC
+/// `chain_key`. Every epoch, when the elected set (mapped to registered EVM addresses) differs from
+/// the destination `EOAValidator`'s current set, each attestor signs the update digest and gossips
+/// a [`SetUpdateVote`](crate::envelope::SetUpdateVote) here; the relayer aggregates a threshold and
+/// submits `submitAttestorSetUpdate` on-chain. Distinct from the message-vote and reobservation
+/// topics so a subscriber to one is not forced to receive the others.
+#[must_use]
+pub fn attestor_set_update_topic(chain_key: u64) -> String {
+    format!("{chain_key}/attestor-set-update/v1")
+}
+
 /// Canonical mapping of a Substrate `ChainKey` (`u64`) to the Solidity `bytes32` chain key passed
 /// to `IOutboxFactory.getOutbox` and bound into each `messageHash` (research §2.3).
 ///
@@ -51,6 +62,13 @@ mod tests {
         assert_eq!(reobservation_topic(42), "42/reobservation-requests/v1");
         // Must be a *different* topic from the vote topic for the same chain.
         assert_ne!(reobservation_topic(42), message_votes_topic(42));
+    }
+
+    #[test]
+    fn attestor_set_update_topic_matches_spec_and_is_distinct() {
+        assert_eq!(attestor_set_update_topic(42), "42/attestor-set-update/v1");
+        assert_ne!(attestor_set_update_topic(42), message_votes_topic(42));
+        assert_ne!(attestor_set_update_topic(42), reobservation_topic(42));
     }
 
     #[test]


### PR DESCRIPTION
## What

The **off-chain half of P2-8**: attestors automatically propose a new destination `EOAValidator` set when the elected set changes, and gossip signed votes for the **relayer** to submit on-chain. Builds on the on-chain EVM-address registry (#1166).

**Design:** attestors only *propose* (sign + gossip); the relayer *aggregates + submits* `submitAttestorSetUpdate`. This mirrors the existing message-delivery flow exactly (attestors sign+gossip, relayer aggregates+delivers) and reuses the relayer's existing destination-chain write capability — no new tx-sending/gas/leader-election on the attestor side.

## Shared protocol (`common/write-ability`, consumed by attestor **and** relayer)
- `IVoteValidator`: `attestorSetUpdateNonce()` + `submitAttestorSetUpdate(address[],bytes)`.
- `attestor_set_update_topic` = `{chain_key}/attestor-set-update/v1`.
- `attestor_set_update_digest` = `keccak256(abi.encode(newAttestors, chainId, nonce))` (matches the `EOAValidator`) + `canonical_attestor_order` (ascending, deduped) so **every attestor signs byte-identical bytes** — the correctness crux for signature aggregation.
- `SetUpdateVote` SCALE envelope (canonical set + nonce + signer + sig).

## Attestor
- `set_update.rs`: `set_needs_update` (set-wise diff), `build_set_update_vote` (canonicalize → digest → sign), and `run_proposer` — polls the elected attestors' registered EVM addresses (`cc-client active_attestor_evm_addresses`) vs the on-chain `EOAValidator` set; when they diverge, signs over the **current on-chain nonce** and gossips. Empty candidate → no-op (never proposes an empty set).
- Wired into `write_ability::run` alongside the attestor-set watcher (OnChainValidator only, Outbox-independent), gossiped via a new p2p publish channel + topic subscription. Drop-on-fail publish — the proposer re-emits each cycle while the set stays diverged.

## Nonce / replay
Attestors sign over the validator's current `attestorSetUpdateNonce`; once an update lands the nonce bumps and stale in-flight votes are naturally rejected on-chain (the replay/rollback protection working as intended).

## Tests
Shared crate: digest (deterministic; nonce/chain/order-sensitive), canonical ordering, envelope. Attestor: set-diff (order/dup-insensitive), sign→recover round-trip. Full attestor suite **97 pass**; shared-crate **16 pass**; clippy + fmt clean across `write-ability`, `cc-client`, `attestor`.

## Remaining (separate repo)
The **relayer half** — snoop `attestor-set-update` topic, aggregate a threshold of `SetUpdateVote`s, and call `submitAttestorSetUpdate` — lives in `usc-message-relayer` and is a separate PR. The shared protocol here is what it consumes.

## Notes
- Stacked on #1166 (base `feat/attestor-evm-address-registration`). Full CI/Bugbot won't run until retargeted onto a canonical branch; verified locally.
- Pairs well with fixing ChainLight-003 (digest lacks `address(this)`) before this goes live.

https://claude.ai/code/session_011dAWAAebPDdCyGxgPPGwjx