### PR TITLE
cli: pin polkadot.js low-level packages to a single version to fix duplicate-@polkadot/util warning

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -68,5 +68,13 @@
         "js-guid": "^1.0.0",
         "prompts": "^2.4.2",
         "time-delta": "^1.0.0"
+    },
+    "resolutions": {
+        "@polkadot/util": "13.5.9",
+        "@polkadot/networks": "13.5.9",
+        "@polkadot/x-bigint": "13.5.9",
+        "@polkadot/x-global": "13.5.9",
+        "@polkadot/x-textdecoder": "13.5.9",
+        "@polkadot/x-textencoder": "13.5.9"
     }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -73,8 +73,10 @@
         "@polkadot/util": "13.5.9",
         "@polkadot/networks": "13.5.9",
         "@polkadot/x-bigint": "13.5.9",
+        "@polkadot/x-fetch": "13.5.9",
         "@polkadot/x-global": "13.5.9",
         "@polkadot/x-textdecoder": "13.5.9",
-        "@polkadot/x-textencoder": "13.5.9"
+        "@polkadot/x-textencoder": "13.5.9",
+        "@polkadot/x-ws": "13.5.9"
     }
 }

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -1441,16 +1441,16 @@
     "@polkadot/x-global" "13.5.9"
     tslib "^2.8.0"
 
-"@polkadot/x-fetch@^13.5.8":
-  version "13.5.8"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-13.5.8.tgz#aeaccbcb8b3b4dfdbfc2f78d028d71e7da136f89"
-  integrity sha512-htNuY8zFw5vzNS2mFm9P22oBJg7Az8Xbg3fMmR/A6ZDhAfxfM6IbX9pPHkNJY2Wng3tysrY5VMOUMb1IIrSf3w==
+"@polkadot/x-fetch@13.5.9", "@polkadot/x-fetch@^13.5.8":
+  version "13.5.9"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-13.5.9.tgz#396a5a884d13d26a04c61b6e43240ca69fd72190"
+  integrity sha512-urwXQZtT4yYROiRdJS6zHu18J/jCoAGpbgPIAjwdqjT11t9XIq4SjuPMxD19xBRhbYe9ocWV8i1KHuoMbZgKbA==
   dependencies:
-    "@polkadot/x-global" "13.5.8"
+    "@polkadot/x-global" "13.5.9"
     node-fetch "^3.3.2"
     tslib "^2.8.0"
 
-"@polkadot/x-global@13.5.8", "@polkadot/x-global@13.5.9", "@polkadot/x-global@^13.5.8":
+"@polkadot/x-global@13.5.9", "@polkadot/x-global@^13.5.8":
   version "13.5.9"
   resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-13.5.9.tgz#22d680f036a879a5aef15963f96d71dd115927a3"
   integrity sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==
@@ -1481,12 +1481,12 @@
     "@polkadot/x-global" "13.5.9"
     tslib "^2.8.0"
 
-"@polkadot/x-ws@^13.5.8":
-  version "13.5.8"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-13.5.8.tgz#6b39779783d32d7b8e1a26f3e70b68bec23a91a2"
-  integrity sha512-tEs69W3O7Y2lPGihOFWwSE91GkaMEAzJhkDouTfacBKwD6O2b1/Im97jBdxQBmi7kN3pAWGXXTk9sz8TCh30Ug==
+"@polkadot/x-ws@13.5.9", "@polkadot/x-ws@^13.5.8":
+  version "13.5.9"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-13.5.9.tgz#796564254e64809619993e8ff77ad098b3b95023"
+  integrity sha512-NKVgvACTIvKT8CjaQu9d0dERkZsWIZngX/4NVSjc01WHmln4F4y/zyBdYn/Z2V0Zw28cISx+lB4qxRmqTe7gbg==
   dependencies:
-    "@polkadot/x-global" "13.5.8"
+    "@polkadot/x-global" "13.5.9"
     tslib "^2.8.0"
     ws "^8.18.0"
 

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -1214,21 +1214,12 @@
     "@polkadot/util-crypto" "13.5.9"
     tslib "^2.8.0"
 
-"@polkadot/networks@13.5.9":
+"@polkadot/networks@13.5.9", "@polkadot/networks@^13.5.8":
   version "13.5.9"
   resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-13.5.9.tgz#d5ed8fa0478956835ba489bd3ed10da40881b9c2"
   integrity sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA==
   dependencies:
     "@polkadot/util" "13.5.9"
