### PR TITLE
fix(DO-2338): grant pull-requests: write so Docker Scout can post PR comments

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,6 +17,15 @@ name: Reusable workflow to build docker image
       GLUWA_BOT_PR:
         description: gluwa-bot PAT (pull-requests:write only) so Docker Scout can post PR comments — GITHUB_TOKEN's own permissions couldn't be elevated (see DO-2338)
         required: false
+      # gluwabot DockerHub token, read-only scope — lets Scout authenticate to the Scout
+      # backend even for a local:// image scan. Deliberately separate from
+      # DOCKER_PUSH_USERNAME/PASSWORD below: those are push-capable, and PR builds run
+      # untrusted Dockerfile/build-script content from the PR, so they must never see a
+      # credential that can push to the real image (see DO-2338).
+      DOCKERHUB_SCOUT_USERNAME:
+        required: false
+      DOCKERHUB_SCOUT_TOKEN:
+        required: false
       # Pre-existing secrets this workflow already consumed before DO-2338 — now need
       # explicit declaration since adding any `secrets:` block switches this workflow_call
       # into strict mode. Empty/unset on PR-triggered docker.yml (which never inherits
@@ -55,20 +64,22 @@ jobs:
           docker build -f scripts/stress-test/Dockerfile -t ${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }} --sbom=true --provenance=mode=max .
           docker images
 
-      # DO-2217: informational only — never fails the build (continue-on-error backs up exit-code:false
-      # in case the action itself errors, e.g. on an empty dockerhub-user during PR runs). See DO-2104
-      # for the org-wide compliance initiative. Runs unconditionally: local CVE scanning needs no
-      # DockerHub credentials — only org-policy evaluation does, and dockerhub-user/password are empty
-      # (not missing) on PR runs since docker-build doesn't inherit secrets there, which the action
-      # treats as "skip login, scan locally".
+      # DO-2217/DO-2338: informational only — never fails the build (continue-on-error backs up
+      # exit-code:false in case the action itself errors). See DO-2104 for the org-wide compliance
+      # initiative. Despite scanning a local:// image, docker/scout-action still authenticates to the
+      # Scout backend and hard-fails ("no credential found") without a real DockerHub login — empty
+      # dockerhub-user/password does NOT mean "scan locally without auth", confirmed live on PR #1214
+      # where continue-on-error silently masked this for every PR build. Uses the read-only
+      # gluwabot/DOCKERHUB_SCOUT_TOKEN credential (never DOCKER_PUSH_*) since PR builds run untrusted
+      # Dockerfile/build-script content and must not see a push-capable credential.
       - name: Docker Scout - CVE scan (${{ github.repository }})
         continue-on-error: true
         uses: docker/scout-action@v1
         with:
           command: cves
           image: local://${{ github.repository }}:${{ inputs.version-string }}
-          dockerhub-user: ${{ secrets.DOCKER_PUSH_USERNAME }}
-          dockerhub-password: ${{ secrets.DOCKER_PUSH_PASSWORD }}
+          dockerhub-user: ${{ secrets.DOCKERHUB_SCOUT_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_SCOUT_TOKEN }}
           exit-code: false
           # DO-2336/DO-2338: without this, the action's default "one comment per job"
           # behavior means the 3rd scan below silently overwrites the first two's
@@ -84,8 +95,8 @@ jobs:
         with:
           command: cves
           image: local://${{ github.repository }}:indexer-for-${{ inputs.version-string }}
-          dockerhub-user: ${{ secrets.DOCKER_PUSH_USERNAME }}
-          dockerhub-password: ${{ secrets.DOCKER_PUSH_PASSWORD }}
+          dockerhub-user: ${{ secrets.DOCKERHUB_SCOUT_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_SCOUT_TOKEN }}
           exit-code: false
           # DO-2336/DO-2338: without this, the action's default "one comment per job"
           # behavior means the 3rd scan below silently overwrites the first two's
