### PR TITLE
ci: drop branches filters so workflows run on every branch/PR

### DIFF
--- a/.github/workflows/attestor-compatibility.yml
+++ b/.github/workflows/attestor-compatibility.yml
@@ -41,7 +41,6 @@ name: Attestor Compatibility
 
 "on":
   pull_request:
-    branches: [main, usc-testnet, usc-dev]
     paths:
       - "attestor/**"
       - "pallets/attestation/**"

--- a/.github/workflows/chainspec.yml
+++ b/.github/workflows/chainspec.yml
@@ -3,7 +3,6 @@ name: chainspec
 
 "on":
   pull_request:
-    branches: [main, usc-testnet, usc-dev]
     paths:
       - "runtime/**"
       - "chainspecs/**"

--- a/.github/workflows/check-runtime-changes.yml
+++ b/.github/workflows/check-runtime-changes.yml
@@ -3,7 +3,6 @@ name: Check runtime changes
 
 "on":
   pull_request:
-    branches: [usc-dev, usc-testnet, main]
     paths:
       - '**Cargo.*'
       - 'precompiles/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ name: CI
 # Controls when the action will run.
 "on":
   pull_request:
-    branches: [main, usc-testnet, usc-dev]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,6 @@ name: "CodeQL"
 
 "on":
   pull_request:
-    branches: [usc-dev]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -5,7 +5,6 @@ name: MegaLinter
 
 "on":
   pull_request:
-    branches: [usc-dev]
   workflow_dispatch:
 
 permissions: read-all

--- a/.github/workflows/proof-gen-api-server.yml
+++ b/.github/workflows/proof-gen-api-server.yml
@@ -3,7 +3,6 @@ name: proof-gen-api-server
 
 "on":
   pull_request:
-    branches: [main, usc-testnet, usc-dev]
     paths:
       - "proof-gen-api-server/**"
       - "common/eth/**"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,6 @@ name: rust
 
 "on":
   pull_request:
-    branches: [main, usc-testnet, usc-dev]
     paths:
       - "**.rs"
       - "**.toml"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -3,7 +3,6 @@ name: sanity
 
 "on":
   pull_request:
-    branches: [main, usc-testnet, usc-dev]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/shell-check.yml
+++ b/.github/workflows/shell-check.yml
@@ -4,7 +4,6 @@ name: shell-check
 # Controls when the action will run.
 "on":
   pull_request:
-    branches: [main, usc-testnet, usc-dev]
     paths:
       - '**.sh'
       - '.github/workflows/shell-check.yml'

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -3,7 +3,6 @@ name: Try Runtime
 
 "on":
   pull_request:
-    branches: [usc-dev]
     paths:
       - "**/migrations/**"
       - "**/migrations.rs"

--- a/.github/workflows/typescript-checks.yml
+++ b/.github/workflows/typescript-checks.yml
@@ -4,7 +4,6 @@ name: typescript-checks
 # Controls when the action will run.
 "on":
   pull_request:
-    branches: [main, usc-testnet, usc-dev]
     paths:
       - '**.ts'
       - '**.js'

--- a/.github/workflows/unit-test-cli.yml
+++ b/.github/workflows/unit-test-cli.yml
@@ -3,7 +3,6 @@ name: unit-test-cli
 
 "on":
   pull_request:
-    branches: [main, usc-testnet, usc-dev]
     paths:
       - "cli/yarn.lock"
       - "cli/src/commands/**"

--- a/.github/workflows/validator-compatibility.yml
+++ b/.github/workflows/validator-compatibility.yml
@@ -25,7 +25,6 @@ name: Validator Compatibility
 
 "on":
   pull_request:
-    branches: [main, usc-testnet, usc-dev]
     paths:
       - "node/**"
       - "runtime/**"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -3,7 +3,6 @@ name: Build WASM Runtime
 
 "on":
   pull_request:
-    branches: [main, usc-testnet, usc-dev]
     paths:
       - '**.rs'
       - '**.toml'


### PR DESCRIPTION
Drops the `branches:` filters from all workflow trigger blocks so CI jobs trigger on every branch/PR, not just the previously-whitelisted branches (main, usc-testnet, usc-dev).

- Removed `branches: [...]` under `push:`/`pull_request:` in 19 workflow files
- `paths:` and other filters left untouched
- No other changes

Requested by Alex in Slack.