### PR TITLE
feat(cli): enforce per-transaction gas limit in prover-check

### DIFF
--- a/cli/src/scripts/prover-check.ts
+++ b/cli/src/scripts/prover-check.ts
@@ -233,6 +233,17 @@ async function main(
         const gasForVerification = BigInt(estimate);
         console.log(`    ... gasForVerification=${gasForVerification}`);
 
+        // Reject any single transaction whose individual gas cost crosses the
+        // per-transaction cap. A single tx must fit comfortably within a block
+        // on its own, so each estimate is checked against singleTxnGasLimit as
+        // soon as it becomes available.
+        const singleTxnGasLimit = 25_000_000n;
+        if (gasForVerification >= singleTxnGasLimit) {
+            throw new Error(
+                `gasForVerification ${gasForVerification} reaches or exceeds the single transaction gas limit (${singleTxnGasLimit}); failing run`,
+            );
+        }
+
         let gasForDecoding = 0n;
         if (contract !== undefined) {
             console.log('    ..... trying to decode proof');
@@ -242,6 +253,11 @@ async function main(
             gasForDecoding = decoded.gasUsed ?? 0n;
             console.log(`    ... decoded as type ${decoded.type}, gasForDecoding=${gasForDecoding}`);
         }
+        if (gasForDecoding >= singleTxnGasLimit) {
+            throw new Error(
+                `gasForDecoding ${gasForDecoding} reaches or exceeds the single transaction gas limit (${singleTxnGasLimit}); failing run`,
+            );
+        }
 
         // Add a 10% safety margin to the raw estimates and reject if the combined cost crosses 70%
         // of the on-chain block gas limit (read above). Using bigint math (11/10 and 7/10) keeps
@@ -249,6 +265,11 @@ async function main(
         // explicit decision; see commit log + linked Slack thread for context.
         const totalGas = ((gasForVerification + gasForDecoding) * 11n) / 10n;
         console.log(`    ... totalGas (with 10% margin)=${totalGas} (threshold=${totalGasThreshold})`);
+        if (totalGas >= singleTxnGasLimit) {
+            throw new Error(
+                `totalGas ${totalGas} reaches or exceeds the single transaction gas limit (${singleTxnGasLimit}); failing run`,
+            );
+        }
         if (totalGas >= totalGasThreshold) {
             throw new Error(
                 `totalGas ${totalGas} reaches or exceeds 70% of the ${blockGasLimit} block gas limit (${totalGasThreshold}); failing run`,


### PR DESCRIPTION
## What

Adds a per-transaction gas cap to `prover-check.ts`:

```ts
const singleTxnGasLimit = 25_000_000n;
```

The estimated gas is compared against `singleTxnGasLimit` in **3 places**, failing the run if it reaches or exceeds the cap:

1. After estimating `gasForVerification`
2. After estimating `gasForDecoding`
3. After computing `totalGas`

## Why

Ensures each individual transaction's gas cost fits comfortably within a block on its own, in addition to the existing 70%-of-block-gas-limit `totalGas` check.

Related: gluwa/cc-next-query-builder#140

## Testing

- `prettier --check src/scripts/prover-check.ts` ✅
- `eslint src/scripts/prover-check.ts` ✅
- `tsc --noEmit` — no errors in prover-check.ts (pre-existing execa test errors are unrelated)