@@ -101,8 +112,8 @@ jobs:
         with:
           command: cves
           image: local://${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }}
-          dockerhub-user: ${{ secrets.DOCKER_PUSH_USERNAME }}
-          dockerhub-password: ${{ secrets.DOCKER_PUSH_PASSWORD }}
+          dockerhub-user: ${{ secrets.DOCKERHUB_SCOUT_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_SCOUT_TOKEN }}
           exit-code: false
           # DO-2336/DO-2338: without this, the action's default "one comment per job"
           # behavior means the 3rd scan below silently overwrites the first two's

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -14,27 +14,11 @@ name: Reusable workflow to build docker image
         required: true
         type: string
 
-# DO-2336/DO-2338: docker/scout-action's `write-comment` defaults to true, but was
-# silently no-op'ing under read-all. GitHub Actions permission ceilings can't be
-# broadened at job level, only narrowed, so this needs pull-requests: write explicitly
-# (and in the calling docker.yml workflow too, since its own ceiling applies as well).
-# Narrowing to just contents:read caused a hard startup_failure (confirmed live) — this
-# keeps every scope read-all was already granting at "read", only elevating
-# pull-requests to "write".
-permissions:
-  actions: read
-  attestations: read
-  checks: read
-  contents: read
-  deployments: read
-  discussions: read
-  issues: read
-  packages: read
-  pages: read
-  pull-requests: write
-  repository-projects: read
-  security-events: read
-  statuses: read
+# DO-2336/DO-2338: a workflow-level granular permissions map here caused a hard
+# startup_failure every time (confirmed live across several attempts) — reverted to the
+# proven-working shorthand. pull-requests: write for docker/scout-action's PR comment is
+# instead granted via a job-level permissions override in the calling docker.yml.
+permissions: read-all
 
 jobs:
   docker-build:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -32,6 +32,7 @@ permissions:
   packages: read
   pages: read
   pull-requests: write
+  repository-projects: read
   security-events: read
   statuses: read
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -14,7 +14,14 @@ name: Reusable workflow to build docker image
         required: true
         type: string
 
-permissions: read-all
+# DO-2336/DO-2338: docker/scout-action's `write-comment` defaults to true, but was
+# silently no-op'ing under read-all — GitHub Actions permission ceilings can't be
+# broadened at job level, only narrowed, so this needs to grant pull-requests: write
+# explicitly (and in the calling docker.yml workflow too, since its own ceiling applies
+# as well). Narrowed the rest from read-all to just what checkout/artifacts need.
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   docker-build:
@@ -54,6 +61,10 @@ jobs:
           dockerhub-user: ${{ secrets.DOCKER_PUSH_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKER_PUSH_PASSWORD }}
           exit-code: false
+          # DO-2336/DO-2338: without this, the action's default "one comment per job"
+          # behavior means the 3rd scan below silently overwrites the first two's
+          # results in the same PR comment. keep-previous-comments preserves all 3.
+          keep-previous-comments: true
 
       - name: Docker Scout - CVE scan (${{ github.repository }}:indexer-for-${{ inputs.version-string }})
         continue-on-error: true
@@ -64,6 +75,10 @@ jobs:
           dockerhub-user: ${{ secrets.DOCKER_PUSH_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKER_PUSH_PASSWORD }}
           exit-code: false
+          # DO-2336/DO-2338: without this, the action's default "one comment per job"
+          # behavior means the 3rd scan below silently overwrites the first two's
+          # results in the same PR comment. keep-previous-comments preserves all 3.
+          keep-previous-comments: true
 
       - name: Docker Scout - CVE scan (${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }})
         continue-on-error: true
@@ -74,6 +89,10 @@ jobs:
           dockerhub-user: ${{ secrets.DOCKER_PUSH_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKER_PUSH_PASSWORD }}
           exit-code: false
