### PR TITLE
ci: build creditcoin-fork from PR #15 in Runtime Upgrade

### DIFF
--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -192,16 +192,6 @@ jobs:
       # Build creditcoin-fork from PR #15 (branch feat_usc) instead of
       # downloading it from release artifacts. See
       # https://github.com/gluwa/creditcoin-fork/pull/15
-      - name: Checkout creditcoin-fork (PR #15 / feat_usc)
-        uses: actions/checkout@v7
-        with:
-          repository: gluwa/creditcoin-fork
-          ref: feat_usc
-          # Check out outside the creditcoin3 workspace tree, otherwise cargo
-          # treats creditcoin-fork as a member of the creditcoin3 workspace.
-          path: ../creditcoin-fork-src
-          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-
       - name: Configure rustc version
         run: |
           # Use the same rustc version as creditcoin3-node (this repo's
@@ -214,11 +204,26 @@ jobs:
         with:
           toolchain: ${{ env.RUSTC_VERSION }}
 
-      - name: Build creditcoin-fork
-        working-directory: ../creditcoin-fork-src
+      # Build creditcoin-fork from PR #15 (branch feat_usc) instead of
+      # downloading it from release artifacts. See
+      # https://github.com/gluwa/creditcoin-fork/pull/15
+      #
+      # Clone into RUNNER_TEMP (outside GITHUB_WORKSPACE) rather than using
+      # actions/checkout with a path: the fork must live outside the creditcoin3
+      # git checkout, otherwise cargo treats it as a member of the creditcoin3
+      # workspace and the build fails. actions/checkout also refuses paths
+      # outside GITHUB_WORKSPACE, so a plain git clone is used here.
+      - name: Build creditcoin-fork (PR #15 / feat_usc)
+        env:
+          FORK_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
         run: |
-          cargo build --release --locked --bin creditcoin-fork
-          cp target/release/creditcoin-fork "$GITHUB_WORKSPACE/creditcoin-fork"
+          FORK_DIR="$RUNNER_TEMP/creditcoin-fork-src"
+          git clone --depth 1 --branch feat_usc \
+            "https://x-access-token:${FORK_TOKEN}@github.com/gluwa/creditcoin-fork.git" \
+            "$FORK_DIR"
+          cargo build --release --locked --bin creditcoin-fork \
+            --manifest-path "$FORK_DIR/Cargo.toml"
+          cp "$FORK_DIR/target/release/creditcoin-fork" "$GITHUB_WORKSPACE/creditcoin-fork"
 
       - name: Start local creditcoin3-node for ${{ needs.setup.outputs.target_chain }}
         run: |

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -197,17 +197,28 @@ jobs:
         with:
           repository: gluwa/creditcoin-fork
           ref: feat_usc
-          path: creditcoin-fork-src
+          # Check out outside the creditcoin3 workspace tree, otherwise cargo
+          # treats creditcoin-fork as a member of the creditcoin3 workspace.
+          path: ../creditcoin-fork-src
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
+      - name: Configure rustc version
+        run: |
+          # Use the same rustc version as creditcoin3-node (this repo's
+          # rust-toolchain.toml), so the fork is built with a matching toolchain.
+          RUSTC_VERSION=$(grep channel rust-toolchain.toml | tail -n1 | tr -d ' ' | cut -f2 -d'"')
+          echo "RUSTC_VERSION=$RUSTC_VERSION" >> "$GITHUB_ENV"
+
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUSTC_VERSION }}
 
       - name: Build creditcoin-fork
-        working-directory: creditcoin-fork-src
+        working-directory: ../creditcoin-fork-src
         run: |
           cargo build --release --locked --bin creditcoin-fork
-          cp target/release/creditcoin-fork ../creditcoin-fork
+          cp target/release/creditcoin-fork "$GITHUB_WORKSPACE/creditcoin-fork"
 
       - name: Start local creditcoin3-node for ${{ needs.setup.outputs.target_chain }}
         run: |

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -189,13 +189,25 @@ jobs:
           file: ${{ needs.setup.outputs.artifact_name }}
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
-      - name: Download creditcoin-fork
-        uses: i3h/download-release-asset@v1
+      # Build creditcoin-fork from PR #15 (branch feat_usc) instead of
+      # downloading it from release artifacts. See
+      # https://github.com/gluwa/creditcoin-fork/pull/15
+      - name: Checkout creditcoin-fork (PR #15 / feat_usc)
+        uses: actions/checkout@v7
         with:
-          owner: gluwa
-          repo: creditcoin-fork
-          tag: latest
-          file: creditcoin-fork
+          repository: gluwa/creditcoin-fork
+          ref: feat_usc
+          path: creditcoin-fork-src
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build creditcoin-fork
+        working-directory: creditcoin-fork-src
+        run: |
+          cargo build --release --locked --bin creditcoin-fork
+          cp target/release/creditcoin-fork ../creditcoin-fork
 
       - name: Start local creditcoin3-node for ${{ needs.setup.outputs.target_chain }}
         run: |


### PR DESCRIPTION
Modifies the **Runtime Upgrade** workflow to build the `creditcoin-fork` binary from [creditcoin-fork PR #15](https://github.com/gluwa/creditcoin-fork/pull/15) (branch `feat_usc`) instead of downloading it from release artifacts (`tag: latest`).

### Change
In the `fork-creditcoin` job, the `Download creditcoin-fork` step (via `i3h/download-release-asset`) is replaced with:
- Checkout `gluwa/creditcoin-fork` at ref `feat_usc`
- Install stable Rust toolchain
- `cargo build --release --locked --bin creditcoin-fork` and copy the binary to the expected `./creditcoin-fork` path

The rest of the job (`chmod a+x ./creditcoin-fork`, `Create fork` step) is unchanged.

### Note
Per the [PR #15 discussion](https://github.com/gluwa/creditcoin-fork/pull/15#discussion_r2871898332), it is not yet confirmed the fork tool works cleanly against creditcoin3 — this workflow change is what lets us test that end-to-end.

Ref: https://github.com/gluwa/creditcoin-fork/pull/15