### PR TITLE
fix(attestation): tag only active-attestor commit_attestation submissions [ATTESTOR-V2-008]

### DIFF
--- a/pallets/attestation/src/extensions.rs
+++ b/pallets/attestation/src/extensions.rs
@@ -39,10 +39,12 @@ use crate::pallet::{ActiveAttestors, Call, Config, MaxCatchup, Pallet};
 /// through: they fail in dispatch (`AttestorNotActive`) and pay fees, so a deregistered or
 /// misconfigured node cannot spam free prevalidation-rejected submissions.
 ///
-/// Admitted `commit_attestation` transactions carry a `provides` tag keyed by
+/// `commit_attestation` transactions from *active attestors* carry a `provides` tag keyed by
 /// `(chain_key, digest)` so the pool holds at most one pending submission per attestation —
 /// racing duplicates from other attestors are deduplicated at admission instead of all being
-/// broadcast and racing to dispatch.
+/// broadcast and racing to dispatch. Submissions from non-active signers are admitted **without**
+/// that tag, so they cannot reserve or evict the pool slot belonging to a legitimate attestation
+/// (ATTESTOR-V2-008).
 ///
 /// Other calls are passed through untouched.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
@@ -134,11 +136,26 @@ where
             let active_attestors = ActiveAttestors::<T>::get(chain_key)
                 .into_iter()
                 .collect::<BTreeSet<_>>();
+            let is_active = active_attestors.contains(who);
             // `check_duplicate` now also enforces the strictly-monotonic per-chain height
             // (via `LastDigest`), so a race loser resubmitting an already-attested height — or
             // a quorum trying a competing digest for that height — is rejected here before fees.
-            if active_attestors.contains(who) && Pallet::<T>::check_duplicate(attestation) {
+            if is_active && Pallet::<T>::check_duplicate(attestation) {
                 return Err(TransactionValidityError::Invalid(InvalidTransaction::Stale));
+            }
+
+            // Submissions from non-active signers are still admitted — they fail in dispatch
+            // (`AttestorNotActive`) and pay the fee, which is what deters spam — but they get
+            // *no* `provides` tag.
+            //
+            // The tag below is derived only from public chain data, so anyone can predict the
+            // digest honest attestors will produce next. Handing a tag to an unauthorized
+            // submitter would let any funded account reserve (or, with higher priority, evict)
+            // the single pool slot for that digest with a transaction guaranteed to fail,
+            // repeatedly delaying attestation progress (ATTESTOR-V2-008). Authorization is only
+            // checked in dispatch, so it must gate the tag here.
+            if !is_active {
+                return Ok(ValidTransaction::default());
             }
 
             // Tag the transaction with what it provides: the attestation itself. Two pending

--- a/pallets/attestation/src/tests.rs
+++ b/pallets/attestation/src/tests.rs
@@ -8547,6 +8547,87 @@ mod prevalidate_attestation_commit_extension {
         })
     }
 
