### PR TITLE
fix(cli): migrate test suite to ESM for execa 10 compat

### DIFF
--- a/cli/.eslintrc.js
+++ b/cli/.eslintrc.js
@@ -26,6 +26,18 @@ module.exports = {
         project: 'tsconfig.json',
         sourceType: 'module',
     },
+    // The base tsconfig excludes src/test from the CommonJS build, so the CLI's
+    // test tree needs the ESM-aware test project for type-aware lint rules.
+    // Scoped as an override so consumers that symlink this config (cc3-indexer,
+    // docs/.../with-hardhat) keep using their own tsconfig.json.
+    overrides: [
+        {
+            files: ['src/test/**/*.ts'],
+            parserOptions: {
+                project: 'tsconfig.test.json',
+            },
+        },
+    ],
     plugins: [
         // "eslint-plugin-jsdoc",
         // "eslint-plugin-prefer-arrow",
@@ -59,18 +71,18 @@ module.exports = {
                 },
             },
         ],
-        "@typescript-eslint/naming-convention": [
-            "error",
+        '@typescript-eslint/naming-convention': [
+            'error',
             {
-              selector: "property",
-              format: ["strictCamelCase"],
-              filter: {
-                // allow CC_SECRET and EVM_SECRET
-                regex: "^(CC_SECRET|CC_PROXY_SECRET|EVM_SECRET|Address20)$",
-                match: false,
-              },
+                selector: 'property',
+                format: ['strictCamelCase'],
+                filter: {
+                    // allow CC_SECRET and EVM_SECRET
+                    regex: '^(CC_SECRET|CC_PROXY_SECRET|EVM_SECRET|Address20)$',
+                    match: false,
+                },
             },
-          ],
+        ],
         '@typescript-eslint/no-empty-function': 'error',
         '@typescript-eslint/no-empty-interface': 'error',
         '@typescript-eslint/no-explicit-any': 'off',
@@ -84,11 +96,11 @@ module.exports = {
             },
         ],
         '@typescript-eslint/no-unused-expressions': 'error',
-        "@typescript-eslint/no-unsafe-argument": "off",
-        "@typescript-eslint/no-unsafe-assignment": "off",
-        "@typescript-eslint/no-unsafe-call": "off",
-        "@typescript-eslint/no-unsafe-member-access": "off",
-        "@typescript-eslint/no-unsafe-return": "off",
+        '@typescript-eslint/no-unsafe-argument': 'off',
+        '@typescript-eslint/no-unsafe-assignment': 'off',
+        '@typescript-eslint/no-unsafe-call': 'off',
+        '@typescript-eslint/no-unsafe-member-access': 'off',
+        '@typescript-eslint/no-unsafe-return': 'off',
         '@typescript-eslint/no-use-before-define': 'off',
         '@typescript-eslint/no-var-requires': 'error',
         '@typescript-eslint/prefer-for-of': 'error',
