### PR TITLE
fix: install Node.js from official upstream tarball instead of NodeSource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,26 @@
 # hadolint global ignore=DL3008,DL3009,DL3013,DL3016,SC3046,DL4006,SC1091,SC2086
 FROM ubuntu:26.04@sha256:b7f48194d4d8b763a478a621cdc81c27be222ba2206ca3ca6bc42b49685f3d9e AS runtime-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG TARGETARCH
+ARG NODE_VERSION=22.23.1
+# NodeSource's apt key fetch (deb.nodesource.com) intermittently 403s from our
+# self-hosted Linode CI runners' shared IP pool. Install the official upstream
+# release directly instead, checksum-verified against nodejs.org's own SHASUMS256.txt.
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends ca-certificates curl && \
+    apt-get install -y --no-install-recommends ca-certificates curl xz-utils libdw1t64 libpq5 && \
     update-ca-certificates && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y libdw1t64 libpq5 nodejs --no-install-recommends && \
+    case "${TARGETARCH}" in \
+      amd64) NODE_ARCH=x64;    NODE_SHA256=9749e988f437343b7fa832c69ded82a312e41a03116d766797ac14f6f9eee578 ;; \
+      arm64) NODE_ARCH=arm64;  NODE_SHA256=0294e8b915ab75f92c7513d2fcb830ae06e10684e6c603e99a87dbf8835389c1 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz && \
+    echo "${NODE_SHA256}  /tmp/node.tar.xz" | sha256sum -c - && \
+    tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 --no-same-owner && \
+    rm /tmp/node.tar.xz && \
+    node --version && \
+    npm --version && \
     npm install -g yarn node-gyp
 # WARNING: devel dependencies should go into the devel-base image below
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:26.04@sha256:b7f48194d4d8b763a478a621cdc81c27be222ba2206ca3ca6bc42b49685f3d9e AS runtime-base
 ENV DEBIAN_FRONTEND=noninteractive
 ARG TARGETARCH
-ARG NODE_VERSION=22.23.1
+ARG NODE_VERSION=20.20.2
 # NodeSource's apt key fetch (deb.nodesource.com) intermittently 403s from our
 # self-hosted Linode CI runners' shared IP pool. Install the official upstream
 # release directly instead, checksum-verified against nodejs.org's own SHASUMS256.txt.
@@ -11,8 +11,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl xz-utils libdw1t64 libpq5 && \
     update-ca-certificates && \
     case "${TARGETARCH}" in \
-      amd64) NODE_ARCH=x64;    NODE_SHA256=9749e988f437343b7fa832c69ded82a312e41a03116d766797ac14f6f9eee578 ;; \
-      arm64) NODE_ARCH=arm64;  NODE_SHA256=0294e8b915ab75f92c7513d2fcb830ae06e10684e6c603e99a87dbf8835389c1 ;; \
+      amd64) NODE_ARCH=x64;    NODE_SHA256=df770b2a6f130ed8627c9782c988fda9669fa23898329a61a871e32f965e007d ;; \
+      arm64) NODE_ARCH=arm64;  NODE_SHA256=73093db209e4e9e09dd7d15a47aeaab1b74833830df03efa5f942a1122c5fa71 ;; \
       *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac && \
     curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz && \


### PR DESCRIPTION
Re-opened: new-usc-testnet was force-pushed/reset back to the commit this branch forked from (5f71fe2a) shortly after PR #1205 merged, wiping that merge out entirely. Same fix, same branch, re-submitting against the current tip.

## Summary
- Docker build was failing on our self-hosted Linode CI runners with `npm: not found`, caused by `deb.nodesource.com`'s GPG key fetch intermittently 403ing from that runner pool's shared IP range (confirmed not an Ubuntu 26.04 incompatibility — same image succeeded minutes earlier from the same infra, and the identical request succeeds from an unrelated network)
- Installs the official Node.js release tarball directly from nodejs.org instead, checksum-verified against their SHASUMS256.txt, arch-aware via TARGETARCH
- Pinned to 20.20.2 (the final release of the 20.x/Iron line) to match the major version already targeted (`setup_20.x`) rather than silently bumping to 22.x — kept minimal/QA-consistent with what the project already runs

## Verification
- Verified locally (native, no emulation): node/npm/yarn all clean, hadolint clean
- `docker scout sbom`: cleanly detects node via binary classification, canonical version string
- Manually triggered the real Docker workflow via workflow_dispatch on this branch against the actual Linode runner — passed the point where the original failed (~1 min in) and proceeded well into the Rust build before being cancelled once confirmed working
- Confirmed the other 4 Dockerfiles in the repo don't use NodeSource — only the root Dockerfile was affected