### PR TITLE
precompiles: make metadata JSON chain output (devnet/testnet/mainnet) flag-driven instead of hand-edited

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -118,12 +118,22 @@ jobs:
       - name: Check metadata JSON files are up to date
         working-directory: ./precompiles/metadata
         run: |
-          ./generate-metadata-json.sh
+          # Mainnet metadata is only regenerated/verified for PRs targeting main: that's the
+          # only time it's "right" to refresh it, since devnet/testnet move independently of
+          # mainnet the rest of the time.
+          generate_args=(--devnet --testnet)
+          files_to_check=(precompiles-creditcoin3-devnet.json precompiles-creditcoin3-testnet.json)
+          if [ "${{ github.base_ref }}" == "main" ]; then
+            generate_args+=(--mainnet)
+            files_to_check+=(precompiles-creditcoin3-mainnet.json)
+          fi
+
+          ./generate-metadata-json.sh "${generate_args[@]}"
           cd ../..
           # Check if metadata JSON files were modified
-          if [ -n "$(git status --short --untracked-files=no precompiles/metadata/precompiles-creditcoin3-devnet.json precompiles/metadata/precompiles-creditcoin3-testnet.json)" ]; then
-            echo "ERROR: Metadata JSON files are out of date. Please run './generate-metadata-json.sh' and commit the changes."
-            git diff precompiles/metadata/precompiles-creditcoin3-devnet.json precompiles/metadata/precompiles-creditcoin3-testnet.json
+          if [ -n "$(git status --short --untracked-files=no "${files_to_check[@]/#/precompiles/metadata/}")" ]; then
+            echo "ERROR: Metadata JSON files are out of date. Please run './generate-metadata-json.sh ${generate_args[*]}' and commit the changes."
+            git diff "${files_to_check[@]/#/precompiles/metadata/}"
             exit 1
           fi
 

--- a/precompiles/metadata/README.md
+++ b/precompiles/metadata/README.md
@@ -19,16 +19,41 @@ This generates compact JSON array files in the `abi/` directory for each Solidit
 ./generate-metadata-json.sh
 ```
 
+By default this regenerates `precompiles-creditcoin3-devnet.json` and `precompiles-creditcoin3-testnet.json` only. `precompiles-creditcoin3-mainnet.json` is opt-in via `--mainnet` (see [Chain Flags](#chain-flags) below) since it should only be refreshed when a change is actually being promoted towards `main`.
+
 This automatically:
 - Extracts precompile information from `runtime/src/precompiles.rs` (addresses and precompile types)
 - Maps precompile types to ABI filenames and display names
 - Reads all Solidity source files from `sol/`
 - Reads all ABI files from `abi/`
-- Generates/updates `precompiles-creditcoin3-devnet.json` and `precompiles-creditcoin3-testnet.json`
+- Generates/updates the requested `precompiles-creditcoin3-*.json` file(s)
 - Formats sources as JSON strings and ABIs as compact JSON strings
 - Ensures proper ordering and formatting
 
 **Note**: The script extracts precompile addresses directly from the runtime configuration, ensuring consistency and avoiding manual mapping errors. If you add a new precompile to `runtime/src/precompiles.rs`, make sure to add its mapping in the `get_precompile_info()` function in the script.
+
+#### Chain Flags
+
+The script accepts flags to control which metadata JSON file(s) get (re)generated, instead of that being something to hand-edit in the script itself:
+
+| Flag           | Effect                                                | Default |
+|----------------|--------------------------------------------------------|---------|
+| `--devnet`     | Generate `precompiles-creditcoin3-devnet.json`          | on      |
+| `--no-devnet`  | Skip `precompiles-creditcoin3-devnet.json`              |         |
+| `--testnet`    | Generate `precompiles-creditcoin3-testnet.json`         | on      |
+| `--no-testnet` | Skip `precompiles-creditcoin3-testnet.json`             |         |
+| `--mainnet`    | Generate `precompiles-creditcoin3-mainnet.json`         | off     |
+| `--no-mainnet` | Skip `precompiles-creditcoin3-mainnet.json`             |         |
+| `--all`        | Shorthand for `--devnet --testnet --mainnet`            |         |
+
+Examples:
+
+```sh
+./generate-metadata-json.sh                 # devnet + testnet (default)
+./generate-metadata-json.sh --mainnet       # devnet + testnet + mainnet
+./generate-metadata-json.sh --all           # same as above
+./generate-metadata-json.sh --no-devnet --mainnet  # testnet + mainnet only
+```
 
 ### 3. Verify the Changes
 
@@ -39,6 +64,8 @@ cd ../..
 git status precompiles/metadata/precompiles-creditcoin3-devnet.json precompiles/metadata/precompiles-creditcoin3-testnet.json
 git diff precompiles/metadata/precompiles-creditcoin3-devnet.json precompiles/metadata/precompiles-creditcoin3-testnet.json
 ```
+
+(add `precompiles-creditcoin3-mainnet.json` to both commands above if you regenerated it with `--mainnet`.)
 
 If there are no changes, the files are up to date. If there are changes, commit them.
 
@@ -57,10 +84,12 @@ If you need to manually update the metadata JSON files:
 
 ## CI Checks
 
-The CI pipeline automatically:
+The CI pipeline (`.github/workflows/sanity.yml`) automatically:
 - Generates ABI files from Solidity sources
-- Generates metadata JSON files using `generate-metadata-json.sh`
-- Checks for uncommitted changes using `git status` and `git diff`
+- Regenerates `devnet`/`testnet` metadata JSON with `generate-metadata-json.sh --devnet --testnet`, and additionally regenerates `mainnet` metadata JSON with `--mainnet` when the PR targets `main` (`github.base_ref == 'main'`)
+- Checks for uncommitted changes using `git status` and `git diff` on whichever file(s) were just regenerated
 - Fails if the metadata JSON files are out of date (prompting you to commit the changes)
+
+Mainnet metadata is intentionally excluded from this check on PRs targeting `usc-dev`/`usc-testnet`, since it's expected to lag behind until a change is actually promoted to `main` — the same `github.base_ref` signal already used elsewhere in this workflow (e.g. the `Prepare ENV for Devnet/Testnet/Mainnet` steps) drives this instead of a hardcoded/hand-edited output list in the script.
 
 This ensures that metadata JSON files are always kept in sync with the source code. The check uses `git diff` directly on the generated files, avoiding the need for temporary files or complex normalization.

--- a/precompiles/metadata/generate-metadata-json.sh
+++ b/precompiles/metadata/generate-metadata-json.sh
@@ -2,18 +2,75 @@
 
 set -euo pipefail
 
-# Script to generate precompiles metadata JSON files for devnet and testnet
-# Usage: ./generate-metadata-json.sh
+# Script to generate precompiles metadata JSON files for devnet, testnet and (optionally) mainnet.
+#
+# Usage: ./generate-metadata-json.sh [--devnet|--no-devnet] [--testnet|--no-testnet] [--mainnet|--no-mainnet] [--all]
+#   Defaults: devnet=on, testnet=on, mainnet=off
+#   --all is shorthand for --devnet --testnet --mainnet
+#
+# Mainnet defaults to off because its metadata should only be refreshed once a change is actually
+# being promoted towards main (see the CI wiring in .github/workflows/sanity.yml, which passes
+# --mainnet only when github.base_ref == 'main'). Pass --mainnet explicitly to opt in locally.
+#
 # This script extracts precompile information from runtime/src/precompiles.rs
 # to ensure consistency and avoid manual mapping errors.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+generate_devnet=true
+generate_testnet=true
+generate_mainnet=false
+
+print_usage() {
+    cat <<'EOF'
+Usage: ./generate-metadata-json.sh [options]
+
+Options:
+  --devnet          Generate precompiles-creditcoin3-devnet.json    (default: on)
+  --no-devnet       Skip precompiles-creditcoin3-devnet.json
+  --testnet         Generate precompiles-creditcoin3-testnet.json   (default: on)
+  --no-testnet      Skip precompiles-creditcoin3-testnet.json
+  --mainnet         Generate precompiles-creditcoin3-mainnet.json   (default: off)
+  --no-mainnet      Skip precompiles-creditcoin3-mainnet.json
+  --all             Shorthand for --devnet --testnet --mainnet
+  -h, --help        Show this help message
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --devnet) generate_devnet=true ;;
+        --no-devnet) generate_devnet=false ;;
+        --testnet) generate_testnet=true ;;
+        --no-testnet) generate_testnet=false ;;
+        --mainnet) generate_mainnet=true ;;
+        --no-mainnet) generate_mainnet=false ;;
+        --all)
+            generate_devnet=true
+            generate_testnet=true
+            generate_mainnet=true
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option '$1'" >&2
+            print_usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [ "$generate_devnet" = false ] && [ "$generate_testnet" = false ] && [ "$generate_mainnet" = false ]; then
+    echo "Error: at least one of --devnet, --testnet or --mainnet must be enabled" >&2
+    exit 1
+fi
+
 sol_directory="sol"
 abi_directory="abi"