@@ -98,8 +110,8 @@ module.exports = {
         '@typescript-eslint/restrict-template-expressions': [
             'error',
             {
-                allowAny: true
-            }
+                allowAny: true,
+            },
         ],
         '@typescript-eslint/semi': ['off', null],
         '@typescript-eslint/triple-slash-reference': [
@@ -163,13 +175,13 @@ module.exports = {
         'no-unsafe-finally': 'error',
         'no-unused-expressions': 'error',
         'no-unused-labels': 'error',
-        "@typescript-eslint/no-unused-vars": [
-            "warn",
+        '@typescript-eslint/no-unused-vars': [
+            'warn',
             {
-                "argsIgnorePattern": "^_",
-                "varsIgnorePattern": "^_",
-                "caughtErrorsIgnorePattern": "^_"
-            }
+                argsIgnorePattern: '^_',
+                varsIgnorePattern: '^_',
+                caughtErrorsIgnorePattern: '^_',
+            },
         ],
         'no-use-before-define': 'off',
         'no-var': 'error',

--- a/cli/jest.config.json
+++ b/cli/jest.config.json
@@ -1,5 +1,23 @@
 {
-    "preset": "ts-jest",
+    "preset": "ts-jest/presets/default-esm",
     "testEnvironment": "node",
-    "testPathIgnorePatterns": ["/node_modules/", "/dist/"]
+    "extensionsToTreatAsEsm": [
+        ".ts"
+    ],
+    "testPathIgnorePatterns": [
+        "/node_modules/",
+        "/dist/"
+    ],
+    "transform": {
+        "^.+\\.tsx?$": [
+            "ts-jest",
+            {
+                "useESM": true,
+                "tsconfig": "tsconfig.test.json"
+            }
+        ]
+    },
+    "transformIgnorePatterns": [
+        "node_modules/(?!(execa|@sindresorhus/merge-streams|figures|get-stream|human-signals|is-plain-obj|is-stream|npm-run-path|path-key|pretty-ms|signal-exit|strip-final-newline|which-command|yoctocolors|unicorn-magic)/)"
+    ]
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -25,14 +25,14 @@
         "lint": "eslint -c .eslintrc.js --max-warnings 0 --ext .ts ./src",
         "typecheck": "tsc --noEmit",
         "prepare": "yarn build",
-        "test:unit": "jest --silent --verbose --runInBand src/test/unit-tests",
-        "test:attestor-cli": "jest --config src/test/integration-tests.config.ts --silent --verbose --runInBand --forceExit src/test/integration-tests/attestor/",
-        "test:validator-cli": "jest --config src/test/integration-tests.config.ts --silent --verbose --runInBand --forceExit src/test/integration-tests/validator/",
-        "test:attestation": "jest --config src/test/attestation-tests.config.ts --verbose --runInBand --forceExit src/test/attestation-tests",
-        "test:blockchain": "jest --config src/test/blockchain-tests.config.ts --silent --verbose --runInBand --forceExit src/test/blockchain-tests",
-        "test:cc3-indexer": "jest --config src/test/cc3-indexer-tests.config.ts --silent --verbose --runInBand --forceExit src/test/cc3-indexer-tests",
-        "test:archiver": "jest --config src/test/archiver-tests.config.ts --silent --verbose --runInBand --forceExit src/test/archiver-tests",
-        "test:randomness": "jest --config src/test/blockchain-tests.config.ts --verbose --runInBand --forceExit src/test/blockchain-tests/pallets/randomness"
+        "test:unit": "NODE_OPTIONS=--experimental-vm-modules jest --silent --verbose --runInBand src/test/unit-tests",
+        "test:attestor-cli": "NODE_OPTIONS=--experimental-vm-modules jest --config src/test/integration-tests.config.ts --silent --verbose --runInBand --forceExit src/test/integration-tests/attestor/",
+        "test:validator-cli": "NODE_OPTIONS=--experimental-vm-modules jest --config src/test/integration-tests.config.ts --silent --verbose --runInBand --forceExit src/test/integration-tests/validator/",
+        "test:attestation": "NODE_OPTIONS=--experimental-vm-modules jest --config src/test/attestation-tests.config.ts --verbose --runInBand --forceExit src/test/attestation-tests",
+        "test:blockchain": "NODE_OPTIONS=--experimental-vm-modules jest --config src/test/blockchain-tests.config.ts --silent --verbose --runInBand --forceExit src/test/blockchain-tests",
+        "test:cc3-indexer": "NODE_OPTIONS=--experimental-vm-modules jest --config src/test/cc3-indexer-tests.config.ts --silent --verbose --runInBand --forceExit src/test/cc3-indexer-tests",
+        "test:archiver": "NODE_OPTIONS=--experimental-vm-modules jest --config src/test/archiver-tests.config.ts --silent --verbose --runInBand --forceExit src/test/archiver-tests",
+        "test:randomness": "NODE_OPTIONS=--experimental-vm-modules jest --config src/test/blockchain-tests.config.ts --verbose --runInBand --forceExit src/test/blockchain-tests/pallets/randomness"
     },
     "devDependencies": {
         "@gluwa/usc-sdk": "0.18.0",

--- a/cli/src/lib/attestor/precompile.ts
+++ b/cli/src/lib/attestor/precompile.ts
@@ -5,8 +5,7 @@ import { OptionValues } from 'commander';
 import { evmAddressToSubstrateAddress } from '../evm/address';
 import { getEvmUrl } from '../evm/rpc';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import contractABIJSON = require('../../test/blockchain-tests/artifacts/attestor_stash.json');
+import contractABIJSON from '../../test/blockchain-tests/artifacts/attestor_stash.json';
 const contractABI = contractABIJSON as unknown as ethers.InterfaceAbi;
 
 export const ATTESTOR_STASH_ADDRESS = '0x0000000000000000000000000000000000000fd4';

--- a/cli/src/lib/staking/validatorStatus.ts
+++ b/cli/src/lib/staking/validatorStatus.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import timeDelta = require('time-delta');
+import timeDelta from 'time-delta';
 
 import { ApiPromise } from '@polkadot/api';
 import { BN } from '..';

--- a/cli/src/test/archiver-tests.config.ts
+++ b/cli/src/test/archiver-tests.config.ts
@@ -1,8 +1,16 @@
 import type { Config } from '@jest/types';
 const config: Config.InitialOptions = {
-    preset: 'ts-jest',
+    preset: 'ts-jest/presets/default-esm',
     testEnvironment: 'node',
     globalSetup: './archiverSetup.ts',
+    extensionsToTreatAsEsm: ['.ts'],
+    transform: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        '^.+\\.tsx?$': ['ts-jest', { useESM: true, tsconfig: 'tsconfig.test.json' }],
+    },
+    transformIgnorePatterns: [
+        'node_modules/(?!(execa|@sindresorhus/merge-streams|figures|get-stream|human-signals|is-plain-obj|is-stream|npm-run-path|path-key|pretty-ms|signal-exit|strip-final-newline|which-command|yoctocolors|unicorn-magic)/)',
+    ],
 };
 
 export default config;

--- a/cli/src/test/attestation-tests.config.ts
+++ b/cli/src/test/attestation-tests.config.ts
@@ -1,8 +1,16 @@
 import type { Config } from '@jest/types';
 const config: Config.InitialOptions = {
-    preset: 'ts-jest',
+    preset: 'ts-jest/presets/default-esm',
     testEnvironment: 'node',
     globalSetup: './attestationSetup.ts',
+    extensionsToTreatAsEsm: ['.ts'],
+    transform: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        '^.+\\.tsx?$': ['ts-jest', { useESM: true, tsconfig: 'tsconfig.test.json' }],
+    },
+    transformIgnorePatterns: [
+        'node_modules/(?!(execa|@sindresorhus/merge-streams|figures|get-stream|human-signals|is-plain-obj|is-stream|npm-run-path|path-key|pretty-ms|signal-exit|strip-final-newline|which-command|yoctocolors|unicorn-magic)/)',
+    ],
 };
 
 export default config;

--- a/cli/src/test/blockchain-tests.config.ts
+++ b/cli/src/test/blockchain-tests.config.ts
@@ -1,9 +1,17 @@
 import type { Config } from '@jest/types';
 const config: Config.InitialOptions = {
-    preset: 'ts-jest',
+    preset: 'ts-jest/presets/default-esm',
     testEnvironment: 'node',
     testTimeout: 240000,
     globalSetup: process.env.BLOCKCHAIN_TESTS_GLOBAL_SETUP || './blockchainSetup.ts',
+    extensionsToTreatAsEsm: ['.ts'],
+    transform: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        '^.+\\.tsx?$': ['ts-jest', { useESM: true, tsconfig: 'tsconfig.test.json' }],
+    },
+    transformIgnorePatterns: [
+        'node_modules/(?!(execa|@sindresorhus/merge-streams|figures|get-stream|human-signals|is-plain-obj|is-stream|npm-run-path|path-key|pretty-ms|signal-exit|strip-final-newline|which-command|yoctocolors|unicorn-magic)/)',
+    ],
 };
 
 export default config;