+    /// Regression test for ATTESTOR-V2-008: only *active attestors* get the shared
+    /// `(chain_key, digest)` `provides` tag.
+    ///
+    /// The tag is derived purely from public chain data, so anyone can predict the digest honest
+    /// attestors will produce next. Authorization is only checked in dispatch, so if prevalidation
+    /// handed the tag out unconditionally, any funded account could reserve — or, with higher
+    /// priority, evict — the single pool slot for that digest using a transaction guaranteed to
+    /// fail, repeatedly delaying attestation progress. Both submissions below name the *same*
+    /// digest; only the authorized one may claim the slot.
+    #[test]
+    fn prevalidate_tags_only_active_attestor_submissions() {
+        ExtBuilder.build_and_execute(|| {
+            let attestor = Attestor::new(STASH_1, ATTESTOR_1);
+            let epoch = 99u64;
+
+            assert_ok!(Attestation::register_attestor(
+                attestor.stash.clone(),
+                SUPPORTED_CHAIN_KEY,
+                attestor.attestor_id,
+            ));
+            assert_ok!(Attestation::attest(
+                RuntimeOrigin::signed(attestor.attestor_id),
+                SUPPORTED_CHAIN_KEY,
+                attestor.public_key,
+                attestor.signature,
+            ));
+            assert_ok!(Attestation::force_election(RuntimeOrigin::root(), epoch));
+
+            let attestation = create_signed_attestation(
+                vec![attestor.clone()],
+                SUPPORTED_CHAIN_KEY,
+                0,
+                None,
+                None,
+            );
+            let chain_key = attestation.chain_key();
+
+            assert!(
+                ActiveAttestors::<Test>::get(chain_key).contains(&attestor.attestor_id),
+                "precondition: signer must be an active attestor"
+            );
+            assert!(
+                !ActiveAttestors::<Test>::get(chain_key).contains(&ATTESTOR_2),
+                "precondition: the impersonator must NOT be an active attestor"
+            );
+
+            let call = RuntimeCall::Attestation(crate::Call::commit_attestation {
+                attestation: attestation.clone(),
+            });
+            let info = call.get_dispatch_info();
+
+            // The legitimate attestor claims the slot for this digest.
+            let authorized = PrevalidateAttestationCommit::<Test>::new()
+                .validate(&attestor.attestor_id, &call, &info, 0)
+                .expect("active attestor is admitted");
+            assert!(
+                !authorized.provides.is_empty(),
+                "an active attestor must still claim the dedup slot"
+            );
+
+            // A non-attestor submitting the *same* attestation is admitted (it pays its fee in
+            // dispatch) but must not be able to conflict with the submission above.
+            let unauthorized = PrevalidateAttestationCommit::<Test>::new()
+                .validate(&ATTESTOR_2, &call, &info, 0)
+                .expect("non-active signers are still admitted, to pay fees in dispatch");
+            assert!(
+                unauthorized.provides.is_empty(),
+                "an unauthorized submission must not claim the shared attestation slot"
+            );
+
+            // The two must not collide in the pool.
+            assert!(
+                authorized
+                    .provides
+                    .iter()
+                    .all(|tag| !unauthorized.provides.contains(tag)),
+                "unauthorized submissions must not preempt the legitimate attestation's slot"
+            );
+        })
+    }
+
     #[test]
     fn prevalidate_attestation_fails_duplicate() {
         ExtBuilder.build_and_execute(|| {
@@ -8678,6 +8759,13 @@ mod prevalidate_attestation_commit_extension {
             assert!(
                 res.is_ok(),
                 "Attestation from an invalid source must still be inserted into the mempool"
+            );
+
+            // ...but carries no `provides` tag, so it cannot occupy the pool slot a legitimate
+            // attestation for this digest would use (ATTESTOR-V2-008).
+            assert!(
+                res.expect("checked ok above").provides.is_empty(),
+                "an unauthorized submission must not be tagged with the shared attestation slot"
             );
 
             let res = Attestation::commit_attestation(


### PR DESCRIPTION
Fixes [ATTESTOR-V2-008](https://github.com/chainlight-io/USC-ATTESTOR-V2-issues/issues/9) — *Shared `provides` Tag Preemption Can Degrade `commit_attestation` Liveness*.

Reopened against a fresh checkout of `usc-dev` with only the single fix commit (2673533), per the history realignment. Supersedes #1201.

## The bug

`PrevalidateAttestationCommit` assigned the shared `(chain_key, digest)` `provides` tag to **every** `commit_attestation` call. The digest is derived purely from public chain data (header number, root, prev digest), so anyone can predict what honest attestors will produce next, and authorization is only enforced in dispatch. Any funded account could therefore:

* **reserve** the single pool slot for the next legitimate digest with a transaction guaranteed to fail (`AttestorNotActive`), or
* **evict** an already-pending legitimate submission by supplying higher priority.

Repeating that across successive digests delays attestation progress. Liveness-only — no integrity impact, and each attempt costs the attacker a fee.

## The fix

Gate the tag on active-set membership. Non-active signers return `ValidTransaction::default()` (admitted, no `provides` tag) — they still fail in dispatch and pay the inclusion fee, so free prevalidation-rejected spam is still deterred; they simply claim no slot.

Per [Didac's review](https://github.com/gluwa/creditcoin3/pull/1201#discussion_r0), the active-set check now runs **before** the duplicate check, so `check_duplicate` only runs for active attestors (whose racing submissions are the reason it exists). Cleaner control flow, no `is_active` temporary.

Deduplication between *real* racing attestors ([ATTESTOR-V2-999](https://github.com/chainlight-io/USC-ATTESTOR-V2-issues/issues/8)) is unchanged.

## Testing

- `prevalidate_tags_only_active_attestor_submissions`: same attestation from an active attestor and a non-attestor — active claims a tag (dedup preserved), non-attestor admitted with empty `provides`, tag sets cannot collide.
- Asserts the empty tag on the existing `prevalidate_attestation_pays_fee_if_not_active_attestor` case.

## Verification

- `cargo test -p pallet-attestation` — 262 passed, 0 failed
- `cargo clippy -p pallet-attestation --all-targets` — clean
- `cargo fmt --all` — clean
