### PR TITLE
Update Node.js to 24 in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:26.04@sha256:b7f48194d4d8b763a478a621cdc81c27be222ba2206ca3ca6bc42b49685f3d9e AS runtime-base
 ENV DEBIAN_FRONTEND=noninteractive
 ARG TARGETARCH
-ARG NODE_VERSION=20.20.2
+ARG NODE_VERSION=24.18.0
 # NodeSource's apt key fetch (deb.nodesource.com) intermittently 403s from our
 # self-hosted Linode CI runners' shared IP pool. Install the official upstream
 # release directly instead, checksum-verified against nodejs.org's own SHASUMS256.txt.
@@ -11,8 +11,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl xz-utils libdw1t64 libpq5 && \
     update-ca-certificates && \
     case "${TARGETARCH}" in \
-      amd64) NODE_ARCH=x64;    NODE_SHA256=df770b2a6f130ed8627c9782c988fda9669fa23898329a61a871e32f965e007d ;; \
-      arm64) NODE_ARCH=arm64;  NODE_SHA256=73093db209e4e9e09dd7d15a47aeaab1b74833830df03efa5f942a1122c5fa71 ;; \
+      amd64) NODE_ARCH=x64;    NODE_SHA256=55aa7153f9d88f28d765fcdad5ae6945b5c0f98a36881703817e4c450fa76742 ;; \
+      arm64) NODE_ARCH=arm64;  NODE_SHA256=58c9520501f6ae2b52d5b210444e24b9d0c029a58c5011b797bc1fe7105886f6 ;; \
       *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac && \
     curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz && \


### PR DESCRIPTION
# Description of proposed changes

Builds on top of PR #1205 and brings the Node.js version used inside docker image to 24 - same used for CI jobs.


---

Practical tips for PR review & merge:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