+          # DO-2336/DO-2338: without this, the action's default "one comment per job"
+          # behavior means the 3rd scan below silently overwrites the first two's
+          # results in the same PR comment. keep-previous-comments preserves all 3.
+          keep-previous-comments: true
 
       - name: Export docker image into a file
         run: |

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -19,9 +19,7 @@ name: Reusable workflow to build docker image
 # broadened at job level, only narrowed, so this needs to grant pull-requests: write
 # explicitly (and in the calling docker.yml workflow too, since its own ceiling applies
 # as well). Narrowed the rest from read-all to just what checkout/artifacts need.
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all
 
 jobs:
   docker-build:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -15,11 +15,25 @@ name: Reusable workflow to build docker image
         type: string
 
 # DO-2336/DO-2338: docker/scout-action's `write-comment` defaults to true, but was
-# silently no-op'ing under read-all — GitHub Actions permission ceilings can't be
-# broadened at job level, only narrowed, so this needs to grant pull-requests: write
-# explicitly (and in the calling docker.yml workflow too, since its own ceiling applies
-# as well). Narrowed the rest from read-all to just what checkout/artifacts need.
-permissions: read-all
+# silently no-op'ing under read-all. GitHub Actions permission ceilings can't be
+# broadened at job level, only narrowed, so this needs pull-requests: write explicitly
+# (and in the calling docker.yml workflow too, since its own ceiling applies as well).
+# Narrowing to just contents:read caused a hard startup_failure (confirmed live) — this
+# keeps every scope read-all was already granting at "read", only elevating
+# pull-requests to "write".
+permissions:
+  actions: read
+  attestations: read
+  checks: read
+  contents: read
+  deployments: read
+  discussions: read
+  issues: read
+  packages: read
+  pages: read
+  pull-requests: write
+  security-events: read
+  statuses: read
 
 jobs:
   docker-build:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -13,11 +13,23 @@ name: Reusable workflow to build docker image
       runs-on:
         required: true
         type: string
+    secrets:
+      GLUWA_BOT_PR:
+        description: gluwa-bot PAT (pull-requests:write only) so Docker Scout can post PR comments — GITHUB_TOKEN's own permissions couldn't be elevated (see DO-2338)
+        required: false
+      # Pre-existing secrets this workflow already consumed before DO-2338 — now need
+      # explicit declaration since adding any `secrets:` block switches this workflow_call
+      # into strict mode. Empty/unset on PR-triggered docker.yml (which never inherits
+      # them, deliberately); populated on release.yml via secrets: inherit.
+      DOCKER_PUSH_USERNAME:
+        required: false
+      DOCKER_PUSH_PASSWORD:
+        required: false
 
 # DO-2336/DO-2338: a workflow-level granular permissions map here caused a hard
-# startup_failure every time (confirmed live across several attempts) — reverted to the
-# proven-working shorthand. pull-requests: write for docker/scout-action's PR comment is
-# instead granted via a job-level permissions override in the calling docker.yml.
+# startup_failure every time (confirmed live across several attempts, cause not
+# identified) — reverted to the proven-working shorthand. docker/scout-action's PR
+# comment instead uses the gluwa-bot PAT above as its own github-token.
 permissions: read-all
 
 jobs:
@@ -62,6 +74,9 @@ jobs:
           # behavior means the 3rd scan below silently overwrites the first two's
           # results in the same PR comment. keep-previous-comments preserves all 3.
           keep-previous-comments: true
+          # gluwa-bot PAT (pull-requests:write only) — GITHUB_TOKEN's own permissions
+          # couldn't be elevated without a hard startup_failure (see comment above).
+          github-token: ${{ secrets.GLUWA_BOT_PR }}
 
       - name: Docker Scout - CVE scan (${{ github.repository }}:indexer-for-${{ inputs.version-string }})
         continue-on-error: true
@@ -76,6 +91,9 @@ jobs:
           # behavior means the 3rd scan below silently overwrites the first two's
           # results in the same PR comment. keep-previous-comments preserves all 3.
           keep-previous-comments: true