-output_devnet="precompiles-creditcoin3-devnet.json"
-output_testnet="precompiles-creditcoin3-testnet.json"
 runtime_precompiles_file="../../runtime/src/precompiles.rs"
 
 # Function to convert decimal to hex address (H160 format)
@@ -236,8 +293,22 @@ for i in "${!entries[@]}"; do
 done
 json_array+="]"
 
-# Format and write to output files
-echo "$json_array" | jq '.' > "$output_devnet"
-echo "$json_array" | jq '.' > "$output_testnet"
+# Format and write to output files (only the ones that were requested)
+generated_files=()
 
-echo "Generated $output_devnet and $output_testnet successfully"
+if [ "$generate_devnet" = true ]; then
+    echo "$json_array" | jq '.' > "precompiles-creditcoin3-devnet.json"
+    generated_files+=("precompiles-creditcoin3-devnet.json")
+fi
+
+if [ "$generate_testnet" = true ]; then
+    echo "$json_array" | jq '.' > "precompiles-creditcoin3-testnet.json"
+    generated_files+=("precompiles-creditcoin3-testnet.json")
+fi
+
+if [ "$generate_mainnet" = true ]; then
+    echo "$json_array" | jq '.' > "precompiles-creditcoin3-mainnet.json"
+    generated_files+=("precompiles-creditcoin3-mainnet.json")
+fi
+
+printf 'Generated %s successfully\n' "$(IFS=', '; echo "${generated_files[*]}")"