-    "@substrate/ss58-registry" "^1.51.0"
-    tslib "^2.8.0"
-
-"@polkadot/networks@^13.5.8":
-  version "13.5.8"
-  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-13.5.8.tgz#5d744f2c9e4fd74cac948dba88edc319c630968a"
-  integrity sha512-e8wPLmTC/YtowkbkTG1BbeDy7PBKcclePSTZe72Xctx8kVssmAX6lKUQNk7tgu1BttGOhn6x9M8RXBBD4zB9Vw==
-  dependencies:
-    "@polkadot/util" "13.5.8"
     "@substrate/ss58-registry" "^1.51.0"
     tslib "^2.8.0"
 
@@ -1376,20 +1367,7 @@
     "@scure/base" "^1.1.7"
     tslib "^2.8.0"
 
-"@polkadot/util@13.5.8", "@polkadot/util@^13.5.8":
-  version "13.5.8"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-13.5.8.tgz#28d7fe9fd5bd77f305cdb10363f77aef6c6d191e"
-  integrity sha512-5xEfNoum/Ct+gYWN3AYvBQ8vq8KiS4HsY3BexPUPXvSXSx3Id/JYA5oFLYnkuRp8hwoQGjX0wqUJ6Hp8D8LHKw==
-  dependencies:
-    "@polkadot/x-bigint" "13.5.8"
-    "@polkadot/x-global" "13.5.8"
-    "@polkadot/x-textdecoder" "13.5.8"
-    "@polkadot/x-textencoder" "13.5.8"
-    "@types/bn.js" "^5.1.6"
-    bn.js "^5.2.1"
-    tslib "^2.8.0"
-
-"@polkadot/util@13.5.9":
+"@polkadot/util@13.5.9", "@polkadot/util@^13.5.8":
   version "13.5.9"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-13.5.9.tgz#26fb10b6479a6a884101d3ad8a3198c35903481c"
   integrity sha512-pIK3XYXo7DKeFRkEBNYhf3GbCHg6dKQisSvdzZwuyzA6m7YxQq4DFw4IE464ve4Z7WsJFt3a6C9uII36hl9EWw==
@@ -1455,15 +1433,7 @@
   dependencies:
     tslib "^2.7.0"
 
-"@polkadot/x-bigint@13.5.8", "@polkadot/x-bigint@^13.5.8":
-  version "13.5.8"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-bigint/-/x-bigint-13.5.8.tgz#60040c94c40c53bd32e10d600802e674b52206f7"
-  integrity sha512-4ltTNgFDZoPnuQBrP7Z3m3imQ3xKb7jKScAT/Gy89h9siLYyJdZ+qawZfO1cll6fqYlka+k7USqGeyOEqoyCfg==
-  dependencies:
-    "@polkadot/x-global" "13.5.8"
-    tslib "^2.8.0"
-
-"@polkadot/x-bigint@13.5.9":
+"@polkadot/x-bigint@13.5.9", "@polkadot/x-bigint@^13.5.8":
   version "13.5.9"
   resolved "https://registry.yarnpkg.com/@polkadot/x-bigint/-/x-bigint-13.5.9.tgz#a0b665a7c120dba02fbe4f2272762895b39e9d0f"
   integrity sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g==
@@ -1480,14 +1450,7 @@
     node-fetch "^3.3.2"
     tslib "^2.8.0"
 
-"@polkadot/x-global@13.5.8", "@polkadot/x-global@^13.5.8":
-  version "13.5.8"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-13.5.8.tgz#6c638290657c3ae7b60a655f9beaeacab59c0fa5"
-  integrity sha512-KDK3CEG/RvfCu3w4HZ/iv6c49XrN5Hz/3mXUQdLfR+TFKADdNCoIhMZ9f7vHYgdnB9tlY9s6Dn2svY99h1wRiw==
-  dependencies:
-    tslib "^2.8.0"
-
-"@polkadot/x-global@13.5.9":
+"@polkadot/x-global@13.5.8", "@polkadot/x-global@13.5.9", "@polkadot/x-global@^13.5.8":
   version "13.5.9"
   resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-13.5.9.tgz#22d680f036a879a5aef15963f96d71dd115927a3"
   integrity sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==
@@ -1502,28 +1465,12 @@
     "@polkadot/x-global" "13.5.9"
     tslib "^2.8.0"
 
-"@polkadot/x-textdecoder@13.5.8":
-  version "13.5.8"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-13.5.8.tgz#65c26d9be283945c394fac6df83f017687023086"
-  integrity sha512-Uzz6spRDzzQDQBN6PNpjz0HVp2kqhQVJRh1ShLP9rBg+nH4we9VGriWGG5stkgNKjRGT0Z7cvx0FupRQoNDU4A==
-  dependencies:
-    "@polkadot/x-global" "13.5.8"
-    tslib "^2.8.0"
-
 "@polkadot/x-textdecoder@13.5.9":
   version "13.5.9"
   resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-13.5.9.tgz#ce6dc1177c2d89549ad5bdfe5409cb6b42182c14"
   integrity sha512-W2HhVNUbC/tuFdzNMbnXAWsIHSg9SC9QWDNmFD3nXdSzlXNgL8NmuiwN2fkYvCQBtp/XSoy0gDLx0C+Fo19cfw==
   dependencies:
     "@polkadot/x-global" "13.5.9"