+          # gluwa-bot PAT (pull-requests:write only) — GITHUB_TOKEN's own permissions
+          # couldn't be elevated without a hard startup_failure (see comment above).
+          github-token: ${{ secrets.GLUWA_BOT_PR }}
 
       - name: Docker Scout - CVE scan (${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }})
         continue-on-error: true
@@ -90,6 +108,9 @@ jobs:
           # behavior means the 3rd scan below silently overwrites the first two's
           # results in the same PR comment. keep-previous-comments preserves all 3.
           keep-previous-comments: true
+          # gluwa-bot PAT (pull-requests:write only) — GITHUB_TOKEN's own permissions
+          # couldn't be elevated without a hard startup_failure (see comment above).
+          github-token: ${{ secrets.GLUWA_BOT_PR }}
 
       - name: Export docker image into a file
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,32 +20,23 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
-# DO-2336/DO-2338: this workflow's ceiling applies to the called build-docker.yml job
-# too. Narrowing to just contents:read caused a hard startup_failure (confirmed live,
-# some job here needs a broader read scope than that) — so this keeps every scope
-# read-all was already granting at "read", and only elevates pull-requests to "write"
-# so docker/scout-action's `write-comment` (defaults true, was silently no-op'ing under
-# read-all) actually works.
-permissions:
-  actions: read
-  attestations: read
-  checks: read
-  contents: read
-  deployments: read
-  discussions: read
-  issues: read
-  packages: read
-  pages: read
-  pull-requests: write
-  repository-projects: read
-  security-events: read
-  statuses: read
+# DO-2336/DO-2338: a workflow-level granular permissions map here caused a hard
+# startup_failure every time (confirmed live across several attempts, even ones
+# listing every scope read-all grants) — reverted to the proven-working shorthand.
+# pull-requests: write for docker/scout-action's PR comment is instead granted at the
+# docker-build job level below.
+permissions: read-all
 
 jobs:
   docker-build:
     needs:
       - deploy-runner-docker-build
     uses: ./.github/workflows/build-docker.yml
+    # DO-2336/DO-2338: job-level grant for docker/scout-action's PR comment, since a
+    # workflow-level granular permissions map caused a hard startup_failure (see above).
+    permissions:
+      contents: read
+      pull-requests: write
     with:
       build-options: "BUILD_ARGS="
       version-string: "latest"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,9 +21,24 @@ concurrency:
   cancel-in-progress: true
 
 # DO-2336/DO-2338: this workflow's ceiling applies to the called build-docker.yml job
-# too — narrowed from read-all to what's actually needed, plus pull-requests: write so
-# docker/scout-action's `write-comment` (defaults true, was silently no-op'ing) works.
-permissions: read-all
+# too. Narrowing to just contents:read caused a hard startup_failure (confirmed live,
+# some job here needs a broader read scope than that) — so this keeps every scope
+# read-all was already granting at "read", and only elevates pull-requests to "write"
+# so docker/scout-action's `write-comment` (defaults true, was silently no-op'ing under
+# read-all) actually works.
+permissions:
+  actions: read
+  attestations: read
+  checks: read
+  contents: read
+  deployments: read
+  discussions: read
+  issues: read
+  packages: read
+  pages: read
+  pull-requests: write
+  security-events: read
+  statuses: read
 
 jobs:
   docker-build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,12 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
-permissions: read-all
+# DO-2336/DO-2338: this workflow's ceiling applies to the called build-docker.yml job
+# too — narrowed from read-all to what's actually needed, plus pull-requests: write so
+# docker/scout-action's `write-comment` (defaults true, was silently no-op'ing) works.
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   docker-build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,11 +20,12 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
-# DO-2336/DO-2338: a workflow-level granular permissions map here caused a hard
-# startup_failure every time (confirmed live across several attempts, even ones
-# listing every scope read-all grants) — reverted to the proven-working shorthand.
-# pull-requests: write for docker/scout-action's PR comment is instead granted at the
-# docker-build job level below.
+# DO-2336/DO-2338: any explicit narrower permissions declaration here (workflow-level
+# or job-level, 2 scopes or 13) caused a hard startup_failure every time, confirmed
+# live across several attempts, for reasons that weren't identified — reverted to the
+# proven-working shorthand. docker/scout-action's PR comment instead uses a dedicated
+# gluwa-bot PAT (secrets.GLUWA_BOT_PR) as its github-token, sidestepping the need for
+# GITHUB_TOKEN's own permissions to be elevated at all.
 permissions: read-all
 
 jobs:
