### PR TITLE
fix(attestor): set a local state_dir so off-cluster runs can boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ prover/artifacts/*
 
 # Editor / IDE local settings (Claude Code, etc.)
 .claude/
+
+# Local write-ability scan cursor (attestor state_dir; see attestor/config.yaml)
+.attestor-state/

--- a/attestor/config.yaml
+++ b/attestor/config.yaml
@@ -113,6 +113,22 @@ write_ability:
   #
   # block_confirmation_depth: 3
 
+  # Directory for durable write-ability state — the Outbox scan cursor, so a restart
+  # resumes where it left off instead of skipping messages published while down.
+  #
+  # Set here because the default is `/data` (the persistent volume the attestor
+  # StatefulSet mounts in k8s), which cannot be created off-cluster: an unprivileged
+  # local process gets "Read-only file system" at the filesystem root, and the boot
+  # deliberately fails loudly when the state dir is not writable. In production leave
+  # this unset so it uses the mounted volume.
+  #
+  # Note for multi-attestor local runs (launch-attestors.sh): the cursor file is named
+  # per chain key (`outbox-cursor-<chain_key>.json`), not per attestor, so instances
+  # sharing this directory share one cursor. Harmless locally — the worst case is one
+  # attestor resuming from another's slightly older position and re-signing a few
+  # messages, which vote dedup absorbs.
+  state_dir: ".attestor-state"
+
   # Anti-abuse bounds.
   #
   # max_tracked_messages: 10000


### PR DESCRIPTION
Follow-up to `4dbe36054` (durable write-ability scan cursor).

## Problem

`state_dir` defaults to `/data` — the volume the attestor StatefulSet mounts — and `cursor::ensure_writable` deliberately fails the boot when it is not writable. Off cluster that default cannot work:

```
$ mkdir -p /data
mkdir: /data: Read-only file system
```

An unprivileged process cannot create a directory at the filesystem root, and GitHub runners execute as the non-root `runner` user. Since a write-ability error propagates to the supervisor, this takes the **whole attestor process** down — block attestation included, not just message voting.

`state_dir` is **config-file only** (no CLI flag, no env var), so the shipped `attestor/config.yaml` is the only place to set it.

## Fix

Point `state_dir` at a repo-local, gitignored directory. Production leaves it unset and keeps using the mounted `/data` volume, so **no chart change is needed** — I verified the attestor chart already provides a PVC at `/data` (`attestor-storage`, RWO) on `usc/messaging`, `master` and HEAD, and `podSecurityContext.runAsUser: 0` means the write probe passes.

## Why this matters now

`launch-attestors.sh` runs the binary directly with this config, so it gates both the local harness and the write-ability e2e. Neither has run against the cursor change yet — it landed at 22:32 UTC on 27 Jul, about eight hours after the last e2e run started (verified with `git merge-base --is-ancestor`). The next dispatch would have failed at attestor boot.

## Also documented

The cursor file is `outbox-cursor-<chain_key>.json` — named per chain key, not per attestor — so several local instances sharing this directory share one cursor. Harmless: the worst case is one attestor resuming from another’s slightly older position and re-signing a few messages, which vote dedup absorbs. Worth knowing before someone debugs it as a bug.

## Verification

YAML parses; key name matches the `state_dir: Option<PathBuf>` field (snake_case, like the neighbouring working keys); the path is creatable from the repo root, which is where zombienet spawns the attestors. Full end-to-end confirmation is the e2e run itself — happy to dispatch it once this lands.

## Note for reviewers

Nothing parses the shipped `attestor/config.yaml` in tests, and `ConfigFileWriteAbility` has no `deny_unknown_fields`, so a mistyped key is **silently ignored** rather than rejected. A test that deserializes the shipped config would close that gap cheaply — out of scope here.