### PR TITLE
Uncomment call to polkadot-js-metadata-cmp for Mainnet

### DIFF
--- a/.github/check-extrinsics.sh
+++ b/.github/check-extrinsics.sh
@@ -71,7 +71,7 @@ for RUNTIME in "${runtimes[@]}"; do
 
   # compare to mainnet and testnet explicitly b/c latest release could be any of them
   # for now this comparison is only used to provide more info in CI
-  # polkadot-js-metadata-cmp wss://rpc.cc3-mainnet.creditcoin.network/ws "$HEAD_WS" > metadata-cmp-with-mainnet.txt
+  polkadot-js-metadata-cmp wss://rpc.cc3-mainnet.creditcoin.network/ws "$HEAD_WS" > metadata-cmp-with-mainnet.txt
   polkadot-js-metadata-cmp wss://rpc.cc3-testnet.creditcoin.network/ws "$HEAD_WS" > metadata-cmp-with-testnet.txt
 
   if [ -n "$changed_extrinsics" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,8 +183,7 @@ jobs:
           path: |
             head-node.log
             release-node.log
-            # disabled until we have mainnet
-            # metadata-cmp-with-mainnet.txt
+            metadata-cmp-with-mainnet.txt
             metadata-cmp-with-testnet.txt
 
   rm-gh-runner-build-creditcoin-node-for-testing:


### PR DESCRIPTION
as far as I can tell this was disabled during the work on creditcoin3-next/USC chains and wasn't reenabled appropriately.

# Description of proposed changes

<describe what this PR is about and why we want it>

---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
