### PR TITLE
ci: pin docker-scout-weekly-report to ubuntu-26.04

### DIFF
--- a/.github/workflows/docker-scout-weekly-report.yml
+++ b/.github/workflows/docker-scout-weekly-report.yml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   scout-weekly-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Install Docker Scout CLI
         run: curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --


### PR DESCRIPTION
## What

Pins `docker-scout-weekly-report.yml` `runs-on` from `ubuntu-latest` -> `ubuntu-26.04`.

## Why

Every other workflow and the `Dockerfile` runtime base are already pinned to `ubuntu-26.04`. This was the only job still riding `ubuntu-latest`. Pinning it keeps the runner OS consistent across CI and avoids silent runner-image drift when GitHub advances `ubuntu-latest`.

Requested by the team in #protocol-cc3.