### PR TITLE
fix(ci): allowlist the WS-protocol variant of anvil restart noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -671,12 +671,18 @@ jobs:
           #   * the alloy WS consumer itself, under alloy_transport_ws / alloy_pubsub; and
           #   * stream_eth's reconnect path, which logs "Eth connection error" wrapping the same
           #     "IO error: Connection reset by peer (os error 104)" / "... refused (os error 111)".
-          # Allowlist ONLY those two documented OS errors, and ONLY from those known reconnect
+          # Killing anvil mid-connection also surfaces one step *above* the socket layer: when the
+          # peer vanishes without sending a WS close frame, tungstenite reports the protocol error
+          # "Connection reset without closing handshake" instead of a raw os error, and
+          # alloy_transport_ws logs it as "WS connection error". Same benign restart, different
+          # layer — so it is enumerated here too rather than left to fail the gate intermittently
+          # (which layer wins is a race between anvil's exit and the read syscall).
+          # Allowlist ONLY these three documented errors, and ONLY from those known reconnect
           # sources, scoped to THIS step via ERROR_ALLOWLIST so the shared gate stays strict
           # everywhere else (e.g. the archiver-testing job, which never restarts eth). Any other
           # error from those sources still fails the gate; functional correctness is asserted
           # separately (checkpoint compare).
-          export ERROR_ALLOWLIST='(alloy_transport_ws|alloy_pubsub|stream_eth|Eth connection error).*(Connection reset by peer \(os error 104\)|Connection refused \(os error 111\))'
+          export ERROR_ALLOWLIST='(alloy_transport_ws|alloy_pubsub|stream_eth|Eth connection error).*(Connection reset by peer \(os error 104\)|Connection refused \(os error 111\)|Connection reset without closing handshake)'
           .github/check-logs-for-error.sh /var/tmp/integration-test-attestor-network/archiver.log
 
       - name: Check attestor logs for errors


### PR DESCRIPTION
# Description of proposed changes

Follow-up to #1217. Adds one more documented error to the archiver log-gate allowlist in the
`integration-test-attestator-network` job.

## The failure

That test restarts anvil on purpose to exercise recovery, and #1217 allowlisted the archiver's
resulting reconnect noise — but only the two raw socket errors:

```
(alloy_transport_ws|alloy_pubsub|stream_eth|Eth connection error).*(Connection reset by peer \(os error 104\)|Connection refused \(os error 111\))
```

Killing anvil mid-connection can instead surface one layer *above* the socket. When the peer
vanishes without sending a WebSocket close frame, tungstenite reports a protocol error rather
than an `os error`, and `alloy_transport_ws` logs it as:

```
ERROR alloy_transport_ws::native: WS connection error err=WebSocket protocol error: Connection reset without closing handshake
```

That slips past the allowlist and fails the gate. Which layer wins is a race between anvil's
exit and the archiver's read syscall, so this is intermittent rather than deterministic — it
took down an unrelated PR's CI here:
https://github.com/gluwa/creditcoin3/actions/runs/30644526852/job/91209993919

## The change

Enumerates `Connection reset without closing handshake` as a third allowed error, and documents
why it exists in the step comment.

Deliberately *not* broadened further:

- Still anchored to the same known reconnect sources (`alloy_transport_ws`, `alloy_pubsub`,
  `stream_eth`, `Eth connection error`).
- Still an explicit enumeration of specific messages, not "any error from those sources".
- Still scoped to this one step via `ERROR_ALLOWLIST`, so every other caller of
  `check-logs-for-error.sh` — `archiver-testing`, `cc3-indexer-testing`, and the
  attestor/validator compatibility jobs — keeps the strict gate. `grep -rn ERROR_ALLOWLIST`
  confirms this step is its only user.

## Verification

Checked the regex against the real log line and against near-miss negatives. The three benign
reconnect lines are allowlisted, while all of these still correctly fail the gate:

| line | still flagged |
| --- | --- |
| `ERROR archiver::store: failed to persist checkpoint err=disk full` | yes |
| `ERROR alloy_transport_ws::native: WS connection error err=WebSocket protocol error: Handshake not finished` | yes |
| `ERROR stream_eth: Eth connection error err=invalid merkle root` | yes |
| `ERROR some_other_mod: Connection reset without closing handshake` | yes |

Note the second row: a *different* WS protocol error from the same source is still caught, so
this only exempts the one abrupt-close message. YAML parses clean; functional correctness of the
test remains asserted separately by the checkpoint compare.
