### PR TITLE
fix(write-ability): audit follow-ups (reorg-safe discovery, quoter, claim, CI)

### DIFF
--- a/.github/workflows/write-ability-e2e.yml
+++ b/.github/workflows/write-ability-e2e.yml
@@ -158,8 +158,11 @@ jobs:
 
       - name: Build usc-contracts artifacts (fee stack)
         working-directory: ./usc-contracts
+        # `npm install` (not `npm ci`): usc-contracts' committed lockfile can lag its package.json
+        # at the pinned SHA (e.g. a missing @openzeppelin/contracts entry), which `npm ci` rejects.
+        # We only need the compiled artifacts, so tolerate the drift and resolve on the fly.
         run: |
-          npm ci
+          npm install
           npx hardhat compile
           echo "USC_CONTRACTS_DIR=$GITHUB_WORKSPACE/usc-contracts" >> "$GITHUB_ENV"
 

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -382,15 +382,15 @@ pub async fn run(
     // doing block attestation. (Polling is simpler and more robust than event subscription; picking
     // up a later Outbox *re-registration* mid-run remains a finer-grained TODO in resolver.rs.)
     let mut resolve_attempts: u64 = 0;
-    // Discovery cursor: advances past blocks already scanned for `OutboxCreated` so each retry only
-    // scans new blocks instead of re-scanning the whole chain history every interval.
-    let mut outbox_scan_from: u64 = 0;
+    // Discovery cursor: advances past confirmed blocks already scanned for `OutboxCreated` so each
+    // retry only scans new blocks instead of re-scanning the whole chain history every interval.
+    let mut outbox_cursor = resolver::OutboxDiscoveryCursor::default();
     let resolved = loop {
         match resolver::resolve(
             &provider,
             &cfg,
             state.destination_chain_key,
-            &mut outbox_scan_from,
+            &mut outbox_cursor,
         )
         .await
         {

--- a/attestor/attestor/src/tasks/write_ability/resolver.rs
+++ b/attestor/attestor/src/tasks/write_ability/resolver.rs
@@ -51,6 +51,18 @@ pub struct ResolvedOutbox {
     pub creditcoin_chain_id: u64,
 }
 
+/// Caller-owned state for the incremental Outbox-discovery scan across activation retries. Tracks
+/// how far we have scanned and against which factory, so each retry only scans new *confirmed*
+/// blocks (no full-history log storm) while staying reorg-safe, and a factory re-registration
+/// restarts the scan from genesis.
+#[derive(Default)]
+pub struct OutboxDiscoveryCursor {
+    /// Next block to scan from.
+    from: u64,
+    /// Factory the cursor was advanced against; a change resets `from` to 0.
+    factory: Option<Address>,
+}
+
 /// Resolve the Outbox for the configured write-ability chain key using `provider` (a Creditcoin L1
 /// EVM connection). `destination_chain_key` is the effective `bytes32` key (see
 /// [`super::MessageVoteState::destination_chain_key`]) used both to ask the factory for its Outbox
@@ -63,15 +75,21 @@ pub async fn resolve<P: Provider>(
     provider: &P,
     cfg: &Config,
     destination_chain_key: B256,
-    scan_from: &mut u64,
+    cursor: &mut OutboxDiscoveryCursor,
 ) -> Result<Option<ResolvedOutbox>> {
     let chain_key = cfg.write_ability_chain_key;
 
-    // The Outbox address is resolved entirely on-chain from chain_key — never configured.
-    // `scan_from` is the caller-owned discovery cursor: it advances past already-scanned blocks so
+    // The Outbox address is resolved entirely on-chain from chain_key — never configured. `cursor`
+    // is the caller-owned discovery state: it advances past already-scanned *confirmed* blocks so
     // repeated resolve retries don't re-scan the whole chain history (see `resolve_outbox_address`).
-    let Some(address) =
-        resolve_outbox_address(provider, chain_key, destination_chain_key, scan_from).await?
+    let Some(address) = resolve_outbox_address(
+        provider,
+        chain_key,
+        destination_chain_key,
+        cfg.block_confirmation_depth,
+        cursor,
+    )
+    .await?
     else {
         return Ok(None);
     };
@@ -101,7 +119,8 @@ async fn resolve_outbox_address<P: Provider>(
     provider: &P,
     chain_key: ChainKey,
     _destination_chain_key: B256,
-    scan_from: &mut u64,
+    confirmation_depth: u64,
+    cursor: &mut OutboxDiscoveryCursor,
 ) -> Result<Option<Address>> {
     // 1. Outbox factory for this chain, from the chain-info precompile.
     let factory = IChainInfo::new(CHAIN_INFO_PRECOMPILE, provider)
@@ -118,6 +137,14 @@ async fn resolve_outbox_address<P: Provider>(
     }
     let factory = factory.factoryAddr;
 
+    // If the resolved factory changed (governance re-registered a different one for this chain key),
+    // the cursor reflects the *old* factory's scanned history and could skip the new factory's
+    // OutboxCreated. Restart from genesis for the new factory.
+    if cursor.factory != Some(factory) {
+        cursor.factory = Some(factory);
+        cursor.from = 0;
+    }
+
     // 2. Discover the factory's Outbox for this chain key. The synced CREATE2 factory has no
     //    `getOutbox` registry, so scan its `OutboxCreated` events (chainKey is an indexed uint32,
     //    topics[2]) and take the first match — a factory deploys one Outbox per chain key.
@@ -125,18 +152,24 @@ async fn resolve_outbox_address<P: Provider>(
     //    Scan in bounded windows (eth_getLogs defaults `fromBlock` to *latest*, and a single
     //    genesis→tip request exceeds common RPC block-range limits on any non-trivial chain — the
     //    same reason the listener chunks at `MAX_LOG_BLOCK_RANGE`). Resume from the caller-owned
-    //    `scan_from` cursor rather than genesis: the factory emits OutboxCreated exactly once, so
-    //    once a retry has scanned [..=tip] and found nothing, the next retry only needs the new
+    //    `cursor.from` rather than genesis: the factory emits OutboxCreated exactly once, so once a
+    //    retry has scanned the confirmed range and found nothing, the next retry only needs the new
     //    blocks — otherwise every 12s retry re-issues a full-history log storm across all attestors.
+    //
+    //    Bound the scan (and thus the cursor) at a CONFIRMED height — `tip - confirmation_depth`,
+    //    mirroring the listener, which never signs above that height. The cursor advances
+    //    permanently, so scanning past the *unconfirmed* tip would let a source reorg re-mine
+    //    OutboxCreated below the cursor and hide the Outbox for the whole process lifetime.
     let tip = provider
         .get_block_number()
         .await
         .context("read EVM tip for Outbox discovery scan")?;
+    let safe_tip = tip.saturating_sub(confirmation_depth);
     let sig = IOutboxFactory::OutboxCreated::SIGNATURE_HASH;
     let topic_chain_key = alloy::primitives::U256::from(chain_key);
-    let mut from = *scan_from;
-    while from <= tip {
-        let chunk_to = tip.min(from + MAX_LOG_BLOCK_RANGE - 1);
+    let mut from = cursor.from;
+    while from <= safe_tip {
+        let chunk_to = safe_tip.min(from + MAX_LOG_BLOCK_RANGE - 1);
         let filter = alloy::rpc::types::Filter::new()
             .address(factory)
             .event_signature(sig)
@@ -156,9 +189,11 @@ async fn resolve_outbox_address<P: Provider>(
         }
         from = chunk_to + 1;
     }
-    // Scanned everything up to `tip` with no match — advance the cursor so the next retry resumes
-    // from here instead of re-scanning history. (`from` is now `tip + 1`, saturating at u64::MAX.)
-    *scan_from = from;
+    // Scanned every confirmed block with no match — advance the cursor so the next retry resumes
+    // from here instead of re-scanning history. `from` is `safe_tip + 1` when the loop ran, or
+    // unchanged (`cursor.from`) if `safe_tip < cursor.from` (tip regressed / depth grew) — never
+    // regressing the cursor.
+    cursor.from = from;
     tracing::warn!(%factory, chain_key, "factory has emitted no OutboxCreated for chain_key yet");
     Ok(None)
 }

--- a/usc-messaging/scripts/claim-delivery.mts
+++ b/usc-messaging/scripts/claim-delivery.mts
@@ -28,22 +28,37 @@ destProvider.pollingInterval = 500;
 const funder = new ethers.Wallet(BALTHATHAR, srcProvider);
 const claimant = new ethers.Wallet(CLAIMANT_KEY, srcProvider);
 
-// ── 1. Find the destination delivery tx (Inbox.MessageDelivered for this messageId) ──────────────
+// ── 1. Find the destination delivery tx (Inbox.MessageDelivered), retrying until it's visible ─────
 const deliveredSig = ethers.id("MessageDelivered(bytes32,address,address)");
-const logs = await destProvider.getLogs({
-  address: dest.inbox,
-  topics: [deliveredSig, messageId],
-  fromBlock: 0,
-  toBlock: "latest",
-});
-if (logs.length === 0) throw new Error(`no MessageDelivered for ${messageId} on Inbox ${dest.inbox}`);
-const deliveryTx = logs[0].transactionHash;
+let deliveryTx: string | undefined;
+for (let i = 0; i < 40; i++) {
+  const logs = await destProvider.getLogs({ address: dest.inbox, topics: [deliveredSig, messageId], fromBlock: 0, toBlock: "latest" });
+  if (logs.length > 0) { deliveryTx = logs[0].transactionHash; break; }
+  if (i % 5 === 0) console.log(`  waiting for MessageDelivered on dest… [${i}]`);
+  await new Promise((s) => setTimeout(s, 3000));
+}
+if (!deliveryTx) throw new Error(`no MessageDelivered for ${messageId} on Inbox ${dest.inbox}`);
 console.log("  delivery tx (dest):", deliveryTx);
 
-// ── 2. Fetch the native USC proof for that tx (retry while the block is still being attested) ────
+// ── 2. Read the funded route from the source vault (gives the canonical destination chain key) ───
+const attest = new ethers.Contract(src.attest, ["function balanceOf(address) view returns (uint256)"], srcProvider);
+const fvAbi = [
+  "function getMessageInfo(bytes32) view returns ((address payer,uint32 destinationChain,uint256 gasLimit,uint256 relayFee,uint256 tip,uint256 tipExpiry,uint256 deliveryDeadline,bool relaySettled))",
+  "function claimDelivery(bytes32 messageId, bytes32 chainKey, uint64 blockHeight, (uint8 kind, bytes32 root, bytes data) inclusionProof, (bytes32 lowerEndpointDigest, bytes32[] roots) continuityProof)",
+  "event DeliveryClaimed(bytes32 indexed messageId, address indexed relayer, uint256 relayFee, uint256 tip)",
+];
+const fv = new ethers.Contract(src.relayerFeeVault, fvAbi, claimant);
+const infoBefore = await fv.getMessageInfo(messageId);
+if (infoBefore.relaySettled) throw new Error("relay already settled before claim — nothing to prove");
+// Derive chainKey from the funded route, not a hardcoded constant: claimDelivery requires
+// chainKey == bytes32(uint256(fd.destinationChain)).
+const chainKey = ethers.zeroPadValue(ethers.toBeHex(Number(infoBefore.destinationChain)), 32);
+console.log("  funded relayFee:", ethers.formatEther(infoBefore.relayFee), "tip:", ethers.formatEther(infoBefore.tip), "destChain:", Number(infoBefore.destinationChain));
+
+// ── 3. Fetch the native USC proof for the delivery tx (retry while the block is still attested) ──
 type ProofResp = {
   headerNumber: number;
-  txBytes: string;
+  txBytes: string | null;
   continuityProof: { lowerEndpointDigest: string; roots: string[] };
   merkleProof: { root: string; siblings: { hash: string; isLeft: boolean }[] };
 };
@@ -52,13 +67,15 @@ for (let i = 0; i < 60; i++) {
   const r = await fetch(`${PROOF_GEN}/api/v1/proof-by-tx/${DEST_CHAIN_KEY}/${deliveryTx}`);
   if (r.status === 422) { if (i % 5 === 0) console.log(`  proof not ready (422), waiting… [${i}]`); await new Promise((s) => setTimeout(s, 3000)); continue; }
   if (!r.ok) throw new Error(`proof-gen ${r.status}: ${await r.text()}`);
-  proof = (await r.json()) as ProofResp;
-  break;
+  const body = (await r.json()) as ProofResp;
+  // A continuity-only response (no txBytes) means the merkle inclusion isn't ready yet — keep waiting.
+  if (!body.txBytes) { if (i % 5 === 0) console.log(`  proof continuity-only (no txBytes), waiting… [${i}]`); await new Promise((s) => setTimeout(s, 3000)); continue; }
+  proof = body; break;
 }
 if (!proof || !proof.txBytes) throw new Error("proof-gen never returned a usable proof (no txBytes)");
 console.log("  proof ready: headerNumber", proof.headerNumber, "siblings", proof.merkleProof.siblings.length);
 
-// ── 3. Build the BlockProverTypes structs claimDelivery expects ──────────────────────────────────
+// ── 4. Build the BlockProverTypes structs claimDelivery expects ──────────────────────────────────
 // InclusionProof.data = abi.encode(bytes txBytes, MerkleProofEntry[] siblings), entry {bytes32 sibling, bool isLeft}.
 const data = ethers.AbiCoder.defaultAbiCoder().encode(
   ["bytes", "tuple(bytes32 sibling, bool isLeft)[]"],
@@ -66,21 +83,8 @@ const data = ethers.AbiCoder.defaultAbiCoder().encode(
 );
 const inclusionProof = { kind: 0, root: proof.merkleProof.root, data }; // ProofKind.BinaryMerkle = 0
 const continuityProof = { lowerEndpointDigest: proof.continuityProof.lowerEndpointDigest, roots: proof.continuityProof.roots };
-const chainKey = ethers.zeroPadValue(ethers.toBeHex(DEST_CHAIN_KEY), 32); // bytes32(uint256(destinationChain))
 
-// ── 4. Top up claimant gas, snapshot balances, claim ─────────────────────────────────────────────
-const attest = new ethers.Contract(src.attest, ["function balanceOf(address) view returns (uint256)"], srcProvider);
-const fvAbi = [
-  "function getMessageInfo(bytes32) view returns ((address payer,uint32 destinationChain,uint256 gasLimit,uint256 relayFee,uint256 tip,uint256 tipExpiry,uint256 deliveryDeadline,bool relaySettled))",
-  "function claimDelivery(bytes32 messageId, bytes32 chainKey, uint64 blockHeight, (uint8 kind, bytes32 root, bytes data) inclusionProof, (bytes32 lowerEndpointDigest, bytes32[] roots) continuityProof)",
-  "event DeliveryClaimed(bytes32 indexed messageId, address indexed relayer, uint256 relayFee, uint256 tip)",
-];
-const fv = new ethers.Contract(src.relayerFeeVault, fvAbi, claimant);
-
-const infoBefore = await fv.getMessageInfo(messageId);
-if (infoBefore.relaySettled) throw new Error("relay already settled before claim — nothing to prove");
-console.log("  funded relayFee:", ethers.formatEther(infoBefore.relayFee), "tip:", ethers.formatEther(infoBefore.tip), "relaySettled:", infoBefore.relaySettled);
-
+// ── 5. Top up claimant gas, snapshot balance, claim ──────────────────────────────────────────────
 await (await funder.sendTransaction({ to: claimant.address, value: ethers.parseEther("1") })).wait(); // gas
 const balBefore = await attest.balanceOf(claimant.address);
 
@@ -91,15 +95,18 @@ const balAfter = await attest.balanceOf(claimant.address);
 const infoAfter = await fv.getMessageInfo(messageId);
 const delta = balAfter - balBefore;
 
-// ── 5. Assert the payout ─────────────────────────────────────────────────────────────────────────
+// ── 6. Assert the payout against the FUNDED amounts, not just the event's own numbers ────────────
 console.log("  DeliveryClaimed:", claimed ? `relayFee=${ethers.formatEther(claimed.args.relayFee)} tip=${ethers.formatEther(claimed.args.tip)}` : "MISSING");
 console.log("  claimant ATTEST delta:", ethers.formatEther(delta), "relaySettled:", infoAfter.relaySettled);
 
 if (!claimed) throw new Error("FAIL: no DeliveryClaimed event");
 if (!infoAfter.relaySettled) throw new Error("FAIL: relaySettled did not flip to true");
-const expected = claimed.args.relayFee + claimed.args.tip;
-if (delta !== expected) throw new Error(`FAIL: ATTEST delta ${delta} != relayFee+tip ${expected}`);
-if (delta <= 0n) throw new Error("FAIL: claimant balance did not increase");
+// Compare to the funded amounts: checking only the event's own fields would mask an underpayment
+// (e.g. a lapsed tipExpiry pays the relayer tip=0 while the event self-consistently reports tip=0).
+if (claimed.args.relayFee !== infoBefore.relayFee) throw new Error(`FAIL: paid relayFee ${claimed.args.relayFee} != funded ${infoBefore.relayFee}`);
+if (claimed.args.tip !== infoBefore.tip) throw new Error(`FAIL: paid tip ${claimed.args.tip} != funded ${infoBefore.tip} (tipExpiry may have lapsed — relayer underpaid)`);
+const expected = infoBefore.relayFee + infoBefore.tip;
+if (delta !== expected) throw new Error(`FAIL: ATTEST delta ${delta} != funded relayFee+tip ${expected}`);
 
-console.log(`✅✅ CLAIM PASS — relayer paid ${ethers.formatEther(delta)} ATTEST, relaySettled=true`);
+console.log(`✅✅ CLAIM PASS — relayer paid ${ethers.formatEther(delta)} ATTEST (full funded relayFee+tip), relaySettled=true`);
 process.exit(0);

--- a/usc-messaging/src/quoter/config.ts
+++ b/usc-messaging/src/quoter/config.ts
@@ -50,6 +50,18 @@ function req(name: string): string {
   return v;
 }
 
+/** The RelayerContract the quote signature binds to (verifyingContract). Must be a real, non-zero
+ *  address — a quote signed against the zero address is unusable and reverts at publish time. */
+function reqRelayerContract(): string {
+  const v = process.env.QUOTER_RELAYER_CONTRACT?.trim();
+  if (!v || /^0x0{40}$/i.test(v))
+    throw new Error(
+      "QUOTER_RELAYER_CONTRACT must be set to the deployed RelayerContract address " +
+        "(the quote's verifyingContract); refusing to sign quotes bound to the zero address",
+    );
+  return v;
+}
+
 // Static per-chain defaults. Override the whole set with QUOTER_CHAINS (JSON array of ChainConfig,
 // coreFee expressed in whole ATTEST as `coreFeeAttest`).
 const DEFAULT_CHAINS: ChainConfig[] = [
@@ -100,11 +112,11 @@ export function loadConfig(): QuoterConfig {
     ),
     priceBufferBps: BigInt(process.env.QUOTER_PRICE_BUFFER_BPS ?? "1000"),
     sourceChainId: BigInt(process.env.QUOTER_SOURCE_CHAIN_ID || "42"),
-    // `||` (not `??`): an empty string from a copied .env.example must fall back to the zero
-    // address, else quote signing calls ethers.getAddress("") and throws a 500 on /quote.
-    relayerContract:
-      process.env.QUOTER_RELAYER_CONTRACT ||
-      "0x0000000000000000000000000000000000000000",
+    // Fail loud at boot rather than signing quotes bound to the zero address: an empty
+    // QUOTER_RELAYER_CONTRACT (e.g. a copied .env.example) would otherwise mint valid-looking
+    // quotes whose verifyingContract can never match the real RelayerContract, so every
+    // publishAndCollectRelayerFee reverts UnauthorizedQuoter — a confusing, late failure.
+    relayerContract: reqRelayerContract(),
     chains: loadChains(),
   };
 }


### PR DESCRIPTION
Proactive correctness-audit fixes across the merged write-ability work (#1189/#1194).

- **Reorg-safe Outbox discovery (HIGH):** the `OutboxCreated` scan cursor advanced past the *unconfirmed* tip, so a source-L1 reorg re-mining the event at a new height would hide the Outbox for the whole process lifetime. Bound the scan + cursor at `tip - block_confirmation_depth` (mirrors the listener). Also reset the cursor when the resolved factory address changes.
- **Quoter fail-loud (LOW):** throw at boot when `QUOTER_RELAYER_CONTRACT` is empty/zero instead of signing quotes bound to `0x0` that revert `UnauthorizedQuoter` late at publish.
- **claim-delivery assertion (MED, test):** assert the payout against the *funded* relayFee/tip (the self-referential check masked a lapsed-tipExpiry underpayment); derive chainKey from the funded route; retry the delivery lookup + continuity-only proofs.
- **CI:** `npm install` (not `npm ci`) for the usc-contracts artifact build — its lockfile lags package.json at the pinned SHA (the current e2e-run failure).

Verified: attestor build/clippy/fmt clean, 47 write_ability tests pass; quoter + scripts typecheck.