### PR TITLE
chore(attestor): demote the external-finalization watch-release log to debug

### DIFF
--- a/attestor/attestor/src/tasks/validation.rs
+++ b/attestor/attestor/src/tasks/validation.rs
@@ -1025,12 +1025,22 @@ async fn submit_one(shared: &Arc<Shared>, agg: Aggregated) -> OutcomeInternal {
     // node's txpool retains it independently of the watch. The nonce burns either way. The next
     // height's submission can race a still-in-mempool tx and surface as a `Future` (nonce gap)
     // or duplicate-nonce rejection on the next round; both paths self-recover via the
-    // `bad_signature`/reconnect arm in `submit_one`. Logged at WARN so the pattern is visible.
+    // `bad_signature`/reconnect arm in `submit_one`.
+    //
+    // Levels differ between the two non-`watch` arms because their meanings differ. Arm 2 is the
+    // expected outcome of losing the submit race — `PrevalidateAttestationCommit` tags commits
+    // with `provides = (chain_key, digest)` so exactly one attestor's submission per attestation
+    // is admitted, and the height finalizing from a peer's copy is the designed steady state. It
+    // resolves to `Outcome::Finalized`, which is deliberately excluded from
+    // `should_unlock_if_unfinalized` (no recovery is needed) and which the handler already
+    // reports as `✅ finalized externally` at INFO — so this line is mechanism detail and logs at
+    // DEBUG. Arm 3 keeps WARN: both upstream signals being stuck for `ATTESTATION_TIMEOUT` is
+    // genuinely anomalous.
     let watch = submit_handle.wait_for_finalized_success();
     tokio::select! {
         result = watch => OutcomeInternal::Eligible(result),
         () = await_block_attested(shared, height) => {
-            tracing::warn!(
+            tracing::debug!(
                 height,
                 "📡 height observed finalized externally — releasing watch (our submitted tx may still land; nonce burns either way)"
             );


### PR DESCRIPTION
# Description of proposed changes

Follow-up to #1225, same reasoning applied to the sibling arm. Demotes

```
WARN attestor::tasks::validation: 📡 height observed finalized externally — releasing watch
     (our submitted tx may still land; nonce burns either way) height=11390780
```

from `warn!` to `debug!` in `submit_one`'s `select!`.

## Why

**It is the designed steady state, not an anomaly.** `PrevalidateAttestationCommit::validate`
tags every admitted `commit_attestation` with `provides = (chain_key, digest)` precisely so the
pool keeps one submission per attestation. Every attestor produces the same digest for a height,
so exactly one copy is admitted and the height finalizes from whichever won. On every losing
side, this arm fires — which is most rounds, for most attestors.

**Nothing actionable is reported.** The arm resolves to `Outcome::Finalized`, which is
deliberately excluded from `should_unlock_if_unfinalized` (there is a unit test pinning that at
`validation.rs:1148`), so no recovery path runs — the height finalized and the pipeline moved on.

**The outcome is already logged at the right level.** `handle_submission_result` reports
`✅ finalized externally` at INFO one line later. So this is the mechanism detail behind an
already-reported outcome — exactly the cause-at-warn / effect-at-info inversion #1225 fixed for
`Outcome::Unresolved`.

Note the argument does not depend on whether our own pending transaction later lands: even if it
does, the comment above the `select!` already states both such paths self-recover, so a
per-occurrence warn is the wrong tool either way.

## Deliberately unchanged

- **The sibling timeout arm keeps `warn!`.** Both upstream signals stuck for
  `ATTESTATION_TIMEOUT` (120s) is genuinely anomalous and worth surfacing. The updated comment
  now records why the two arms differ, replacing the stale "Logged at WARN so the pattern is
  visible" sentence.
- **The message text is untouched**, including the `nonce burns either way` parenthetical — see
  below.

## One thing worth a reviewer's eye

I am not convinced the surrounding comment's premise still holds, and I did **not** change it
because I could not verify it. It claims "The nonce burns either way" and that the next round
sees "a `Future` (nonce gap) or duplicate-nonce rejection".

Given the `provides`-tag dedup, a race loser's pending transaction should be revalidated after
the peer's copy lands, at which point `PrevalidateAttestationCommit` returns
`InvalidTransaction::Stale` (`extensions.rs:141`, via `check_duplicate`'s strictly-monotonic
height check) and the pool drops it — never included, so no nonce consumed and no fee. If that
is right, the nonce does not burn on this path and the parenthetical is misleading.

That reasoning is about txpool revalidation internals, so I would rather someone who knows them
confirm it than assert it here — #1225 already had to correct one confidently-wrong mechanism
claim in this same area. Happy to follow up with a message/comment fix once it is settled; it
does not affect the log-level change either way.

## Notes

- No CI job, script or test greps for this string (checked `.github/`, `scripts/`, `cli/src`).
- CI runs the attestor at `RUST_LOG=debug`, so the line is still captured where it is useful;
  production at `RUST_LOG=info` goes quiet.
- No behaviour change: one log level and one comment.
