### PR TITLE
ci(write-ability-e2e): give the relayer its own p2p port

### DIFF
--- a/.github/workflows/write-ability-e2e.yml
+++ b/.github/workflows/write-ability-e2e.yml
@@ -277,6 +277,7 @@ jobs:
             --inbox-address "$INBOX_ADDR" \
             --signer-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
             --attestor-set "$ATTESTOR_SET" \
+            --p2p-port 9300 \
             --relayer-fee-vault-address "$RELAYER_FEE_VAULT_ADDR" \
             --ack-proof-gen-url http://127.0.0.1:3100 \
             --ack-validator-address "$ACK_VALIDATOR_ADDR" \


### PR DESCRIPTION
The relayer's libp2p listener defaulted to **tcp/9100**, which `launch-attestors.sh` already uses for the first attestor's API port (9100–9102 for a 3-attestor set). The swarm could never bind:

```
swarm listen failed; retrying after backoff listen=/ip4/0.0.0.0/tcp/9100 attempt=1..9
```

The relayer otherwise started fine — `All workers online`, delivery worker up with `fee_vault=Some(0x3c20…)` — but the vote subscription never came up, so the step's `libp2p subscriber online` gate timed out and the job failed **after** the usc-contracts build, fee-stack deploy and attestor-zombienet stages had all passed. See [run 30275181718](https://github.com/gluwa/creditcoin3/actions/runs/30275181718).

Fix: pass `--p2p-port 9300`, matching the local harness this workflow was ported from — the flag was simply missed in the port.

## Progress on the e2e

Each recent fix has moved the failure later, which is the point:

| Step | Before | Now |
|---|---|---|
| Build usc-contracts artifacts | ❌ lockfile drift | ✅ (fixed in #1195) |
| Deploy fee stack + register factory | not reached | ✅ |
| Launch attestor zombienet | not reached | ✅ |
| Start relayer | not reached | ❌ → **this PR** |
| Publish / delivery / ack / claim asserts | not reached | next to exercise |

## Side observations (not fixed here)

* The bind failure is a retrying `WARN`, not fatal, so the process stayed up but permanently useless. A bind failure on the vote path should arguably fail fast or surface in `/health`.
* The log printed `err=` **empty**, losing the underlying `AddrInUse` — a one-line logging fix that would have made this diagnosable immediately.

Both are relayer-side (separate repo); happy to file them there if useful.