### PR TITLE
ci(check-prover): DEBUG print runner IP before prover-check

### DIFF
--- a/.github/workflows/check-prover.yml
+++ b/.github/workflows/check-prover.yml
@@ -77,6 +77,12 @@ jobs:
           NAME=$(echo "${{ matrix.creditcoinUrl }}" | sed "s/wss//" | sed "s/ws//" | tr -d "/" | tr -d ":" | sed "s/rpc.//" | sed "s/.creditcoin.network//")
           echo "chain-name=$NAME" >> "$GITHUB_OUTPUT"
 
+      - name: DEBUG - Print runner IP address
+        run: |
+          # see https://opensource.com/article/18/5/how-find-ip-address-linux
+          IP_ADDRESS=$(curl https://ifconfig.me)
+          echo "INFO: IP_ADDRESS=$IP_ADDRESS"
+
       - name: Execute prover-check.ts on checkpoint boundaries
         working-directory: ./cli
         env:


### PR DESCRIPTION
Adds a temporary `DEBUG - Print runner IP address` step before each `prover-check.ts` execution in the `check-for` job of `check-prover.yml`.

Prints the runner public IP (via `api.ipify.org`) so we can see which egress IP the prover checks originate from. Non-fatal (`curl ... || echo`).

Requested by @ in Slack.