### PR TITLE
ci(write-ability-e2e): auth the private usc-contracts checkout

### DIFF
--- a/.github/workflows/write-ability-e2e.yml
+++ b/.github/workflows/write-ability-e2e.yml
@@ -119,6 +119,9 @@ jobs:
           repository: gluwa/usc-contracts
           ref: 7f5b64a501a354019d78714cfb293d934a1527c3 # sync/contracts-dev-694d6cc — bump deliberately
           path: usc-contracts
+          # usc-contracts is private; the default GITHUB_TOKEN is scoped to creditcoin3 only and
+          # gets "Repository not found". Use the org bot PAT (same one build-native uses cross-repo).
+          token: ${{ secrets.GLUWA_BOT_TOKEN }}
 
       - name: Rust cache (usc-message-relayer)
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
The migrated write-ability-e2e job checks out the private `gluwa/usc-contracts` repo for fee contract artifacts. The default `GITHUB_TOKEN` is scoped to creditcoin3 and gets `Repository not found` (seen in run 30250836569). Pass `secrets.GLUWA_BOT_TOKEN` (the org bot PAT already used for cross-repo access in build-native) as the checkout token.

Follow-up to the CI migration merged in #1189.