### PR DESCRIPTION
## Problem

`precompiles/metadata/generate-metadata-json.sh` hardcodes which `precompiles-creditcoin3-*.json` files it writes. Across branches/merges this has been hand-edited back and forth instead of being driven by anything dynamic:

- The `output_mainnet` block (3 lines: variable, write, log message) has been added and removed **at least 3 separate times** purely as a side effect of merges between branches (e.g. `94b95e98` adds it, `61d035eb` still has it, `2704d4f9`/`f063470e` remove it again).
- Right now `main`/`usc-testnet` only ever write `devnet`+`testnet`, while `usc-dev` writes all three - i.e. the *same script* behaves differently depending on which branch you're on, with no flag or parameter driving that, just drift.
- This already caused **real, silent staleness**: on `main`, `precompiles-creditcoin3-mainnet.json`'s last content update is `61d035eb`, while `testnet`'s is a later commit (`5f71fe2a`) - nothing since has kept it in sync, because the script no longer writes it and CI's "metadata is up to date" check in `sanity.yml` only diffs `devnet`/`testnet`. Meanwhile `check-solidity-source-vs-metadata.sh` still trusts `precompiles-creditcoin3-mainnet.json` as ground truth whenever a PR targets `main` (`TARGET_CHAIN=mainnet`), with no automated regeneration keeping it honest in between.

## Fix

- `generate-metadata-json.sh` now accepts `--devnet/--no-devnet`, `--testnet/--no-testnet`, `--mainnet/--no-mainnet`, and `--all`, defaulting to **devnet=on, testnet=on, mainnet=off**. No more editing the script body to change which files get written.
- `sanity.yml`'s "Check metadata JSON files are up to date" step now passes `--mainnet` (and checks the mainnet file) **only when `github.base_ref == 'main'`** - reusing the exact same signal that already drives the `Prepare ENV for Devnet/Testnet/Mainnet` steps a few lines down in that same job, instead of introducing yet another bespoke branch check.
- Updated `precompiles/metadata/README.md` to document the flags and the new CI behavior.

## Why mainnet defaults to off

Devnet/testnet metadata should stay in sync on every PR regardless of target branch (cheap, and both already share byte-identical content since the script writes the same `$json_array` to both). Mainnet metadata should only be refreshed once a change is actually being promoted towards `main` - generating/checking it on every `usc-dev`/`usc-testnet` PR would either force premature mainnet-metadata churn or (as happened here) get silently disabled instead.

## Verification

- `bash -n` syntax-checked the updated script.
- Flag-parsing logic (defaults, `--mainnet`, `--all`, `--no-devnet --mainnet`, all-off error, unknown-flag error) unit-tested in isolation via Git Bash - all behave as intended.
- Could not run the full script end-to-end in this environment (`jq`/`solc` aren't installed here), so the ABI/JSON-generation logic itself is unchanged from the current script and wasn't otherwise touched.

## Open questions for reviewer

- Is "only refresh mainnet metadata on PRs targeting `main`" actually the right trigger, or should this instead be tied to cutting an actual mainnet release/tag? Right now `github.base_ref == 'main'` matches the existing pattern used for `TARGET_CHAIN` elsewhere in this same job, but happy to change it if there's a better signal.
- Should `precompiles-creditcoin3-mainnet.json` be regenerated fresh in this PR to fix the current drift, or handled as a separate follow-up once this mechanism is agreed on?