-    tslib "^2.8.0"
-
-"@polkadot/x-textencoder@13.5.8":
-  version "13.5.8"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-13.5.8.tgz#b42261938f817de4edff560b58b0ec95687c8223"
-  integrity sha512-2jcVte6mUy+GXjpZsS7dFca8C2r8EGgaG5o7mVQZ+PjauD06O/UP2g48UuDJHGe1QCJN0f0WaoD+RNw9tOF2yQ==
-  dependencies:
-    "@polkadot/x-global" "13.5.8"
     tslib "^2.8.0"
 
 "@polkadot/x-textencoder@13.5.9":


### PR DESCRIPTION
## Problem

The CLI pipeline prints:

```
@polkadot/util has multiple versions, ensure that there is only one installed.
```

This isn't a lint rule in this repo - it's a runtime `console.warn` baked into `@polkadot/util` itself, which registers a version marker on `globalThis` at import time and complains if it detects a second, differently-versioned copy of itself loaded in the same process. It's accurate here: `cli/yarn.lock` really did have two physically separate installed copies of several polkadot.js low-level packages (confirmed identically present on `main`, so this isn't new/introduced by `new-usc-testnet`):

- `@polkadot/util`: `13.5.8` and `13.5.9`
- `@polkadot/networks`: `13.5.8` and `13.5.9`
- `@polkadot/x-bigint`: `13.5.8` and `13.5.9`
- `@polkadot/x-global`: `13.5.8` and `13.5.9`
- `@polkadot/x-textdecoder`: `13.5.8` and `13.5.9`
- `@polkadot/x-textencoder`: `13.5.8` and `13.5.9`

### Why this happened

Almost the entire `@polkadot/api@16.5.2` family (`api-augment`, `api-base`, `rpc-core`, `types`, `types-codec`, etc.) depends on these packages via a caret range, e.g. `"@polkadot/util": "^13.5.8"`. That's what resolved to the `13.5.8` copies.

But `@polkadot/keyring` (pulled in by `@polkadot/api`/`@polkadot/rpc-provider` via the same `^13.5.8` range) itself resolved to the newer patch `13.5.9`, and - per the standard polkadot.js monorepo convention of exact-pinning sibling packages within the same lockstep release - `keyring@13.5.9`'s own manifest pins `"@polkadot/util": "13.5.9"` (no caret, not a range). Yarn Classic doesn't retroactively collapse an exact pin into an already-resolved caret match (even though `13.5.9` satisfies `^13.5.8`), so it just creates a second, separate physical copy instead. Same story for `networks`/`x-bigint`/`x-global`/`x-textdecoder`/`x-textencoder`, all pulled in transitively by `keyring`/`util-crypto`.

## Fix

Add a `resolutions` block to `cli/package.json` pinning all six affected packages to `13.5.9` (the version already used by `keyring`/`util-crypto`, and compatible with every existing `^13.5.8` requester per semver), then regenerate `cli/yarn.lock`.

## Verification

- Ran `yarn install` in `cli/` and confirmed `cli/yarn.lock` now has exactly one lockfile block per affected package (e.g. `"@polkadot/util@13.5.9", "@polkadot/util@^13.5.8":` collapsed into a single entry, versus two separate blocks before).
- Confirmed on disk that `cli/node_modules/@polkadot/util` (and siblings) now contains a single physical copy at `13.5.9`, with no nested duplicate installed elsewhere.
- `yarn install` did fail afterwards on the `prepare` (`tsc`) lifecycle script in this environment, but that's unrelated to this change and pre-existing on `main` too: `cli/src/test/blockchain-tests/artifacts/*.json` are checked out as literal-text symlink placeholders (containing the string `../../../../../precompiles/metadata/abi/*.json`) rather than real symlinks on this Windows checkout, which `tsc` then fails to parse as JSON. Confirmed this is identical on `main` and not something this change touches or introduces.

## Open question for reviewer

Would you rather pin via `resolutions` (this PR, quick/local fix) or instead bump the whole `@polkadot/api` family to a release where all sibling `@polkadot/*` packages were republished in lockstep at a matching patch version (removes the skew at the source, but is a bigger dependency bump)? Happy to go either way.
