### PR TITLE
fix: install Node.js from official upstream tarball instead of NodeSource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,26 @@
 # hadolint global ignore=DL3008,DL3009,DL3013,DL3016,SC3046,DL4006,SC1091,SC2086
 FROM ubuntu:26.04@sha256:b7f48194d4d8b763a478a621cdc81c27be222ba2206ca3ca6bc42b49685f3d9e AS runtime-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG TARGETARCH
+ARG NODE_VERSION=22.23.1
+# NodeSource's apt key fetch (deb.nodesource.com) intermittently 403s from our
+# self-hosted Linode CI runners' shared IP pool. Install the official upstream
+# release directly instead, checksum-verified against nodejs.org's own SHASUMS256.txt.
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends ca-certificates curl && \
+    apt-get install -y --no-install-recommends ca-certificates curl xz-utils libdw1t64 libpq5 && \
     update-ca-certificates && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y libdw1t64 libpq5 nodejs --no-install-recommends && \
+    case "${TARGETARCH}" in \
+      amd64) NODE_ARCH=x64;    NODE_SHA256=9749e988f437343b7fa832c69ded82a312e41a03116d766797ac14f6f9eee578 ;; \
+      arm64) NODE_ARCH=arm64;  NODE_SHA256=0294e8b915ab75f92c7513d2fcb830ae06e10684e6c603e99a87dbf8835389c1 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz && \
+    echo "${NODE_SHA256}  /tmp/node.tar.xz" | sha256sum -c - && \
+    tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 --no-same-owner && \
+    rm /tmp/node.tar.xz && \
+    node --version && \
+    npm --version && \
     npm install -g yarn node-gyp
 # WARNING: devel dependencies should go into the devel-base image below
 


### PR DESCRIPTION
## Summary
- `docker.yml`'s Docker build job was failing on our self-hosted Linode CI runners (`nl-ams`, ephemeral) with `npm: not found`
- Root cause: `deb.nodesource.com`'s GPG signing-key fetch intermittently returns HTTP 403 from that runner pool's IP range (confirmed: identical request succeeds cleanly from an unrelated network; same Ubuntu 26.04 image succeeded minutes earlier from the same CI infra, ruling out an OS-incompatibility). The NodeSource setup script logs the failure but exits 0, so `apt-get install nodejs` silently falls back to Ubuntu's own `universe`-component `nodejs` package, which doesn't bundle `npm` — hence the error downstream.
- Considered switching to Ubuntu's native `nodejs`/`npm` packages instead, but ruled it out: both are in `universe` (best-effort security support, not Canonical's main-archive guarantee), `npm` is stuck at 9.2.0 (~2022, a full major behind), and the version strings are noisier for Docker Scout's CVE matching.
- Fix instead installs the official Node.js release tarball directly from nodejs.org, checksum-verified against their own published `SHASUMS256.txt`, arch-aware via `TARGETARCH` (amd64/arm64).

## Verification
- Verified locally (native arm64, no emulation): `node --version`, `npm --version`, `yarn install` all clean
- Hadolint: clean
- `docker scout sbom`: cleanly detects `node@22.23.1` via binary classification, standard purl (`pkg:github/nodejs/node@22.23.1`), no distro-suffix version string
- Manually triggered the real `Docker` workflow via `workflow_dispatch` on this branch against the actual Linode runner — passed the point where the original run failed (which failed in ~1 min) and proceeded well into the Rust build (25+ min) before being cancelled once the fix was confirmed working
- Confirmed the other 4 Dockerfiles in the repo (`cc3-indexer/Dockerfile`, `cc3-indexer/postgres/Dockerfile`, `scripts/stress-test/Dockerfile`, `scripts/usc-audit-automation/Dockerfile`) don't use NodeSource — only the root `Dockerfile` was affected

## Test plan
- [ ] Full Docker CI run (triggered by this PR) completes successfully on the Linode runner