--- a/cli/src/test/blockchain-tests/helpers.ts
+++ b/cli/src/test/blockchain-tests/helpers.ts
@@ -1,6 +1,10 @@
 import { ethers } from 'ethers';
 import { readFile } from 'fs/promises';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+// ESM has no __dirname; derive the current directory from import.meta.url.
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
 
 // matches artifacts/proof_example_erc20.json
 export const validQuery = {
@@ -52,7 +56,7 @@ export const deployContract = async (
 ): Promise<ethers.Contract> => {
     console.log(`deploying ${contractName}`);
 
-    const artifactsPath = path.resolve(__dirname, `./artifacts/${contractName}.json`);
+    const artifactsPath = path.resolve(currentDir, `./artifacts/${contractName}.json`);
 
     const contents = await readFile(artifactsPath);
     const metadata = JSON.parse(contents.toString());

--- a/cli/src/test/blockchain-tests/precompiles/attestor-stash.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/attestor-stash.test.ts
@@ -9,8 +9,7 @@ import { chain_Anvil2_Key } from '../pallets/supported-chains/consts';
 import { attestorStashAddress } from './consts';
 import { testIf } from '../../utils';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import contractABIJSON = require('../artifacts/attestor_stash.json');
+import contractABIJSON from '../artifacts/attestor_stash.json' with { type: 'json' };
 const contractABI = contractABIJSON as unknown as ethers.InterfaceAbi;
 
 // Event signatures (must match pallet-evm-precompile-attestor-stash)

--- a/cli/src/test/blockchain-tests/precompiles/block-prover.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/block-prover.test.ts
@@ -8,8 +8,7 @@ import { chain_Anvil1_Key, chain_Anvil1_Url } from '../pallets/supported-chains/
 import { blockProverAddress } from './consts';
 import { testIf } from '../../utils';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import contractABIJSON = require('../artifacts/block_prover.json');
+import contractABIJSON from '../artifacts/block_prover.json' with { type: 'json' };
 const contractABI = contractABIJSON as unknown as ethers.InterfaceAbi;
 
 describe('Precompile: block-prover', (): void => {

--- a/cli/src/test/blockchain-tests/precompiles/chain-info.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/chain-info.test.ts
@@ -11,8 +11,7 @@ import {
 } from '../pallets/supported-chains/consts';
 import { chainInfoAddress } from './consts';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import contractABIJSON = require('../artifacts/chain_info.json');
+import contractABIJSON from '../artifacts/chain_info.json' with { type: 'json' };
 const contractABI = contractABIJSON as unknown as ethers.InterfaceAbi;
 
 const supportedChainKey = chain_Anvil2_Key;

--- a/cli/src/test/blockchain-tests/precompiles/ed25519-verifier.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/ed25519-verifier.test.ts
@@ -5,8 +5,7 @@ import { u8aToHex } from '@polkadot/util';
 import { newApi, ApiPromise, BN, MICROUNITS_PER_CTC } from '../../../lib';
 import { fundFromSudo } from '../../integration-tests/helpers';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import contractABIJSON = require('../artifacts/ed25519_verifier.json');
+import contractABIJSON from '../artifacts/ed25519_verifier.json' with { type: 'json' };
 const contractABI = contractABIJSON as unknown as ethers.InterfaceAbi;
 
 describe('Precompile: Ed25519Verifier.verify()', (): void => {

--- a/cli/src/test/blockchain-tests/precompiles/sr25519-verifier.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/sr25519-verifier.test.ts
@@ -5,8 +5,7 @@ import { u8aToHex } from '@polkadot/util';
 import { newApi, ApiPromise, BN, MICROUNITS_PER_CTC } from '../../../lib';
 import { fundFromSudo } from '../../integration-tests/helpers';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import contractABIJSON = require('../artifacts/sr25519_verifier.json');
+import contractABIJSON from '../artifacts/sr25519_verifier.json' with { type: 'json' };
 const contractABI = contractABIJSON as unknown as ethers.InterfaceAbi;
 
 describe('Precompile: Sr25519Verifier.verify()', (): void => {

--- a/cli/src/test/blockchain-tests/precompiles/substrate-transfer.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/substrate-transfer.test.ts
@@ -5,8 +5,7 @@ import { mnemonicGenerate } from '@polkadot/util-crypto';
 import { newApi, ApiPromise, BN, MICROUNITS_PER_CTC } from '../../../lib';
 import { fundFromSudo } from '../../integration-tests/helpers';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import contractABIJSON = require('../artifacts/substrate_transfer.json');
+import contractABIJSON from '../artifacts/substrate_transfer.json' with { type: 'json' };
 const contractABI = contractABIJSON as unknown as ethers.InterfaceAbi;
 
 describe('Precompile: transfer_substrate()', (): void => {

--- a/cli/src/test/cc3-indexer-tests.config.ts
+++ b/cli/src/test/cc3-indexer-tests.config.ts
@@ -1,11 +1,19 @@
 import type { Config } from '@jest/types';
 
 const config: Config.InitialOptions = {
-    preset: 'ts-jest',
+    preset: 'ts-jest/presets/default-esm',
     testEnvironment: 'node',
     testTimeout: 30_000,
     globalSetup: './cc3-indexer-tests/globalSetup.ts',
     testSequencer: './alphabeticalSequencer.js',
+    extensionsToTreatAsEsm: ['.ts'],
+    transform: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        '^.+\\.tsx?$': ['ts-jest', { useESM: true, tsconfig: 'tsconfig.test.json' }],
+    },
+    transformIgnorePatterns: [
+        'node_modules/(?!(execa|@sindresorhus/merge-streams|figures|get-stream|human-signals|is-plain-obj|is-stream|npm-run-path|path-key|pretty-ms|signal-exit|strip-final-newline|which-command|yoctocolors|unicorn-magic)/)',
+    ],
 };
 
 export default config;

--- a/cli/src/test/cc3-indexer-tests/handleTransactionVerified.test.ts
+++ b/cli/src/test/cc3-indexer-tests/handleTransactionVerified.test.ts
@@ -9,8 +9,7 @@ import { blockProverAddress } from '../blockchain-tests/precompiles/consts';
 import { forElapsedBlocks } from '../utils';
 import { graphQLQuery } from './common';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import blockProverABIJSON = require('../blockchain-tests/artifacts/block_prover.json');
+import blockProverABIJSON from '../blockchain-tests/artifacts/block_prover.json' with { type: 'json' };
 const blockProverABI = blockProverABIJSON as unknown as ethers.InterfaceAbi;
 
 describe('handleTransactionVerified()', () => {

--- a/cli/src/test/integration-tests.config.ts
+++ b/cli/src/test/integration-tests.config.ts
@@ -2,10 +2,21 @@ import 'jest-expect-message';
 import type { Config } from '@jest/types';
 
 const config: Config.InitialOptions = {
-    preset: 'ts-jest',
+    preset: 'ts-jest/presets/default-esm',
     testEnvironment: 'node',
     testTimeout: 30_000,
     setupFilesAfterEnv: ['jest-expect-message', './integrationTestSetupAfterEnv.ts'],
+    extensionsToTreatAsEsm: ['.ts'],
+    transform: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        '^.+\\.tsx?$': ['ts-jest', { useESM: true, tsconfig: 'tsconfig.test.json' }],
+    },
+    // execa >=6 is pure ESM; let ts-jest transpile it (and its ESM-only deps)
+    // instead of ignoring node_modules, otherwise jest's runtime hits
+    // "Cannot use import statement outside a module" on execa's ESM entrypoint.
+    transformIgnorePatterns: [
+        'node_modules/(?!(execa|@sindresorhus/merge-streams|figures|get-stream|human-signals|is-plain-obj|is-stream|npm-run-path|path-key|pretty-ms|signal-exit|strip-final-newline|which-command|yoctocolors|unicorn-magic)/)',
+    ],
 };
 
 export default config;

--- a/cli/src/test/integration-tests/helpers.ts
+++ b/cli/src/test/integration-tests/helpers.ts
@@ -3,7 +3,7 @@ import { WasmPrivateKey } from 'bls-signatures-bindings';
 import { BN, mnemonicGenerate } from '../../lib';
 import { initKeyringPair, CallerKeyring } from '../../lib/account/keyring';
 import { signSendAndWatchCcKeyring, TxStatus } from '../../lib/tx';
-import { commandSync } from 'execa';
+import { execaSync, parseCommandString } from 'execa';
 import { parseAmount } from '../../commands/options';
 import { KeyringPair } from '../../lib';
 import { substrateAddressToEvmAddress, evmAddressToSubstrateAddress } from '../../lib/evm/address';
@@ -101,7 +101,7 @@ export function CLIBuilder(env: any) {
     }
 
     function CLICmd(cmd: string) {
-        return commandSync(`node ${CLI_PATH} ${cmd} ${extraArgs}`, { env });
+        return execaSync('node', parseCommandString(`${CLI_PATH} ${cmd} ${extraArgs}`), { env });
     }
     return CLICmd;
 }

--- a/cli/src/test/integration-tests/validator/convertAddress.test.ts
+++ b/cli/src/test/integration-tests/validator/convertAddress.test.ts
@@ -1,4 +1,4 @@
-import { commandSync } from 'execa';
+import { execaSync, parseCommandString } from 'execa';
 import { describeIf } from '../../utils';
 import { ALICE_NODE_URL, BOB_NODE_URL, CLI_PATH } from '../helpers';
 import { initEthKeyringPair, initKeyringPair } from '../../../lib/account/keyring';
@@ -36,14 +36,17 @@ describeIf(
         });
 
         it('should NOT convert an invalid EVM address', () => {
-            const result = commandSync(`node ${CLI_PATH} convert-address --address 0x123`, { reject: false });
+            const result = execaSync('node', parseCommandString(`${CLI_PATH} convert-address --address 0x123`), {
+                reject: false,
+            });
 
             expect(result.stderr).toContain('Not a valid Substrate or EVM address.');
         }, 60000);
 
         it('should NOT convert an invalid Substrate address', () => {
-            const result = commandSync(
-                `node ${CLI_PATH} convert-address --address 5FQMKPxJuFBCeH7zQvw0xa>>!jXb1WeQxvf8`,
+            const result = execaSync(
+                'node',
+                parseCommandString(`${CLI_PATH} convert-address --address 5FQMKPxJuFBCeH7zQvw0xa>>!jXb1WeQxvf8`),
                 {
                     reject: false,
                 },
@@ -53,16 +56,18 @@ describeIf(
         }, 60000);
 
         it('should convert a known Substrate address to a known EVM address', () => {
-            const result = commandSync(
-                `node ${CLI_PATH} convert-address --address ${substrateAddress} --url ${ALICE_NODE_URL}`,
+            const result = execaSync(
+                'node',
+                parseCommandString(`${CLI_PATH} convert-address --address ${substrateAddress} --url ${ALICE_NODE_URL}`),
             );
 
             expect(result.stdout.toLowerCase()).toContain(expectedAssociatedEvmAddress.toLowerCase());
         }, 60000);
 
         it('should convert a known EVM address to a known Substrate address', () => {
-            const result = commandSync(
-                `node ${CLI_PATH} convert-address --address ${evmAddress} --url ${BOB_NODE_URL}`,
+            const result = execaSync(
+                'node',
+                parseCommandString(`${CLI_PATH} convert-address --address ${evmAddress} --url ${BOB_NODE_URL}`),
             );
 
             expect(result.stdout.toLowerCase()).toContain(expectedAssociatedSubtrateAddress.toLowerCase());

--- a/cli/src/test/integration-tests/validator/showAddress.test.ts
+++ b/cli/src/test/integration-tests/validator/showAddress.test.ts
@@ -1,4 +1,4 @@
-import { commandSync } from 'execa';
+import { execaSync, parseCommandString } from 'execa';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { CLI_PATH, randomTestAccount, ALICE_NODE_URL, BOB_NODE_URL } from '../helpers';
 import { describeIf } from '../../utils';
@@ -16,7 +16,7 @@ describeIf(
 
                 const caller = randomTestAccount();
 
-                const result = commandSync(`node ${CLI_PATH} show-address ${nodeUrl}`, {
+                const result = execaSync('node', parseCommandString(`${CLI_PATH} show-address ${nodeUrl}`), {
                     env: {
                         CC_SECRET: caller.secret,
                     },

--- a/cli/src/test/utils.ts
+++ b/cli/src/test/utils.ts
@@ -1,16 +1,8 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import execa = require('execa');
+import os from 'os';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import fs = require('fs');
+import path from 'path';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import os = require('os');
-
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import path = require('path');
-
-import { commandSync } from 'execa';
+import { execa, execaSync, parseCommandString } from 'execa';
 
 import type { EventRecord, Balance, DispatchError } from '../lib';
 import { ApiPromise, expectNoEventError, expectNoDispatchError, newApi } from '../lib';
@@ -110,11 +102,11 @@ function runNode(name: string, extraArgs: string) {
     // warning: do NOT await, runs in background
     void execa(
         '../target/release/creditcoin3-node',
-        `--chain dev --validator --pruning archive ${extraArgs}`.split(' '),
+        parseCommandString(`--chain dev --validator --pruning archive ${extraArgs}`),
         {
             detached: true,
-            stdout: fs.openSync(`${logPrefix}.stdout`, 'w'),
-            stderr: fs.openSync(`${logPrefix}.stderr`, 'w'),
+            stdout: { file: `${logPrefix}.stdout` },
+            stderr: { file: `${logPrefix}.stderr` },
         },
     );
 }
@@ -140,7 +132,8 @@ export async function startAliceAndBob() {
 export function killCreditcoinNodes() {
     console.log('INFO: killing all creditcoin3-node processes');
 
-    commandSync(`killall -9 creditcoin3-node`);
+    const [command, ...args] = parseCommandString('killall -9 creditcoin3-node');
+    execaSync(command, args);
 }
 
 export async function expectIsFinalizing() {

--- a/cli/src/test/utils.ts
+++ b/cli/src/test/utils.ts
@@ -105,6 +105,7 @@ function runNode(name: string, extraArgs: string) {
         parseCommandString(`--chain dev --validator --pruning archive ${extraArgs}`),
         {
             detached: true,
+            reject: false,
             stdout: { file: `${logPrefix}.stdout` },
             stderr: { file: `${logPrefix}.stderr` },
         },

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -17,7 +17,7 @@
         },
         "resolveJsonModule": true
     },
-    "exclude": ["node_modules", "**/__tests__/*", "dist"],
+    "exclude": ["node_modules", "**/__tests__/*", "src/test", "dist"],
 
     "ts-node": {
         "require": ["tsconfig-paths/register"],

--- a/cli/tsconfig.test.json
+++ b/cli/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "module": "esnext",
+        "moduleResolution": "bundler"
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Stacked on top of #1177 (the `execa 5.1.1 → 10.0.0` bump).

## Why
execa v6+ is **pure ESM** and removed `commandSync`. The CLI test suite runs under `ts-jest` in **CommonJS** mode, so with execa 10 the `check-format / cli` job dies at `tsc`:

```
error TS2305: Module '"execa"' has no exported member 'commandSync'.
error TS2349: This expression is not callable. (import execa = require('execa'))
```

…and even after fixing the types, jest would fail at **runtime** with `Cannot use import statement outside a module` because ts-jest emits `require()` for a pure-ESM package. So this needs a full jest ESM migration, not just an API swap.

## What changed
**execa API (v5 → v10), test-only:**
- `commandSync(\`node x\`)` → `execaSync('node', parseCommandString('x'))`
- `import execa = require('execa')` → `import { execa } from 'execa'`
- raw-fd stdio `{ stdout: fs.openSync(path) }` → v10 file-redirect `{ stdout: { file: path } }`
- `killall` template → explicit argv form

**Jest ESM migration:**
- All jest configs (`jest.config.json` + 5 `*-tests.config.ts`) → `ts-jest/presets/default-esm` with `useESM` + `transformIgnorePatterns` allowing execa's ESM dep tree
- New `tsconfig.test.json` (`module: esnext`, `moduleResolution: bundler`) so tests get `import.meta` / import attributes while the CLI build stays `commonjs`
- `NODE_OPTIONS=--experimental-vm-modules` added to all `test:*` scripts

**CommonJS-only patterns that break under ESM:**
- `import x = require('*.json')` (7 test files + `src/lib/attestor/precompile.ts`) → ESM JSON imports
- `import os/path/timeDelta = require(...)` → default/named ESM imports
- `__dirname` in `blockchain-tests/helpers.ts` → `import.meta.url` (renamed to avoid `no-underscore-dangle`)
- Excluded `src/test` from the CommonJS CLI build; pointed ESLint at `tsconfig.test.json` so type-aware linting still covers tests

## Verification
- `yarn build` ✓ (CLI stays CommonJS)
- `yarn lint` ✓
- `yarn check-format` ✓ (the originally failing job)
- Empirically confirmed under the new ESM jest config: execa 10 imports cleanly and `execaSync` spawns a real subprocess (no more `Cannot use import` / `exports is not defined`). Full integration runs still need a `creditcoin3-node` binary, which isn't available in my sandbox.

**CLI runtime behavior is unchanged** — execa is only used in tests.