### PR TITLE
chore(attestor): quiet the per-round unresolved-submission warn, fix its misattributed cause

### DIFF
--- a/attestor/attestor/src/tasks/validation.rs
+++ b/attestor/attestor/src/tasks/validation.rs
@@ -302,7 +302,15 @@ async fn handle_submission_result(
             tracing::info!(height, "✅ finalized externally");
         }
         Outcome::Unresolved => {
-            tracing::warn!(
+            // Debug, not warn: every path that produces `Unresolved` already logs its own cause
+            // at the appropriate level (bad-sig, exhausted retry window and watch timeout all
+            // warn in `submit_one`; the benign txpool races log at info). Reaching here says
+            // nothing new, and the actionable case — the height *not* finalizing after the
+            // bounded wait below — has its own warn. Keeping this at warn made a self-healing
+            // race (a same-nonce tx of ours still pending, code 1014) light up Grafana on every
+            // attestation round; cf. the `TransactionError::Invalid` arm above, demoted for the
+            // same reason.
+            tracing::debug!(
                 height,
                 "❓ submission outcome unresolved — unlocking height unless it finalizes shortly"
             );

--- a/attestor/attestor/src/tasks/validation.rs
+++ b/attestor/attestor/src/tasks/validation.rs
@@ -890,11 +890,16 @@ async fn submit_one(shared: &Arc<Shared>, agg: Aggregated) -> OutcomeInternal {
         .attestation()
         .commit_attestation(agg.attestation_signed.into());
     const POOL_INVALID_TX: i32 = 1010;
-    // Txpool refused to *replace* an in-pool tx with the same nonce ("Priority is too low").
-    // That in-pool tx is almost always our own earlier commit_attestation still pending
-    // (subxt's default nonce comes from chain state, not the pool, so a resubmission reuses
-    // the pending tx's nonce with equal-or-lower priority). Resubmitting cannot succeed until
-    // that tx resolves — retrying here spins at wire speed against a healthy node.
+    // Txpool refused to admit our tx alongside an in-pool one ("Priority is too low"). That
+    // in-pool tx is normally a *peer's* commit_attestation for the same attestation, not ours:
+    // `PrevalidateAttestationCommit` tags every admitted commit with
+    // `provides = (chain_key, digest)` precisely so the pool keeps one submission per
+    // attestation and the every-attestor-submits race is deduplicated at admission. All copies
+    // carry the default priority 0, and replacement needs strictly-greater priority, so
+    // whichever attestor arrives first wins and the rest land here. Resubmitting cannot succeed
+    // while that tx is pending — retrying would spin at wire speed against a healthy node.
+    // Losing this race costs nothing: we are rejected before fees, and the winner's stored
+    // `SignedAttestation` credits every signer in `attestors`, including us.
     const POOL_TOO_LOW_PRIORITY: i32 = 1014;
     // Pace the generic rpc-error retry arm. `Client::reconnect` succeeds instantly against a
     // healthy node (and a success resets its shared backoff), so without a pause a
@@ -965,14 +970,14 @@ async fn submit_one(shared: &Arc<Shared>, agg: Aggregated) -> OutcomeInternal {
                             return OutcomeInternal::Unresolved;
                         }
                         if obj.code() == POOL_TOO_LOW_PRIORITY {
-                            // A same-nonce tx (ours, still pending) already occupies the pool
-                            // slot — see POOL_TOO_LOW_PRIORITY. Same shape as the 1010 race:
-                            // Unresolved lets the handler's bounded wait observe it landing,
-                            // and unlocks the height if it never does.
+                            // A commit for this same `(chain_key, digest)` — normally a peer's,
+                            // see POOL_TOO_LOW_PRIORITY — already holds the pool slot. Same shape
+                            // as the 1010 race: Unresolved lets the handler's bounded wait
+                            // observe it landing, and unlocks the height if it never does.
                             tracing::info!(
                                 height,
                                 code = obj.code(),
-                                "🚦 same-nonce tx already pending in txpool — awaiting its resolution"
+                                "🚦 attestation already pending in txpool — lost the submit race, awaiting its resolution"
                             );
                             return OutcomeInternal::Unresolved;
                         }


### PR DESCRIPTION
# Description of proposed changes

Two small changes to `attestor/attestor/src/tasks/validation.rs`, both about the same
recurring log noise:

1. Demote `❓ submission outcome unresolved` from `warn!` to `debug!`.
2. Correct the comment (and one log message) that misattributed the cause of txpool code
   1014.

## Why the log level

On a healthy attestor this warns on **every attestation round** — every ~2 minutes — for a
condition that is both expected and self-healing:

```
🚦 same-nonce tx already pending in txpool — awaiting its resolution height=25653620 code=1014  [INFO]
❓ submission outcome unresolved — unlocking height unless it finalizes shortly height=25653620  [WARN]
💾 cc3 finalized height=25653620 digest=0x4afe…                                                 [INFO]
```

Three reasons the `warn!` earns nothing:

1. **Every producer of `Outcome::Unresolved` already logs its own cause at the right level.**
   In `submit_one`, bad-signature, exhausted retry window and watch timeout all `warn!`; the
   benign txpool races (1010/1014) log at `info!`. Reaching the handler adds no information —
   and in the 1014 case we log the cause at `info` and the effect at `warn` one line later.
2. **The actionable case has its own warning.** If the height still hasn't finalized after the
   bounded `wait_finalized`, `🔓 height not finalized after unresolved submission — unlocking`
   fires at `warn!`. That is the line worth alerting on, and it is absent from healthy logs.
3. **Precedent in the same `match`.** The `TransactionError::Invalid` arm was already demoted
   with the comment *"Demote to info so Grafana doesn't light up on a known harmless outcome."*

## Why the comment was wrong

The comment above `POOL_TOO_LOW_PRIORITY` claimed the conflicting in-pool transaction is
"almost always our own earlier `commit_attestation`" reusing a nonce that subxt derives from
chain state. That sent me down a nonce-management rabbit hole before I read
`pallets/attestation/src/extensions.rs`.

What actually happens is by design. `PrevalidateAttestationCommit::validate` tags every
admitted commit with `provides = (IDENTIFIER, chain_key, digest)` *specifically* so the pool
holds at most one pending submission per attestation and the every-attestor-submits race is
deduplicated at admission rather than letting every copy broadcast and race to dispatch. All
copies carry the default priority 0, and replacing an in-pool transaction requires
strictly-greater priority, so whichever attestor arrives first wins deterministically and
every other one gets 1014 — conflicting with a **peer's** transaction, not its own. The
sibling 1010 `detail=Transaction is outdated` is the same extension returning
`InvalidTransaction::Stale` for a race loser whose height is already attested.

Losing that race costs nothing, which is the point of doing it at admission: race losers are
rejected **before fees**, and the winner's stored `SignedAttestation` credits every signer in
`attestors`, so a node that votes but never submits still participates. (`commit_attestation`
is also `Pays::No` for the winner.)

The log message itself said "same-nonce tx already pending", which is what misled me, so it is
reworded to "attestation already pending in txpool — lost the submit race". I checked that no
CI job, script or test greps for either string.

## Notes

- CI runs the attestor at `RUST_LOG=debug`, so the demoted line is still captured where the
  detail is useful; production at `RUST_LOG=info` goes quiet.
- `.github/check-logs-for-error.sh` only counts `ERROR:`, so none of this affected the log gate.
- No behaviour change: log levels and comments only.
