### PR TITLE
ci: bump setup-node to Node 24 across workflows

### DIFF
--- a/.github/workflows/attestor-compatibility.yml
+++ b/.github/workflows/attestor-compatibility.yml
@@ -309,7 +309,7 @@ jobs:
       - name: Install CLI dependencies
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
       - name: Build CLI

--- a/.github/workflows/chainspec.yml
+++ b/.github/workflows/chainspec.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
       - run: npm install -g yarn

--- a/.github/workflows/check-prover.yml
+++ b/.github/workflows/check-prover.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
       - run: npm install -g yarn
@@ -165,7 +165,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
       - run: npm install -g yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Install Node Dependencies
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
       - run: npm install --ignore-scripts -g @polkadot/metadata-cmp
 
       - name: Download creditcoin-node binary
@@ -344,7 +344,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: |
             attestor/scripts/package.json
@@ -815,7 +815,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
       - run: npm install -g yarn
@@ -929,7 +929,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
       - run: npm install -g yarn
@@ -1104,7 +1104,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: docs/smart-contract-development/with-hardhat/package-lock.json
 
@@ -1333,7 +1333,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: |
             cc3-indexer/yarn.lock
@@ -1554,7 +1554,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
       - run: npm install -g yarn
@@ -1636,7 +1636,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
       - run: npm install -g yarn
@@ -1865,7 +1865,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
 

--- a/.github/workflows/proof-gen-api-server.yml
+++ b/.github/workflows/proof-gen-api-server.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: |
             attestor/scripts/package-lock.json
@@ -395,7 +395,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: |
             attestor/scripts/package-lock.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Download binaries
         uses: actions/download-artifact@v8

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -398,7 +398,7 @@ jobs:
       - name: Install JS Dependencies
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
       - working-directory: cli
@@ -525,7 +525,7 @@ jobs:
       - name: Install JS Dependencies
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
       - working-directory: cli

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
       - run: npm install -g yarn

--- a/.github/workflows/typescript-checks.yml
+++ b/.github/workflows/typescript-checks.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
       - run: npm install -g yarn
 
       - name: Install Solidity compiler

--- a/.github/workflows/unit-test-cli.yml
+++ b/.github/workflows/unit-test-cli.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
       - run: npm install -g yarn

--- a/.github/workflows/validator-compatibility.yml
+++ b/.github/workflows/validator-compatibility.yml
@@ -256,7 +256,7 @@ jobs:
       - name: Install CLI dependencies
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
           cache-dependency-path: cli/yarn.lock
       - name: Build CLI


### PR DESCRIPTION
## What

Bumps every `setup-node` `node-version` from **20 → 24** across all GitHub Actions workflows (22 lines, 11 files).

## Why

Node 20 is approaching end-of-life. This aligns all CC3 workflows on Node 24, matching the version already used in `usc-testnet-bridge-examples`.

## Notes

- Workflow-only change — no `node:` base image exists in any CC3 Dockerfile (`cc3-indexer` uses the SubQuery image, stress-test/audit use Deno, postgres uses `postgres:18-alpine`), so no Dockerfile edits were required.
- `scripts/*/package.json` `engines.node: >=18.0.0` floors are left untouched (they already permit 24).
- The `NODE_VERSION` bash variables in `validator-compatibility.yml` refer to the chain node build, not Node.js, and were left unchanged.

Requested by the team in #protocol-cc3.