### PR TITLE
test(cc3-indexer): fix the flaky attestation-interval test (waits for an era, needs an epoch)

### DIFF
--- a/cli/src/test/cc3-indexer-tests/handleEventAttestationIntervalChanged.test.ts
+++ b/cli/src/test/cc3-indexer-tests/handleEventAttestationIntervalChanged.test.ts
@@ -1,8 +1,46 @@
 import { newApi, ApiPromise, KeyringPair } from '../../lib';
 import { getChainStatus } from '../../lib/chain/status';
-import { waitEras } from '../integration-tests/helpers';
-import { forElapsedBlocks, randomIntBetween } from '../utils';
+import { forElapsedBlocks, randomIntBetween, sleep } from '../utils';
 import { graphQLQuery } from './common';
+
+// Poll the chain until `set_chain_attestation_interval` has actually been *applied* to
+// `chainKey`, i.e. `ChainAttestationInterval` reads back as `expected`.
+//
+// The extrinsic only writes `PendingAttestationInterval`; the value is moved into
+// `ChainAttestationInterval` (and `AttestationIntervalChanged` emitted) by
+// `apply_interval_updates()`, which runs from `on_new_epoch_randomness` — an **epoch**
+// boundary. Waiting a fixed `waitEras(1)` raced that: `signAndSend` is not awaited to
+// inclusion, so the boundary could pass *before* the extrinsic landed, leaving the value
+// pending with nothing left to wait for. The assertions then read the chain-registration
+// record (the only AttestationIntervalChanged ever emitted for that key) and saw the default
+// interval. Polling the applied value removes the ordering assumption entirely — it simply
+// waits for the next boundary after the write, however the two interleave.
+//
+// Throws on timeout so a genuinely stuck update still fails the test rather than hanging.
+async function waitForIntervalApplied(
+    api: ApiPromise,
+    chainKey: bigint,
+    expected: bigint,
+    timeoutMs = 240_000,
+    intervalMs = 3_000,
+): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    let last = '<none>';
+
+    while (Date.now() < deadline) {
+        const applied = (await api.query.attestation.chainAttestationInterval(chainKey)).toBigInt();
+        last = applied.toString();
+        if (applied === expected) {
+            return;
+        }
+        await sleep(intervalMs);
+    }
+
+    throw new Error(
+        `attestation interval for chain_key ${chainKey} was not applied within ${timeoutMs}ms ` +
+            `(expected ${expected}, last saw ${last}) — the pending update never reached an epoch boundary`,
+    );
+}
 
 describe('handleEventAttestationIntervalChanged()', () => {
     let api: ApiPromise;
@@ -62,8 +100,10 @@ describe('handleEventAttestationIntervalChanged()', () => {
             await api.tx.sudo
                 .sudo(api.tx.attestation.setChainAttestationInterval(newChainKey, newInterval))
                 .signAndSend(root, { nonce: await api.rpc.system.accountNextIndex(root.address) });
-            // wait for the pending change to take effect
-            await waitEras(1, api);
+
+            // Wait for the pending change to actually be applied on-chain, rather than for a fixed
+            // number of eras — see waitForIntervalApplied for why the fixed wait raced.
+            await waitForIntervalApplied(api, newChainKey, newInterval);
 
             // wait for indexer to index this event
             await forElapsedBlocks(api, { minBlocks: 3 });


### PR DESCRIPTION
## Problem

`cc3-indexer-testing` fails intermittently on **every** branch, always on the same two assertions in `handleEventAttestationIntervalChanged.test.ts`:

```
✕ graphQL returns known AttestationIntervalChanged entity
    expect(BigInt(node.blockNumber)).toBeGreaterThan(startingBlock)
      Expected: > 75n   Received: 74n

✕ graphQL returns updated AttestationChainData entity
    expect(BigInt(node.attestationInterval)).toEqual(newInterval)
      Expected: 14n     Received: 10n
```

Observed failing on `fix/attestor-startup-checkpoint-anchor-v2` (#1218), on `fix/prevalidate-provides-active-only-v2` (which touches neither the indexer nor attestor startup — identical failure, same 2 failed / 49 passed), and earlier on `writeability-off-usc-dev`; passing on `fix/archiver-log-gate-ws-restart-v2` and on later runs of the same branches. **It's the test, not any of those changes** — which is why it belongs here rather than on any feature branch.

## Root cause

An ordering assumption, not a timing shortfall.

`set_chain_attestation_interval` only writes `PendingAttestationInterval`. The value is moved into `ChainAttestationInterval` — and `AttestationIntervalChanged` emitted — by `apply_interval_updates()`, which runs from `on_new_epoch_randomness`, i.e. at an **epoch** boundary:

```rust
// pallets/attestation/src/impls.rs
fn on_new_epoch_randomness(epoch: u64, randomness: Randomness) {
    ...
    // We also apply attestation interval updates, if any, at epoch boundaries.
    Self::apply_interval_updates();
}
```

The test instead waited `waitEras(1)`, and `signAndSend` is never awaited to inclusion. So the boundary could pass **before** the extrinsic landed. When that happened the value stayed pending with nothing left to wait for, and both assertions fell back on the only `AttestationIntervalChanged` ever emitted for that chain key — the one from chain registration, carrying the default interval `10` at a block *below* `startingBlock`. That is exactly the observed `74n` / `10n`.

## Fix

Poll `ChainAttestationInterval` until it reads back the new value, instead of waiting a fixed number of eras. That drops the ordering assumption entirely: it waits for the first epoch boundary *after* the write, however the two interleave. It throws on timeout so a genuinely stuck update still fails the test rather than hanging.

Same shape as the existing `waitForReversionComplete` helper in `zz-handleEventRevertedAttestationChainTo.test.ts`, and the same direction as the earlier *"cc3-indexer: poll for reversion completion instead of fixed block wait"* change.

## Verification

`tsc --noEmit` clean · `eslint --max-warnings 0` clean · `prettier --check` clean. The test itself needs a live node + indexer, so it is verified by CI here rather than locally.

## Expected effect

Should stop the intermittent `cc3-indexer-testing` failures across `usc-dev` and every feature branch. Unblocks one of the two failures on #1218 and the only indexer failure on #1215.
