### PR TITLE
test(attestation): bump sanity beforeAll hook timeout to 60s

### DIFF
--- a/cli/src/test/attestation-tests/sanity.test.ts
+++ b/cli/src/test/attestation-tests/sanity.test.ts
@@ -37,7 +37,7 @@ describe('BlockAttested events', (): void => {
 
         provider_Anvil1 = new WebSocketProvider(chain_Anvil1_Url);
         startBlock_Anvil1 = await provider_Anvil1.getBlockNumber();
-    });
+    }, 60_000);
 
     afterAll(async () => {
         await api.disconnect();


### PR DESCRIPTION
## Problem

`integration-test-attestator-network` intermittently fails at the **Run attestation tests** step with:

```
FAIL src/test/attestation-tests/sanity.test.ts
  BlockAttested events › are emitted frequently enough and match Ethereum
    thrown: "Exceeded timeout of 5000 ms for a hook."
    at beforeAll (sanity.test.ts:21:5)
```

The `beforeAll` hook does real network setup before any test runs:
- opens a fresh WS connection via `newApi()` to the CC3 node
- queries `babe.epochIndex`, `attestation.activeAttestors`, `attestation.chainAttestationInterval`
- opens an ethers `WebSocketProvider` to Anvil1 and calls `getBlockNumber()`

All of that runs inside jest's **default 5000ms** hook budget. On a loaded CI runner these live WS handshakes can easily exceed 5s, failing the entire suite before the node/anvil are even stressed.

## Root cause is timing, not a node/anvil bug

I pulled the run artifacts and scanned the node + anvil logs from the failing run:
- **creditcoin3-node** (alice/bob/charlie/dave): 0 `ERROR`/`panic`/`FATAL`; blocks produced, GRANDPA finalizing normally.
- **anvil1.log / anvil2.log**: clean, served RPC, reached expected block heights.
- **anvil1-restart.json** (2.3GB WS-restart recovery scenario): scanned in full, 0 error/reset/refused/disconnect hits.
- **zombienet**: all 6 attestors funded → registered → started.

Infra was healthy — the failure is purely the harness running out of jest's default hook timeout.

## Fix

Give the setup hook an explicit **60s** timeout:

```ts
beforeAll(async () => {
    ...
}, 60_000);
```

A 5s budget for multi-connection bootstrap (CC3 WS + Anvil WS + several chain queries) is too tight regardless of flakiness.

## Testing
- `yarn check-format` ✓
- `yarn lint` ✓
- `yarn build` ✓