### PR TITLE
feat(attestor): hot-reload the Outbox listener on factory/Outbox rotation

### DIFF
--- a/attestor/attestor/src/tasks/write_ability/listener.rs
+++ b/attestor/attestor/src/tasks/write_ability/listener.rs
@@ -157,7 +157,14 @@ fn pick_to_block(
 #[derive(Clone, Debug)]
 pub struct IndexedMessage {
     pub message_id: B256,
+    /// The dApp that published the message (`MessagePublished.emitterAddress`) — **not** the Outbox.
     pub emitter: Address,
+    /// Outbox this was observed on. Carried so a consumer can tell whether the message still belongs
+    /// to the active Outbox: on a governance/factory rotation the old listener is aborted, but
+    /// messages it already queued stay buffered in the channel and would otherwise be signed against
+    /// a superseded Outbox. `message_hash` is Outbox-independent, so provenance cannot be recovered
+    /// from it downstream.
+    pub outbox: Address,
     pub payload: Vec<u8>,
     /// `keccak256(abi.encode(...))` — the digest the attestor signs (PoC §5.2).
     pub message_hash: B256,
@@ -470,6 +477,7 @@ async fn scan_range<P: Provider>(
                 let indexed = IndexedMessage {
                     message_id: decoded.data.messageId,
                     emitter,
+                    outbox: resolved.address,
                     payload,
                     message_hash: hash,
                 };

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -975,11 +975,16 @@ async fn run_outbox_monitor<P: Provider>(
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
     let mut active = Some(current);
+    // The factory the active Outbox was resolved from. The pause decision compares the cursor's
+    // live factory against THIS — never against the cursor's value on the previous tick: `resolve`
+    // records a governance transition into the cursor as soon as it reads the new registration, so
+    // an attempt that then fails (RPC error / timeout) would have already consumed the transition,
+    // and a tick-to-tick comparison would keep signing the superseded Outbox forever (bugbot).
+    let mut active_factory = cursor.factory();
     loop {
         tokio::select! {
             () = token.cancelled() => return,
             _ = tick.tick() => {
-                let previous_factory = cursor.factory();
                 // Same per-attempt bound as the activation loop: an unbounded resolve against a
                 // black-holed RPC would wedge rotation detection silently (the chunked cursor keeps
                 // whatever progress the attempt made, so a timeout costs nothing).
@@ -993,37 +998,74 @@ async fn run_outbox_monitor<P: Provider>(
                         "Outbox rotation check RPC attempt timed out after {RPC_ATTEMPT_TIMEOUT:?}"
                     ))
                 });
-                match attempt {
-                    Ok(Some(next)) if active.map(|current| current.address) != Some(next.address) => {
+                match rotation_action(&attempt, active.map(|o| o.address), active_factory, cursor.factory()) {
+                    RotationAction::Swap(next) => {
                         tracing::info!(
                             old = ?active.map(|outbox| outbox.address),
                             new = %next.address,
                             "🧭 replacement Outbox resolved"
                         );
                         active = Some(next);
+                        active_factory = cursor.factory();
                         if resolved_tx.send(Some(next)).is_err() {
                             return;
                         }
                     }
-                    Ok(Some(_)) => {}
-                    Ok(None) if cursor.factory() != previous_factory && active.is_some() => {
+                    RotationAction::KeepCurrent => {
+                        active_factory = cursor.factory();
+                    }
+                    RotationAction::Pause => {
                         tracing::warn!(
                             old = ?active.map(|outbox| outbox.address),
                             new_factory = ?cursor.factory(),
                             "Outbox factory changed without a finalized replacement — pausing signing"
                         );
                         active = None;
+                        active_factory = cursor.factory();
                         if resolved_tx.send(None).is_err() {
                             return;
                         }
                     }
-                    Ok(None) => {}
-                    Err(err) => {
-                        tracing::warn!(error = %format!("{err:#}"), "Outbox rotation check failed; will retry");
-                    }
+                    RotationAction::Nothing => {}
+                }
+                if let Err(err) = attempt {
+                    tracing::warn!(error = %format!("{err:#}"), "Outbox rotation check failed; will retry");
                 }
             }
         }
+    }
+}
+
+/// What one rotation-monitor tick should do. Pure so the consumed-transition case is testable.
+#[derive(Debug, PartialEq)]
+enum RotationAction {
+    /// A different Outbox resolved — hot-swap the listener to it.
+    Swap(resolver::ResolvedOutbox),
+    /// The active Outbox re-resolved — just refresh the factory it is attributed to.
+    KeepCurrent,
+    /// The registered factory no longer matches the active Outbox's and no replacement has
+    /// resolved — publish `None` so signing stops on the superseded Outbox.
+    Pause,
+    Nothing,
+}
+
+/// Pause fires on `cursor_factory != active_factory` even when the attempt ERRORED: the cursor's
+/// factory only changes when `resolve` actually read a different registered factory on-chain, so a
+/// scan failure after that read must not mask the transition (it would otherwise never re-fire —
+/// the cursor keeps the new factory, and later ticks would see no further change).
+fn rotation_action(
+    attempt: &anyhow::Result<Option<resolver::ResolvedOutbox>>,
+    active: Option<Address>,
+    active_factory: Option<Address>,
+    cursor_factory: Option<Address>,
+) -> RotationAction {
+    match attempt {
+        Ok(Some(next)) if active != Some(next.address) => RotationAction::Swap(*next),
+        Ok(Some(_)) => RotationAction::KeepCurrent,
+        Ok(None) | Err(_) if active.is_some() && cursor_factory != active_factory => {
+            RotationAction::Pause
+        }
+        Ok(None) | Err(_) => RotationAction::Nothing,
     }
 }
 
@@ -1240,4 +1282,88 @@ async fn handle_reobservation<P: alloy::providers::Provider>(
         "♻️ re-signing reobserved message"
     );
     produce_vote(state, metrics, signer, our_address, chain_key, indexed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::address;
+
+    fn outbox(addr: Address) -> resolver::ResolvedOutbox {
+        resolver::ResolvedOutbox {
+            address: addr,
+            destination_chain_key: B256::ZERO,
+            creditcoin_chain_id: 42,
+            created_at_block: Some(1),
+        }
+    }
+
+    const OUTBOX_A: Address = address!("00000000000000000000000000000000000000aa");
+    const OUTBOX_B: Address = address!("00000000000000000000000000000000000000bb");
+    const FACTORY_1: Address = address!("00000000000000000000000000000000000000f1");
+    const FACTORY_2: Address = address!("00000000000000000000000000000000000000f2");
+
+    // The bugbot case this module exists for: `resolve` records the governance transition into the
+    // cursor (F1 -> F2) and then the SAME attempt fails, so the transition never coincides with a
+    // clean `Ok(None)`. A tick-to-tick factory comparison consumes it; comparing against the
+    // active Outbox's factory must keep firing until the pause actually happens.
+    #[test]
+    fn pause_survives_a_transition_consumed_by_a_failed_attempt() {
+        // Tick N: cursor already moved to F2, attempt errored (scan failed after the factory read).
+        let attempt: anyhow::Result<Option<resolver::ResolvedOutbox>> =
+            Err(anyhow!("eth_getLogs failed"));
+        assert_eq!(
+            rotation_action(&attempt, Some(OUTBOX_A), Some(FACTORY_1), Some(FACTORY_2)),
+            RotationAction::Pause,
+        );
+
+        // Tick N+1: clean Ok(None) — with the tick-to-tick rule this saw "no change" and kept
+        // signing forever; against the active factory it still pauses.
+        let attempt: anyhow::Result<Option<resolver::ResolvedOutbox>> = Ok(None);
+        assert_eq!(
+            rotation_action(&attempt, Some(OUTBOX_A), Some(FACTORY_1), Some(FACTORY_2)),
+            RotationAction::Pause,
+        );
+    }
+
+    #[test]
+    fn routine_failures_and_quiet_ticks_do_nothing() {
+        let err: anyhow::Result<Option<resolver::ResolvedOutbox>> = Err(anyhow!("rpc blip"));
+        assert_eq!(
+            rotation_action(&err, Some(OUTBOX_A), Some(FACTORY_1), Some(FACTORY_1)),
+            RotationAction::Nothing,
+        );
+        let none: anyhow::Result<Option<resolver::ResolvedOutbox>> = Ok(None);
+        assert_eq!(
+            rotation_action(&none, Some(OUTBOX_A), Some(FACTORY_1), Some(FACTORY_1)),
+            RotationAction::Nothing,
+        );
+        // Nothing active (already paused, or never resolved) — nothing to pause.
+        assert_eq!(
+            rotation_action(&none, None, None, Some(FACTORY_2)),
+            RotationAction::Nothing,
+        );
+    }
+
+    #[test]
+    fn replacement_swaps_and_same_outbox_keeps_current() {
+        let next = outbox(OUTBOX_B);
+        let attempt: anyhow::Result<Option<resolver::ResolvedOutbox>> = Ok(Some(next));
+        assert_eq!(
+            rotation_action(&attempt, Some(OUTBOX_A), Some(FACTORY_1), Some(FACTORY_2)),
+            RotationAction::Swap(next),
+        );
+        // Resuming from a pause is a swap too (nothing was active).
+        assert_eq!(
+            rotation_action(&attempt, None, None, Some(FACTORY_2)),
+            RotationAction::Swap(next),
+        );
+        // Same address re-resolved (e.g. a new factory adopting the same Outbox): keep signing,
+        // but re-attribute the active Outbox to the cursor's factory.
+        let same: anyhow::Result<Option<resolver::ResolvedOutbox>> = Ok(Some(outbox(OUTBOX_A)));
+        assert_eq!(
+            rotation_action(&same, Some(OUTBOX_A), Some(FACTORY_1), Some(FACTORY_2)),
+            RotationAction::KeepCurrent,
+        );
+    }
 }

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -39,7 +39,7 @@ use alloy::primitives::{Address, B256};
 use alloy::providers::{Provider, ProviderBuilder};
 use anyhow::anyhow;
 use parking_lot::{Mutex, RwLock};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use zeroize::Zeroizing;
 
 use write_ability::envelope::{MessageVote, ReobservationRequest, SetUpdateVote};
@@ -447,8 +447,8 @@ pub async fn run(
     // Resolve the Outbox, retrying until it's available rather than disabling for the whole run:
     // an attestor can be started before the factory/Outbox is registered on-chain and will activate
     // write-ability automatically once they are, with no restart. While unresolved it just keeps
-    // doing block attestation. (Polling is simpler and more robust than event subscription; picking
-    // up a later Outbox *re-registration* mid-run remains a finer-grained TODO in resolver.rs.)
+    // doing block attestation. The discovery cursor stays live after activation in
+    // `run_outbox_monitor`, which detects factory and Outbox rotations with the same polling.
     let mut resolve_attempts: u64 = 0;
     let mut consecutive_resolve_failures: u64 = 0;
     // Discovery cursor: advances past confirmed blocks already scanned for `OutboxCreated` so each
@@ -635,18 +635,44 @@ pub async fn run(
         path = %cursor_store.path().display(),
         "🗂️ persisting Outbox scan cursor across restarts"
     );
-    let mut listener = tokio::spawn(async move {
+    let listener_tx = tx.clone();
+    let listener = tokio::spawn(async move {
         listener::watch(
             &listener_provider,
             resolved,
             confirmation_depth,
             scan_from,
             cursor_store,
-            tx,
+            listener_tx,
             listener_token,
         )
         .await
     });
+
+    // One live resolved-Outbox view feeds both the supervision loop below and the reobservation
+    // worker. The monitor inherits the discovery cursor from initial activation, so it scans only
+    // new finalized factory events — and starts over from genesis automatically when governance
+    // re-points the chain key at a different factory.
+    let (resolved_tx, mut resolved_rx) = watch::channel(Some(resolved));
+    let mut outbox_monitor = {
+        let provider = provider.clone();
+        let cfg = cfg.clone();
+        let token = shared.token.clone();
+        let destination_chain_key = state.destination_chain_key;
+        tokio::spawn(run_outbox_monitor(
+            provider,
+            cfg,
+            destination_chain_key,
+            outbox_cursor,
+            resolved,
+            resolved_tx,
+            token,
+        ))
+    };
+    // `listener` becomes `None` during a rotation gap (factory changed, replacement Outbox not yet
+    // finalized); `active_outbox` mirrors the last value taken from the watch for log context.
+    let mut listener = Some(listener);
+    let mut active_outbox = Some(resolved);
 
     // Reobservation runs in its OWN task, NOT inline in this loop (audit P1-4): its tip + eth_getLogs
     // RPCs (deadline-bounded, serial) must not be able to stall vote production / message ingestion
@@ -657,9 +683,10 @@ pub async fn run(
         let state = state.clone();
         let shared = shared.clone();
         let signer = signer.clone();
+        let resolved_rx = resolved_rx.clone();
         tokio::spawn(run_reobservation_worker(
             provider,
-            resolved,
+            resolved_rx,
             state,
             shared,
             signer,
@@ -678,11 +705,35 @@ pub async fn run(
         // still picked promptly (graceful shutdown tolerates finishing one in-flight item first).
         tokio::select! {
             () = shared.token.cancelled() => break,
+            joined = async { listener.as_mut().expect("branch guarded by listener.is_some()").await }, if listener.is_some() => {
+                // A clean `Ok(())` here during shutdown is the listener obeying the cancel token,
+                // not an early exit; the same applies to every sibling arm below.
+                if shared.token.is_cancelled() {
+                    break;
+                }
+                let err = match joined {
+                    Ok(Ok(())) => anyhow!("outbox listener exited without error or shutdown"),
+                    Ok(Err(err)) => err.context("outbox listener died"),
+                    Err(join_err) => anyhow!("outbox listener panicked: {join_err}"),
+                };
+                outbox_monitor.abort();
+                reobs_worker.abort();
+                if let Some(w) = &set_watcher {
+                    w.abort();
+                }
+                if let Some(p) = &set_update_proposer {
+                    p.abort();
+                }
+                return Err(Error::WriteAbility(err));
+            }
             joined = wait_for_optional_child(&mut set_watcher) => {
                 if shared.token.is_cancelled() {
                     break;
                 }
-                listener.abort();
+                if let Some(l) = &listener {
+                    l.abort();
+                }
+                outbox_monitor.abort();
                 reobs_worker.abort();
                 if let Some(p) = &set_update_proposer {
                     p.abort();
@@ -693,7 +744,10 @@ pub async fn run(
                 if shared.token.is_cancelled() {
                     break;
                 }
-                listener.abort();
+                if let Some(l) = &listener {
+                    l.abort();
+                }
+                outbox_monitor.abort();
                 reobs_worker.abort();
                 if let Some(w) = &set_watcher {
                     w.abort();
@@ -704,7 +758,10 @@ pub async fn run(
                 if shared.token.is_cancelled() {
                     break;
                 }
-                listener.abort();
+                if let Some(l) = &listener {
+                    l.abort();
+                }
+                outbox_monitor.abort();
                 if let Some(w) = &set_watcher {
                     w.abort();
                 }
@@ -713,27 +770,117 @@ pub async fn run(
                 }
                 return Err(Error::WriteAbility(child_exit_error("reobservation worker", joined)));
             }
-            maybe = rx.recv() => {
-                let Some(indexed) = maybe else {
-                    // On shutdown a closed channel is expected, not a fault: every cancel path in
-                    // `watch` returns `Ok(())` and drops the sole sender, so this arm becomes ready
-                    // at the same time as the cancel branch above and `select!` picks between them
-                    // at random. Losing that race must not be reported as an abnormal exit.
+            joined = &mut outbox_monitor => {
+                if shared.token.is_cancelled() {
+                    break;
+                }
+                if let Some(l) = &listener {
+                    l.abort();
+                }
+                reobs_worker.abort();
+                if let Some(w) = &set_watcher {
+                    w.abort();
+                }
+                if let Some(p) = &set_update_proposer {
+                    p.abort();
+                }
+                return Err(Error::WriteAbility(child_exit_error("Outbox rotation monitor", joined)));
+            }
+            changed = resolved_rx.changed() => {
+                if changed.is_err() {
+                    // The monitor drops the sender when it returns on cancel, so this is the same
+                    // clean-exit-during-shutdown race as the sibling arms above.
                     if shared.token.is_cancelled() {
                         break;
                     }
-                    // Otherwise the listener really did exit early. Harvest its result and surface
+                    if let Some(l) = &listener {
+                        l.abort();
+                    }
+                    reobs_worker.abort();
+                    if let Some(w) = &set_watcher {
+                        w.abort();
+                    }
+                    if let Some(p) = &set_update_proposer {
+                        p.abort();
+                    }
+                    return Err(Error::WriteAbility(anyhow!(
+                        "Outbox rotation monitor channel closed unexpectedly"
+                    )));
+                }
+                let next = *resolved_rx.borrow_and_update();
+
+                // Stop the old scanner before starting the new one: both cursor stores live in the
+                // same per-chain state directory, so letting the writers overlap during the swap
+                // would race. Awaiting the aborted task closes that window.
+                if let Some(old_listener) = listener.take() {
+                    old_listener.abort();
+                    let _ = old_listener.await;
+                }
+                let old_outbox = active_outbox.map(|outbox| outbox.address);
+                active_outbox = next;
+
+                if let Some(resolved) = next {
+                    tracing::warn!(
+                        ?old_outbox,
+                        new_outbox = %resolved.address,
+                        "🔄 governance/factory rotation detected — switching Outbox listener"
+                    );
+                    let listener_provider = provider.clone();
+                    let listener_token = shared.token.clone();
+                    let cursor_store = cursor::CursorStore::new(
+                        &cfg.state_dir,
+                        cfg.write_ability_chain_key,
+                        resolved.address,
+                    );
+                    let listener_tx = tx.clone();
+                    // Start the replacement listener at the new Outbox's creation height, not at the
+                    // boot-time `scan_from`. Its cursor file is keyed by address so there is nothing
+                    // persisted to resume from, and governance can point a chain key at an Outbox
+                    // created *before* this process booted — whose earlier `MessagePublished` events
+                    // would then sit below `scan_from` and never be scanned. Falling back to
+                    // `scan_from` only when the log carried no block number keeps the old behaviour
+                    // for that (not normally reachable) case.
+                    let swap_start = resolved.created_at_block.or(scan_from);
+                    listener = Some(tokio::spawn(async move {
+                        listener::watch(
+                            &listener_provider,
+                            resolved,
+                            confirmation_depth,
+                            swap_start,
+                            cursor_store,
+                            listener_tx,
+                            listener_token,
+                        )
+                        .await
+                    }));
+                } else {
+                    tracing::warn!(
+                        ?old_outbox,
+                        "⏸️ Outbox factory changed or was removed without a finalized replacement Outbox — signing paused"
+                    );
+                }
+            }
+            maybe = rx.recv() => {
+                let Some(indexed) = maybe else {
+                    // Unreachable while this task holds `tx` for rotation respawns, but kept
+                    // defensively: a closed channel during shutdown is expected, not a fault.
+                    if shared.token.is_cancelled() {
+                        break;
+                    }
+                    // Otherwise a listener really did exit early. Harvest its result and surface
                     // the underlying error to the supervisor — otherwise it would only see a generic
-                    // early-Ok exit and the failure reason would be lost.
-                    let err = match (&mut listener).await {
-                        Ok(Ok(())) => anyhow!("outbox listener exited without error or shutdown"),
-                        Ok(Err(err)) => err.context("outbox listener died"),
-                        Err(join_err) => anyhow!("outbox listener panicked: {join_err}"),
+                    // early-Ok exit and the failure reason would be lost. Abort every sibling task
+                    // before surfacing the error — dropping a `JoinHandle` here would only detach
+                    // it, leaving it running until the shared cancel token eventually fires.
+                    let err = match listener.take() {
+                        Some(handle) => match handle.await {
+                            Ok(Ok(())) => anyhow!("outbox listener exited without error or shutdown"),
+                            Ok(Err(err)) => err.context("outbox listener died"),
+                            Err(join_err) => anyhow!("outbox listener panicked: {join_err}"),
+                        },
+                        None => anyhow!("Outbox message channel closed while no listener was running"),
                     };
-                    // Abort every sibling task before surfacing the error, including the
-                    // reobservation worker — dropping its `JoinHandle` here would only detach it,
-                    // leaving it running against the now-dead listener until the shared cancel
-                    // token eventually fires.
+                    outbox_monitor.abort();
                     reobs_worker.abort();
                     if let Some(w) = &set_watcher {
                         w.abort();
@@ -743,12 +890,44 @@ pub async fn run(
                     }
                     return Err(Error::WriteAbility(err));
                 };
-                produce_vote(&state, &shared.metrics, &signer, our_address, chain_key, indexed);
+                // Aborting the old listener does not drain what it already queued, so after a
+                // rotation the channel can still hold messages observed on the superseded Outbox.
+                // Signing those would contradict the pause above (and the reobservation worker,
+                // which already refuses to serve requests while no Outbox is active), so gate on
+                // provenance rather than on the fact that a message arrived.
+                //
+                // Compare against the *live* watch value, not the `active_outbox` cache: this arm
+                // and the rotation arm are both ready when a rotation lands, so if this one wins
+                // the cache is still one rotation behind and would wave the stale message through.
+                let current = *resolved_rx.borrow();
+                match current {
+                    Some(active) if active.address == indexed.outbox => {
+                        produce_vote(&state, &shared.metrics, &signer, our_address, chain_key, indexed);
+                    }
+                    Some(active) => {
+                        tracing::warn!(
+                            message_id = %indexed.message_id,
+                            observed_on = %indexed.outbox,
+                            active_outbox = %active.address,
+                            "dropping a message buffered from a superseded Outbox"
+                        );
+                    }
+                    None => {
+                        tracing::warn!(
+                            message_id = %indexed.message_id,
+                            observed_on = %indexed.outbox,
+                            "dropping a buffered message while no Outbox is active"
+                        );
+                    }
+                }
             }
         }
     }
 
-    listener.abort();
+    if let Some(listener) = listener {
+        listener.abort();
+    }
+    outbox_monitor.abort();
     reobs_worker.abort();
     if let Some(w) = set_watcher {
         w.abort();
@@ -779,6 +958,75 @@ fn child_exit_error(
     }
 }
 
+/// Continue resolving after activation and publish a new value whenever governance points the chain
+/// key at another factory or the active factory emits a replacement Outbox. A factory transition
+/// with no finalized replacement Outbox publishes `None` immediately so consumers stop signing the
+/// de-registered Outbox while discovery continues.
+async fn run_outbox_monitor<P: Provider>(
+    provider: P,
+    cfg: Config,
+    destination_chain_key: B256,
+    mut cursor: resolver::OutboxDiscoveryCursor,
+    current: resolver::ResolvedOutbox,
+    resolved_tx: watch::Sender<Option<resolver::ResolvedOutbox>>,
+    token: tokio_util::sync::CancellationToken,
+) {
+    let mut tick = tokio::time::interval(std::time::Duration::from_secs(OUTBOX_RESOLVE_RETRY_SECS));
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    let mut active = Some(current);
+    loop {
+        tokio::select! {
+            () = token.cancelled() => return,
+            _ = tick.tick() => {
+                let previous_factory = cursor.factory();
+                // Same per-attempt bound as the activation loop: an unbounded resolve against a
+                // black-holed RPC would wedge rotation detection silently (the chunked cursor keeps
+                // whatever progress the attempt made, so a timeout costs nothing).
+                let attempt = tokio::time::timeout(
+                    RPC_ATTEMPT_TIMEOUT,
+                    resolver::resolve(&provider, &cfg, destination_chain_key, &mut cursor),
+                )
+                .await
+                .unwrap_or_else(|_| {
+                    Err(anyhow!(
+                        "Outbox rotation check RPC attempt timed out after {RPC_ATTEMPT_TIMEOUT:?}"
+                    ))
+                });
+                match attempt {
+                    Ok(Some(next)) if active.map(|current| current.address) != Some(next.address) => {
+                        tracing::info!(
+                            old = ?active.map(|outbox| outbox.address),
+                            new = %next.address,
+                            "🧭 replacement Outbox resolved"
+                        );
+                        active = Some(next);
+                        if resolved_tx.send(Some(next)).is_err() {
+                            return;
+                        }
+                    }
+                    Ok(Some(_)) => {}
+                    Ok(None) if cursor.factory() != previous_factory && active.is_some() => {
+                        tracing::warn!(
+                            old = ?active.map(|outbox| outbox.address),
+                            new_factory = ?cursor.factory(),
+                            "Outbox factory changed without a finalized replacement — pausing signing"
+                        );
+                        active = None;
+                        if resolved_tx.send(None).is_err() {
+                            return;
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        tracing::warn!(error = %format!("{err:#}"), "Outbox rotation check failed; will retry");
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Reobservation responder, run as its own task (audit P1-4). Consumes verified-on-request pull
 /// requests off `reobs_rx`, re-fetches + re-signs one at a time under a wall-clock deadline, so a
 /// slow/black-holed RPC can never stall the main write-ability loop (vote production + ingestion).
@@ -787,7 +1035,7 @@ fn child_exit_error(
 #[allow(clippy::too_many_arguments)]
 async fn run_reobservation_worker<P: alloy::providers::Provider>(
     provider: P,
-    resolved: resolver::ResolvedOutbox,
+    mut resolved_rx: watch::Receiver<Option<resolver::ResolvedOutbox>>,
     state: Arc<MessageVoteState>,
     shared: Arc<Shared>,
     signer: signing::MessageSigner,
@@ -806,18 +1054,44 @@ async fn run_reobservation_worker<P: alloy::providers::Provider>(
                     tracing::debug!("reobservation channel closed — worker exiting");
                     return;
                 };
+                // `borrow_and_update`, not `borrow`: this snapshot must also mark the value seen.
+                // With a plain `borrow` a rotation that landed before this request was picked up
+                // leaves the receiver still flagged as changed, so the `changed()` branch below
+                // fires immediately and abandons work whose snapshot was already current — dropping
+                // the first recovery attempt after every rotation.
+                let Some(resolved) = *resolved_rx.borrow_and_update() else {
+                    tracing::warn!(message_id = ?request.message_id, "dropping reobservation request while no Outbox is active");
+                    continue;
+                };
                 let handle = handle_reobservation(
                     &provider, &resolved, &state, &shared.metrics, &signer, our_address, chain_key,
                     confirmation_depth, &mut limiter, request,
                 );
-                if tokio::time::timeout(reobservation::REOBS_RPC_TIMEOUT, handle)
-                    .await
-                    .is_err()
-                {
-                    tracing::warn!(
-                        "reobservation re-fetch exceeded {:?} — RPC unresponsive; dropping this request",
-                        reobservation::REOBS_RPC_TIMEOUT
-                    );
+                // The Outbox is snapshotted above, so a rotation part-way through would have us
+                // re-fetch and re-sign against the superseded address. Abandon the in-flight
+                // response instead of finishing it: reobservation is a pull-based recovery path, so
+                // the requester just asks again once the new listener is up, and the per-message
+                // rate limiter keeps that bounded.
+                tokio::select! {
+                    () = shared.token.cancelled() => return,
+                    changed = resolved_rx.changed() => {
+                        if changed.is_err() {
+                            tracing::debug!("Outbox rotation channel closed — reobservation worker exiting");
+                            return;
+                        }
+                        tracing::warn!(
+                            observed_on = %resolved.address,
+                            "abandoning an in-flight reobservation — the Outbox rotated mid-request"
+                        );
+                    }
+                    outcome = tokio::time::timeout(reobservation::REOBS_RPC_TIMEOUT, handle) => {
+                        if outcome.is_err() {
+                            tracing::warn!(
+                                "reobservation re-fetch exceeded {:?} — RPC unresponsive; dropping this request",
+                                reobservation::REOBS_RPC_TIMEOUT
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/attestor/attestor/src/tasks/write_ability/reobservation.rs
+++ b/attestor/attestor/src/tasks/write_ability/reobservation.rs
@@ -259,6 +259,7 @@ pub async fn reobserve<P: Provider>(
         return Ok(Some(IndexedMessage {
             message_id: decoded.data.messageId,
             emitter,
+            outbox: resolved.address,
             payload,
             message_hash: hash,
         }));

--- a/attestor/attestor/src/tasks/write_ability/resolver.rs
+++ b/attestor/attestor/src/tasks/write_ability/resolver.rs
@@ -13,11 +13,9 @@
 //! an attestor started before the factory/Outbox is registered activates automatically once they
 //! exist — no restart needed. It runs normal block attestation in the meantime.
 //!
-//! TODO(write-ability): pick up a later *re-registration* (factory address change / new Outbox)
-//! mid-run. The polling activation above only fires until the first successful resolve; reacting to
-//! changes after that would mean subscribing (via the cc3 client) to the `OutboxFactoryRegistered`
-//! event (`pallets/supported-chains/src/lib.rs`) and the `OutboxCreated` event
-//! (`common/write-ability/src/abi.rs`) and re-resolving.
+//! Resolution continues after activation: [`super::run_outbox_monitor`] polls this resolver with the
+//! same incremental cursor and hot-swaps the listener when governance changes the factory or the
+//! active factory emits a replacement Outbox.
 
 use alloy::primitives::{Address, B256};
 use alloy::providers::Provider;
@@ -51,6 +49,13 @@ pub struct ResolvedOutbox {
     pub destination_chain_key: B256,
     /// Creditcoin L1 EVM chain id (`eth_chainId`) bound into `messageHash`.
     pub creditcoin_chain_id: u64,
+    /// Block the binding `OutboxCreated` was emitted in, when the log reported one.
+    ///
+    /// A listener started for *this* Outbox needs no history before this height, and must not start
+    /// after it: on a hot swap the boot-time `start_block` is the wrong floor, because governance can
+    /// point a chain key at an Outbox that was created before this process booted, whose earlier
+    /// `MessagePublished` events would then never be scanned.
+    pub created_at_block: Option<u64>,
 }
 
 /// Caller-owned state for the incremental Outbox-discovery scan across activation retries. Tracks
@@ -63,11 +68,12 @@ pub struct OutboxDiscoveryCursor {
     from: u64,
     /// Factory the cursor was advanced against; a change resets `from` to 0.
     factory: Option<Address>,
-    /// Newest `OutboxCreated` address seen so far, carried across attempts. Progress and discovery
-    /// must advance together: `from` moves past each completed chunk, so keeping the match only in a
-    /// local would lose it whenever a *later* chunk failed — the next attempt would resume past the
-    /// event and report "no Outbox" forever (bugbot). Reset with `from` on a factory change.
-    found: Option<Address>,
+    /// Newest `OutboxCreated` (address, emitting block) seen so far, carried across attempts.
+    /// Progress and discovery must advance together: `from` moves past each completed chunk, so
+    /// keeping the match only in a local would lose it whenever a *later* chunk failed — the next
+    /// attempt would resume past the event and report "no Outbox" forever (bugbot). Reset with
+    /// `from` on a factory change.
+    found: Option<(Address, Option<u64>)>,
 }
 
 impl OutboxDiscoveryCursor {
@@ -76,6 +82,13 @@ impl OutboxDiscoveryCursor {
     /// is not mistaken for a dead RPC.
     pub(super) fn scanned_to(&self) -> u64 {
         self.from
+    }
+
+    /// Factory the current scan position belongs to. The rotation monitor uses this to distinguish
+    /// "no new Outbox event" from "governance changed/removed the factory and the replacement has
+    /// not emitted an Outbox yet".
+    pub(super) fn factory(&self) -> Option<Address> {
+        self.factory
     }
 }
 
@@ -98,7 +111,7 @@ pub async fn resolve<P: Provider>(
     // The Outbox address is resolved entirely on-chain from chain_key — never configured. `cursor`
     // is the caller-owned discovery state: it advances past already-scanned *confirmed* blocks so
     // repeated resolve retries don't re-scan the whole chain history (see `resolve_outbox_address`).
-    let Some(address) = resolve_outbox_address(
+    let Some((address, created_at_block)) = resolve_outbox_address(
         provider,
         chain_key,
         destination_chain_key,
@@ -119,6 +132,7 @@ pub async fn resolve<P: Provider>(
         address,
         destination_chain_key,
         creditcoin_chain_id,
+        created_at_block,
     }))
 }
 
@@ -137,7 +151,7 @@ async fn resolve_outbox_address<P: Provider>(
     _destination_chain_key: B256,
     confirmation_depth: u64,
     cursor: &mut OutboxDiscoveryCursor,
-) -> Result<Option<Address>> {
+) -> Result<Option<(Address, Option<u64>)>> {
     // 1. Outbox factory for this chain, from the chain-info precompile.
     let factory = IChainInfo::new(CHAIN_INFO_PRECOMPILE, provider)
         .get_outbox_factory_address(chain_key)
@@ -145,6 +159,12 @@ async fn resolve_outbox_address<P: Provider>(
         .await
         .context("chain-info precompile get_outbox_factory_address() reverted")?;
     if !factory.exists || factory.factoryAddr.is_zero() {
+        // Record removal as a real governance transition. Keeping the previous factory here would
+        // make the monitor interpret `Ok(None)` as merely "no new events" and continue signing the
+        // de-registered Outbox until another factory eventually appeared.
+        cursor.factory = None;
+        cursor.from = 0;
+        cursor.found = None;
         tracing::warn!(
             chain_key,
             "no Outbox factory registered on-chain for chain_key"
@@ -219,12 +239,12 @@ async fn resolve_outbox_address<P: Provider>(
             // Record into the cursor, not a local: this must survive an attempt that is abandoned
             // after this chunk (see `OutboxDiscoveryCursor::found`). `get_logs` returns ascending,
             // so the last log of the newest non-empty chunk stays the newest match overall.
-            cursor.found = Some(
-                IOutboxFactory::OutboxCreated::decode_log(&log.inner, true)
-                    .context("decode OutboxCreated log")?
-                    .data
-                    .outbox,
-            );
+            let outbox = IOutboxFactory::OutboxCreated::decode_log(&log.inner, true)
+                .context("decode OutboxCreated log")?
+                .data
+                .outbox;
+            // Keep the emitting block: it is the only floor a hot-swapped listener can trust.
+            cursor.found = Some((outbox, log.block_number));
         }
         from = chunk_to + 1;
         // Record progress per *chunk*, not per scan. A resolve attempt can be abandoned mid-loop
@@ -240,9 +260,12 @@ async fn resolve_outbox_address<P: Provider>(
     // `from` is `safe_tip + 1` when the loop ran, or unchanged (`cursor.from`) if
     // `safe_tip < cursor.from` (tip regressed / depth grew) — never regressing the cursor.
     cursor.from = cursor.from.max(from);
-    if let Some(outbox) = cursor.found {
-        tracing::info!(%factory, %outbox, chain_key, "🧭 resolved Outbox on-chain (OutboxCreated scan)");
-        return Ok(Some(outbox));
+    if let Some((outbox, created_at_block)) = cursor.found {
+        tracing::info!(
+            %factory, %outbox, chain_key, ?created_at_block,
+            "🧭 resolved Outbox on-chain (OutboxCreated scan)"
+        );
+        return Ok(Some((outbox, created_at_block)));
     }
     tracing::warn!(%factory, chain_key, "factory has emitted no OutboxCreated for chain_key yet");
     Ok(None)
@@ -269,12 +292,12 @@ mod tests {
         let mut cursor = OutboxDiscoveryCursor {
             from: 1_000,
             factory: Some(factory),
-            found: Some(outbox),
+            found: Some((outbox, Some(950))),
         };
 
         // Attempt 2 resumes from 1_000 and finds nothing new; the earlier discovery must survive.
         assert_eq!(cursor.scanned_to(), 1_000);
-        assert_eq!(cursor.found, Some(outbox));
+        assert_eq!(cursor.found, Some((outbox, Some(950))));
 
         // A factory re-registration invalidates both: the new factory's Outbox may live anywhere,
         // and the old address must not be reported for it.

--- a/attestor/attestor/src/tasks/write_ability/resolver.rs
+++ b/attestor/attestor/src/tasks/write_ability/resolver.rs
@@ -40,7 +40,7 @@ pub const CHAIN_INFO_PRECOMPILE: Address = Address::new([
 const MAX_LOG_BLOCK_RANGE: u64 = 2000;
 
 /// The Outbox an attestor watches, plus the immutable inputs every `messageHash` on it binds.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ResolvedOutbox {
     /// Outbox contract address on Creditcoin L1.
     pub address: Address,

--- a/attestor/attestor/tests/e2e_anvil.rs
+++ b/attestor/attestor/tests/e2e_anvil.rs
@@ -83,6 +83,9 @@ async fn outbox_publish_indexed_signed_and_reaches_quorum() {
         address: *outbox.address(),
         destination_chain_key: ck_b32,
         creditcoin_chain_id,
+        // The fixture hands the Outbox over directly rather than discovering it, so there is no
+        // `OutboxCreated` log to take a height from; this test drives `watch` with an explicit start.
+        created_at_block: None,
     };
     assert_eq!(resolved.address, *outbox.address());
     assert_eq!(resolved.destination_chain_key, ck_b32);


### PR DESCRIPTION
## What

Keeps Outbox discovery alive **after** activation. A new `run_outbox_monitor` task continues polling the resolver with the same chunk-committed cursor and publishes the live `ResolvedOutbox` through a `watch` channel, so the attestor reacts to governance rotations without a restart (previously the resolver's own TODO):

- **Replacement Outbox** (new factory, or the active factory emits a new `OutboxCreated`): the supervisor aborts *and awaits* the old listener (both cursor stores live in the same state dir — awaiting closes the concurrent-writer window), then spawns a new one starting at the replacement's `OutboxCreated` height rather than the boot-time `scan_from`. Governance can bind an Outbox created *before* this process booted; its earlier `MessagePublished` events would otherwise sit below `scan_from` and never be scanned.
- **Factory removed / changed with no finalized replacement**: the monitor publishes `None`, signing pauses instead of continuing against a de-registered Outbox, and discovery keeps running. De-registration now also resets the discovery cursor (factory/from/found), so `Ok(None)` can't be misread as "no new events".
- **Stale-message provenance**: `IndexedMessage` now carries the Outbox it was observed on. Aborting a listener doesn't drain what it already queued, so the vote loop gates each message against the *live* watch value (not a cached copy — the vote arm and the rotation arm can be ready in the same `select!` pass) and drops messages from a superseded Outbox.
- **Reobservation**: the worker snapshots the watch per request with `borrow_and_update` (a plain `borrow` would leave a pre-request rotation flagged as changed and abandon the first recovery attempt after every rotation), and abandons an in-flight re-sign if the Outbox rotates mid-request — pull-based recovery just retries against the new listener.
- **Bounded monitor RPC**: each rotation-check resolve gets the same `RPC_ATTEMPT_TIMEOUT` bound as the activation loop, so a black-holed RPC can't silently wedge rotation detection (the chunked cursor keeps any progress the attempt made).

## Why now

This is P1 from the #1215 review: on usc-dev we already rotated the Outbox once (contract redeploy), and every attestor needed a manual restart to notice.

## Rework note

Rebuilt from the original branch onto the current `writeability-off-usc-dev` — #1236 (RPC timeouts moved inside `poll_once`, clean-shutdown races) and #1238 (chunk-committed discovery cursor carrying `found` across attempts) rewrote the same supervision code, so the changes were re-derived rather than mechanically rebased. The cursor's carried discovery now records the `OutboxCreated` block alongside the address, which is what makes the hot-swap start height correct.

## Testing

- `cargo test -p attestor --lib` — 111 passed (includes the cursor-carry regression test updated for the `(address, block)` pair)
- `cargo test -p attestor --test e2e_anvil -- --ignored` — passes with a local anvil
- clippy `--all-targets` clean (one pre-existing warning on the base branch left untouched)