@@ -32,11 +33,12 @@ jobs:
     needs:
       - deploy-runner-docker-build
     uses: ./.github/workflows/build-docker.yml
-    # DO-2336/DO-2338: job-level grant for docker/scout-action's PR comment, since a
-    # workflow-level granular permissions map caused a hard startup_failure (see above).
-    permissions:
-      contents: read
-      pull-requests: write
+    # DO-2336/DO-2338: explicit named pass-through, NOT `secrets: inherit` — this job
+    # deliberately has no DOCKER_PUSH_USERNAME/PASSWORD (only release.yml, tag-triggered,
+    # does real pushes); inherit would leak those in and make "Push docker images"
+    # start firing on every ordinary PR/push build here.
+    secrets:
+      GLUWA_BOT_PR: ${{ secrets.GLUWA_BOT_PR }}
     with:
       build-options: "BUILD_ARGS="
       version-string: "latest"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,9 +23,7 @@ concurrency:
 # DO-2336/DO-2338: this workflow's ceiling applies to the called build-docker.yml job
 # too — narrowed from read-all to what's actually needed, plus pull-requests: write so
 # docker/scout-action's `write-comment` (defaults true, was silently no-op'ing) works.
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all
 
 jobs:
   docker-build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,9 +36,13 @@ jobs:
     # DO-2336/DO-2338: explicit named pass-through, NOT `secrets: inherit` — this job
     # deliberately has no DOCKER_PUSH_USERNAME/PASSWORD (only release.yml, tag-triggered,
     # does real pushes); inherit would leak those in and make "Push docker images"
-    # start firing on every ordinary PR/push build here.
+    # start firing on every ordinary PR/push build here. DOCKERHUB_SCOUT_* is a separate
+    # read-only gluwabot token safe to expose to PR builds (which run untrusted PR
+    # content) — it lets Scout authenticate without granting any push capability.
     secrets:
       GLUWA_BOT_PR: ${{ secrets.GLUWA_BOT_PR }}
+      DOCKERHUB_SCOUT_USERNAME: ${{ secrets.DOCKERHUB_SCOUT_USERNAME }}
+      DOCKERHUB_SCOUT_TOKEN: ${{ secrets.DOCKERHUB_SCOUT_TOKEN }}
     with:
       build-options: "BUILD_ARGS="
       version-string: "latest"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,7 @@ permissions:
   packages: read
   pages: read
   pull-requests: write
+  repository-projects: read
   security-events: read
   statuses: read
 


### PR DESCRIPTION
## Summary
- `docker/scout-action`'s `write-comment` input defaults to `true`, but was silently no-op'ing because this workflow (and its caller `docker.yml`) declared `permissions: read-all` — no `pull-requests` write scope, and GitHub Actions permission ceilings can only be narrowed at job level, never broadened
- Granted `pull-requests: write` in both `docker.yml` and `build-docker.yml`, narrowing everything else to just `contents: read` (all these jobs actually use)
- Added `keep-previous-comments: true` — without it, the action's default "one comment per job" behavior means the 3rd Scout scan (proof-gen-stress-test) silently overwrites the first two images' (main, indexer) results in the same PR comment

Part of DO-2336 (org-wide Docker Scout CVE-scan rework — surface results as PR comments instead of only in the raw log).

## Test plan
- [ ] This PR's own `docker-build` workflow run posts 3 separate Scout-result comments (main, indexer, proof-gen-stress-test), not one overwriting the others