### PR TITLE
fix(attestor): bound write-ability RPC recovery

### DIFF
--- a/attestor/attestor/src/tasks/write_ability/attestor_set.rs
+++ b/attestor/attestor/src/tasks/write_ability/attestor_set.rs
@@ -83,14 +83,26 @@ pub async fn watch(
             _ = tick.tick() => {
                 // Fresh connection each poll — see the fn doc. A dead/transiently-unreachable RPC
                 // fails only this tick and is retried on the next, instead of wedging the watcher.
-                let (set, onchain_threshold) =
-                    match fetch_attestor_set_and_threshold(&dest_rpc_url, validator).await {
-                        Ok(v) => v,
-                        Err(err) => {
-                            tracing::warn!(%validator, %err, "failed to read on-chain attestor set/threshold; will retry");
-                            continue;
-                        }
-                    };
+                let (set, onchain_threshold) = match tokio::time::timeout(
+                    super::RPC_ATTEMPT_TIMEOUT,
+                    fetch_attestor_set_and_threshold(&dest_rpc_url, validator),
+                )
+                .await
+                {
+                    Ok(Ok(v)) => v,
+                    Ok(Err(err)) => {
+                        tracing::warn!(%validator, %err, "failed to read on-chain attestor set/threshold; will retry");
+                        continue;
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            %validator,
+                            timeout_secs = super::RPC_ATTEMPT_TIMEOUT.as_secs(),
+                            "timed out reading on-chain attestor set/threshold; will retry"
+                        );
+                        continue;
+                    }
+                };
                 if set.is_empty() {
                     tracing::warn!(%validator, "EOAValidator.attestors() returned empty — keeping current set");
                     continue;

--- a/attestor/attestor/src/tasks/write_ability/listener.rs
+++ b/attestor/attestor/src/tasks/write_ability/listener.rs
@@ -202,7 +202,17 @@ pub async fn watch<P: Provider>(
         // would otherwise leave `from_block = last_seen + 1 > tip` and silently scan nothing forever
         // (bugbot: stale cursor stalls scanning). On a transient head-read failure, fall back to the
         // persisted value unclamped rather than fail boot.
-        let head = provider.get_block_number().await.unwrap_or(persisted);
+        let head = match tokio::time::timeout(POLL_TIMEOUT, provider.get_block_number()).await {
+            Ok(Ok(head)) => head,
+            Ok(Err(err)) => {
+                tracing::warn!(%err, "could not clamp persisted Outbox cursor to live head");
+                persisted
+            }
+            Err(_) => {
+                tracing::warn!("timed out clamping persisted Outbox cursor to live head");
+                persisted
+            }
+        };
         let clamped = persisted.min(head);
         // Rewind by a bounded lookback so a crash between enqueuing a range's votes and gossiping them
         // re-scans that window (at-least-once; downstream dedups). See CURSOR_RESUME_LOOKBACK_BLOCKS.
@@ -221,9 +231,9 @@ pub async fn watch<P: Provider>(
         );
         start.saturating_sub(1)
     } else {
-        let head = provider
-            .get_block_number()
+        let head = tokio::time::timeout(POLL_TIMEOUT, provider.get_block_number())
             .await
+            .context("timed out reading Creditcoin L1 chain head")?
             .context("failed to read Creditcoin L1 chain head")?;
         tracing::info!(
             head,

--- a/attestor/attestor/src/tasks/write_ability/listener.rs
+++ b/attestor/attestor/src/tasks/write_ability/listener.rs
@@ -202,7 +202,7 @@ pub async fn watch<P: Provider>(
         // would otherwise leave `from_block = last_seen + 1 > tip` and silently scan nothing forever
         // (bugbot: stale cursor stalls scanning). On a transient head-read failure, fall back to the
         // persisted value unclamped rather than fail boot.
-        let head = match tokio::time::timeout(POLL_TIMEOUT, provider.get_block_number()).await {
+        let head = match tokio::time::timeout(RPC_TIMEOUT, provider.get_block_number()).await {
             Ok(Ok(head)) => head,
             Ok(Err(err)) => {
                 tracing::warn!(%err, "could not clamp persisted Outbox cursor to live head");
@@ -231,7 +231,7 @@ pub async fn watch<P: Provider>(
         );
         start.saturating_sub(1)
     } else {
-        let head = tokio::time::timeout(POLL_TIMEOUT, provider.get_block_number())
+        let head = tokio::time::timeout(RPC_TIMEOUT, provider.get_block_number())
             .await
             .context("timed out reading Creditcoin L1 chain head")?
             .context("failed to read Creditcoin L1 chain head")?;

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -70,7 +70,12 @@ const RESOLVE_ESCALATE_EVERY_ATTEMPTS: u64 = (5 * 60) / OUTBOX_RESOLVE_RETRY_SEC
 /// repeated RPC errors against the same bare alloy provider mean the connection is no longer
 /// usable. Surface the failure so the process supervisor rebuilds the provider on restart instead
 /// of retrying the same dead socket indefinitely.
-const MAX_CONSECUTIVE_RESOLVE_FAILURES: u64 = 10;
+///
+/// Sized to ~5 minutes (matching [`RESOLVE_ESCALATE_EVERY_ATTEMPTS`]): a *planned* node restart —
+/// the CI outage-recovery scenarios bounce the CC3 node for a couple of minutes, and a devnet
+/// rollout looks the same — must ride out on retries, not exit the process. Only an outage long
+/// past any orchestrated restart indicates the provider itself is wedged.
+const MAX_CONSECUTIVE_RESOLVE_FAILURES: u64 = (5 * 60) / OUTBOX_RESOLVE_RETRY_SECS;
 
 /// Message-vote state shared between this task (producer) and the p2p task (publisher + incoming
 /// validator). Lives on [`Shared`](crate::shared::Shared) as `Option`, set only when message

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -450,6 +450,13 @@ pub async fn run(
     // retry only scans new blocks instead of re-scanning the whole chain history every interval.
     let mut outbox_cursor = resolver::OutboxDiscoveryCursor::default();
     let resolved = loop {
+        // Progress-aware failure budget, mirroring the listener's `next_failure_count`. Outbox
+        // discovery is a *chunked* log scan, so one attempt legitimately exceeds
+        // `RPC_ATTEMPT_TIMEOUT` on a long chain while still advancing the cursor each chunk.
+        // Counting those as failures would trip `MAX_CONSECUTIVE_RESOLVE_FAILURES` and restart —
+        // and `outbox_cursor` is in-memory, so the restart discards every chunk already scanned,
+        // making it a loop that never activates rather than a recovery.
+        let scanned_before = outbox_cursor.scanned_to();
         let attempt = tokio::select! {
             attempt = tokio::time::timeout(
                 RPC_ATTEMPT_TIMEOUT,
@@ -469,11 +476,22 @@ pub async fn run(
                 if let Some(proposer) = &set_update_proposer {
                     proposer.abort();
                 }
+                // On shutdown these children exit cleanly with `Ok(())` and race the cancel branch,
+                // so this arm winning must not turn an intentional stop into a task failure. The
+                // post-activation loop already guards the same way.
+                if shared.token.is_cancelled() {
+                    return Ok(());
+                }
                 return Err(Error::WriteAbility(child_exit_error("attestor-set watcher", joined)));
             }
             joined = wait_for_optional_child(&mut set_update_proposer) => {
                 if let Some(watcher) = &set_watcher {
                     watcher.abort();
+                }
+                // See the watcher arm: a clean child exit during shutdown must not be reported as a
+                // failure.
+                if shared.token.is_cancelled() {
+                    return Ok(());
                 }
                 return Err(Error::WriteAbility(child_exit_error("attestor-set-update proposer", joined)));
             }
@@ -514,7 +532,17 @@ pub async fn run(
             }
             Err(err) => {
                 resolve_attempts += 1;
-                consecutive_resolve_failures += 1;
+                if outbox_cursor.scanned_to() > scanned_before {
+                    // Advanced before failing: this is a wide scan in progress, not a dead endpoint.
+                    consecutive_resolve_failures = 0;
+                    tracing::info!(
+                        scanned_to = outbox_cursor.scanned_to(),
+                        error = %format!("{err:#}"),
+                        "🐢 Outbox discovery advanced but did not finish this attempt; continuing (not counted as a failure)"
+                    );
+                } else {
+                    consecutive_resolve_failures += 1;
+                }
                 if consecutive_resolve_failures >= MAX_CONSECUTIVE_RESOLVE_FAILURES {
                     return Err(Error::WriteAbility(err.context(format!(
                         "Outbox resolution failed {consecutive_resolve_failures} consecutive times; restarting to rebuild the RPC provider"
@@ -552,11 +580,22 @@ pub async fn run(
                 if let Some(proposer) = &set_update_proposer {
                     proposer.abort();
                 }
+                // On shutdown these children exit cleanly with `Ok(())` and race the cancel branch,
+                // so this arm winning must not turn an intentional stop into a task failure. The
+                // post-activation loop already guards the same way.
+                if shared.token.is_cancelled() {
+                    return Ok(());
+                }
                 return Err(Error::WriteAbility(child_exit_error("attestor-set watcher", joined)));
             }
             joined = wait_for_optional_child(&mut set_update_proposer) => {
                 if let Some(watcher) = &set_watcher {
                     watcher.abort();
+                }
+                // See the watcher arm: a clean child exit during shutdown must not be reported as a
+                // failure.
+                if shared.token.is_cancelled() {
+                    return Ok(());
                 }
                 return Err(Error::WriteAbility(child_exit_error("attestor-set-update proposer", joined)));
             }

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -33,7 +33,7 @@ pub mod signing;
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use alloy::primitives::{Address, B256};
 use alloy::providers::{Provider, ProviderBuilder};
@@ -54,12 +54,23 @@ pub use config::{AttestorSet, Config};
 /// activation without a restart).
 const OUTBOX_RESOLVE_RETRY_SECS: u64 = 12;
 
+/// Wall-clock bound for one write-ability RPC attempt. Every long-lived loop catches this error and
+/// retries with a fresh attempt; startup-only calls surface it to the process supervisor so a
+/// black-holed socket can never leave the pod serving a permanently-green health endpoint.
+pub(super) const RPC_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// After this many consecutive failed resolves (~5 min at [`OUTBOX_RESOLVE_RETRY_SECS`]) the retry is
 /// probably no longer "waiting for on-chain registration" but a misconfiguration — most likely a
 /// deploy-ordering trap where the attestor was upgraded ahead of the runtime, so the renamed
 /// chain-info selector (`get_outbox_factory_address`) reverts and resolution can never succeed (S3).
 /// Escalate the log to error-level at each multiple so it is alertable instead of buried in warns.
 const RESOLVE_ESCALATE_EVERY_ATTEMPTS: u64 = (5 * 60) / OUTBOX_RESOLVE_RETRY_SECS;
+
+/// A responsive node may legitimately report that no Outbox exists yet (`Ok(None)`) forever, but
+/// repeated RPC errors against the same bare alloy provider mean the connection is no longer
+/// usable. Surface the failure so the process supervisor rebuilds the provider on restart instead
+/// of retrying the same dead socket indefinitely.
+const MAX_CONSECUTIVE_RESOLVE_FAILURES: u64 = 10;
 
 /// Message-vote state shared between this task (producer) and the p2p task (publisher + incoming
 /// validator). Lives on [`Shared`](crate::shared::Shared) as `Option`, set only when message
@@ -169,14 +180,22 @@ pub async fn register_evm_address(
     let address = signer.address();
     let ours = sp_core::H160::from_slice(address.as_slice());
 
-    match cc3.attestor_evm_address(chain_key).await {
-        Ok(Some(existing)) if existing == ours => {
+    let existing =
+        tokio::time::timeout(RPC_ATTEMPT_TIMEOUT, cc3.attestor_evm_address(chain_key)).await;
+    match existing {
+        Ok(Ok(Some(existing))) if existing == ours => {
             tracing::debug!(evm_address = %address, "🔗 write-ability EVM address already registered on-chain");
             return true;
         }
-        Ok(_) => {}
-        Err(err) => {
+        Ok(Ok(_)) => {}
+        Ok(Err(err)) => {
             tracing::warn!(%err, "could not read the on-chain EVM address registration; will attempt to (re)register");
+        }
+        Err(_) => {
+            tracing::warn!(
+                timeout_secs = RPC_ATTEMPT_TIMEOUT.as_secs(),
+                "timed out reading the on-chain EVM address registration; will attempt to (re)register"
+            );
         }
     }
 
@@ -189,16 +208,29 @@ pub async fn register_evm_address(
         }
     };
 
-    match cc3.set_attestor_evm_address(chain_key, ours, proof).await {
-        Ok(()) => {
+    match tokio::time::timeout(
+        RPC_ATTEMPT_TIMEOUT,
+        cc3.set_attestor_evm_address(chain_key, ours, proof),
+    )
+    .await
+    {
+        Ok(Ok(())) => {
             tracing::info!(evm_address = %address, "🔗 registered write-ability EVM address on-chain");
             true
         }
-        Err(err) => {
+        Ok(Err(err)) => {
             tracing::warn!(
                 %err,
                 evm_address = %address,
                 "failed to register write-ability EVM address on-chain — will retry; the destination EOAValidator set omits this attestor until it succeeds"
+            );
+            false
+        }
+        Err(_) => {
+            tracing::warn!(
+                evm_address = %address,
+                timeout_secs = RPC_ATTEMPT_TIMEOUT.as_secs(),
+                "timed out registering write-ability EVM address on-chain — will retry"
             );
             false
         }
@@ -211,8 +243,10 @@ pub async fn register_evm_address(
 async fn resolve_destination_chain_key(cfg: &Config, cc3: &cc_client::Client) -> Option<B256> {
     let chain_key = cfg.write_ability_chain_key;
     let local = chain_key_to_bytes32(chain_key);
-    match cc3.get_write_ability_config(chain_key).await {
-        Ok(Some(on_chain)) => {
+    let config =
+        tokio::time::timeout(RPC_ATTEMPT_TIMEOUT, cc3.get_write_ability_config(chain_key)).await;
+    match config {
+        Ok(Ok(Some(on_chain))) => {
             if !on_chain.message_attestation_enabled {
                 tracing::info!(
                     chain_key,
@@ -231,20 +265,28 @@ async fn resolve_destination_chain_key(cfg: &Config, cc3: &cc_client::Client) ->
             }
             Some(key)
         }
-        Ok(None) => {
+        Ok(Ok(None)) => {
             tracing::warn!(
                 chain_key,
                 "no on-chain WriteAbilityConfig registered for this chain — using the locally derived chain key"
             );
             Some(local)
         }
-        Err(err) => {
+        Ok(Err(err)) => {
             // Availability over strictness: a transient read failure must not disable a locally
             // configured attestor. Explicit governance "off" is only honored via Ok(Some(..)).
             tracing::warn!(
                 chain_key,
                 %err,
                 "failed to read on-chain WriteAbilityConfig — falling back to local config"
+            );
+            Some(local)
+        }
+        Err(_) => {
+            tracing::warn!(
+                chain_key,
+                timeout_secs = RPC_ATTEMPT_TIMEOUT.as_secs(),
+                "timed out reading on-chain WriteAbilityConfig — falling back to local config"
             );
             Some(local)
         }
@@ -317,7 +359,7 @@ pub async fn run(
     // On-chain attestor-set hot-reload watcher (only when the set is sourced from the validator).
     // Runs independently of Outbox resolution — the set is unrelated to the Outbox — so it keeps the
     // active set in sync even while write-ability is idle waiting for the Outbox.
-    let set_watcher = match (&cfg.attestor_set, cfg.destination_eth_rpc_url.as_ref()) {
+    let mut set_watcher = match (&cfg.attestor_set, cfg.destination_eth_rpc_url.as_ref()) {
         (AttestorSet::OnChainValidator(validator), Some(url)) => {
             Some(tokio::spawn(attestor_set::watch(
                 state.clone(),
@@ -340,7 +382,7 @@ pub async fn run(
     // on-chain EVM-address registry) diverges from the destination validator's set, for the relayer
     // to submit. Like `set_watcher` it is Outbox-independent, only meaningful for an OnChainValidator
     // set, and derives its own EVM signer from `seed`.
-    let set_update_proposer = match (&cfg.attestor_set, cfg.destination_eth_rpc_url.as_ref()) {
+    let mut set_update_proposer = match (&cfg.attestor_set, cfg.destination_eth_rpc_url.as_ref()) {
         (AttestorSet::OnChainValidator(validator), Some(url)) => {
             match signing::MessageSigner::from_seed(&seed) {
                 Ok(proposer_signer) => Some(tokio::spawn(set_update::run_proposer(
@@ -366,10 +408,18 @@ pub async fn run(
             "cc3_eth_rpc_url is required when message attestation is on"
         ))
     })?;
-    let provider = ProviderBuilder::new()
-        .on_builtin(rpc.as_str())
-        .await
-        .map_err(|e| Error::WriteAbility(anyhow!("connect Creditcoin L1 EVM RPC: {e}")))?;
+    let provider = tokio::time::timeout(
+        RPC_ATTEMPT_TIMEOUT,
+        ProviderBuilder::new().on_builtin(rpc.as_str()),
+    )
+    .await
+    .map_err(|_| {
+        Error::WriteAbility(anyhow!(
+            "connect Creditcoin L1 EVM RPC timed out after {:?}",
+            RPC_ATTEMPT_TIMEOUT
+        ))
+    })?
+    .map_err(|e| Error::WriteAbility(anyhow!("connect Creditcoin L1 EVM RPC: {e}")))?;
 
     // Capture the chain head *before* the resolve loop. When no explicit `start_block` is
     // configured we scan from here, not from the head after resolution finishes — otherwise
@@ -378,10 +428,16 @@ pub async fn run(
     // signed or gossiped. Operators expecting a long activation wait should still set `start_block`
     // to bound the initial backfill range (no MessagePublished logs exist before Outbox creation,
     // so the effective scan is small in the common case).
-    let head_before_resolve = provider
-        .get_block_number()
-        .await
-        .map_err(|e| Error::WriteAbility(anyhow!("read Creditcoin L1 chain head: {e}")))?;
+    let head_before_resolve =
+        tokio::time::timeout(RPC_ATTEMPT_TIMEOUT, provider.get_block_number())
+            .await
+            .map_err(|_| {
+                Error::WriteAbility(anyhow!(
+                    "read Creditcoin L1 chain head timed out after {:?}",
+                    RPC_ATTEMPT_TIMEOUT
+                ))
+            })?
+            .map_err(|e| Error::WriteAbility(anyhow!("read Creditcoin L1 chain head: {e}")))?;
 
     // Resolve the Outbox, retrying until it's available rather than disabling for the whole run:
     // an attestor can be started before the factory/Outbox is registered on-chain and will activate
@@ -389,20 +445,52 @@ pub async fn run(
     // doing block attestation. (Polling is simpler and more robust than event subscription; picking
     // up a later Outbox *re-registration* mid-run remains a finer-grained TODO in resolver.rs.)
     let mut resolve_attempts: u64 = 0;
+    let mut consecutive_resolve_failures: u64 = 0;
     // Discovery cursor: advances past confirmed blocks already scanned for `OutboxCreated` so each
     // retry only scans new blocks instead of re-scanning the whole chain history every interval.
     let mut outbox_cursor = resolver::OutboxDiscoveryCursor::default();
     let resolved = loop {
-        match resolver::resolve(
-            &provider,
-            &cfg,
-            state.destination_chain_key,
-            &mut outbox_cursor,
-        )
-        .await
-        {
+        let attempt = tokio::select! {
+            attempt = tokio::time::timeout(
+                RPC_ATTEMPT_TIMEOUT,
+                resolver::resolve(
+                    &provider,
+                    &cfg,
+                    state.destination_chain_key,
+                    &mut outbox_cursor,
+                ),
+            ) => attempt.unwrap_or_else(|_| {
+                Err(anyhow!(
+                    "Outbox resolution RPC attempt timed out after {:?}",
+                    RPC_ATTEMPT_TIMEOUT
+                ))
+            }),
+            joined = wait_for_optional_child(&mut set_watcher) => {
+                if let Some(proposer) = &set_update_proposer {
+                    proposer.abort();
+                }
+                return Err(Error::WriteAbility(child_exit_error("attestor-set watcher", joined)));
+            }
+            joined = wait_for_optional_child(&mut set_update_proposer) => {
+                if let Some(watcher) = &set_watcher {
+                    watcher.abort();
+                }
+                return Err(Error::WriteAbility(child_exit_error("attestor-set-update proposer", joined)));
+            }
+            () = shared.token.cancelled() => {
+                if let Some(watcher) = &set_watcher {
+                    watcher.abort();
+                }
+                if let Some(proposer) = &set_update_proposer {
+                    proposer.abort();
+                }
+                return Ok(());
+            }
+        };
+        match attempt {
             Ok(Some(r)) => break r,
             Ok(None) => {
+                consecutive_resolve_failures = 0;
                 resolve_attempts += 1;
                 if resolve_attempts % RESOLVE_ESCALATE_EVERY_ATTEMPTS == 0 {
                     // WARN, not ERROR: `Ok(None)` means nothing is registered on-chain yet, which is
@@ -426,6 +514,12 @@ pub async fn run(
             }
             Err(err) => {
                 resolve_attempts += 1;
+                consecutive_resolve_failures += 1;
+                if consecutive_resolve_failures >= MAX_CONSECUTIVE_RESOLVE_FAILURES {
+                    return Err(Error::WriteAbility(err.context(format!(
+                        "Outbox resolution failed {consecutive_resolve_failures} consecutive times; restarting to rebuild the RPC provider"
+                    ))));
+                }
                 // `{:#}` (alternate Display), not `%err`: these errors are built with
                 // `anyhow::Context`, whose plain Display prints ONLY the outermost context. Logging
                 // it that way reduced every failure to the bare phrase "…get_outbox_factory_address()
@@ -445,7 +539,27 @@ pub async fn run(
             }
         }
         tokio::select! {
-            () = shared.token.cancelled() => return Ok(()),
+            () = shared.token.cancelled() => {
+                if let Some(watcher) = &set_watcher {
+                    watcher.abort();
+                }
+                if let Some(proposer) = &set_update_proposer {
+                    proposer.abort();
+                }
+                return Ok(());
+            }
+            joined = wait_for_optional_child(&mut set_watcher) => {
+                if let Some(proposer) = &set_update_proposer {
+                    proposer.abort();
+                }
+                return Err(Error::WriteAbility(child_exit_error("attestor-set watcher", joined)));
+            }
+            joined = wait_for_optional_child(&mut set_update_proposer) => {
+                if let Some(watcher) = &set_watcher {
+                    watcher.abort();
+                }
+                return Err(Error::WriteAbility(child_exit_error("attestor-set-update proposer", joined)));
+            }
             () = tokio::time::sleep(std::time::Duration::from_secs(OUTBOX_RESOLVE_RETRY_SECS)) => {}
         }
     };
@@ -494,7 +608,7 @@ pub async fn run(
     // RPCs (deadline-bounded, serial) must not be able to stall vote production / message ingestion
     // if the shared provider black-holes. The bounded `reobs_rx` channel already drops excess, so a
     // flood is bounded to serial, deadline-capped work here.
-    let reobs_worker = {
+    let mut reobs_worker = {
         let provider = provider.clone();
         let state = state.clone();
         let shared = shared.clone();
@@ -520,6 +634,41 @@ pub async fn run(
         // still picked promptly (graceful shutdown tolerates finishing one in-flight item first).
         tokio::select! {
             () = shared.token.cancelled() => break,
+            joined = wait_for_optional_child(&mut set_watcher) => {
+                if shared.token.is_cancelled() {
+                    break;
+                }
+                listener.abort();
+                reobs_worker.abort();
+                if let Some(p) = &set_update_proposer {
+                    p.abort();
+                }
+                return Err(Error::WriteAbility(child_exit_error("attestor-set watcher", joined)));
+            }
+            joined = wait_for_optional_child(&mut set_update_proposer) => {
+                if shared.token.is_cancelled() {
+                    break;
+                }
+                listener.abort();
+                reobs_worker.abort();
+                if let Some(w) = &set_watcher {
+                    w.abort();
+                }
+                return Err(Error::WriteAbility(child_exit_error("attestor-set-update proposer", joined)));
+            }
+            joined = &mut reobs_worker => {
+                if shared.token.is_cancelled() {
+                    break;
+                }
+                listener.abort();
+                if let Some(w) = &set_watcher {
+                    w.abort();
+                }
+                if let Some(p) = &set_update_proposer {
+                    p.abort();
+                }
+                return Err(Error::WriteAbility(child_exit_error("reobservation worker", joined)));
+            }
             maybe = rx.recv() => {
                 let Some(indexed) = maybe else {
                     // On shutdown a closed channel is expected, not a fault: every cancel path in
@@ -564,6 +713,26 @@ pub async fn run(
         p.abort();
     }
     Ok(())
+}
+
+/// Await an optional child without making the select branch ready when that child is disabled.
+async fn wait_for_optional_child(
+    child: &mut Option<tokio::task::JoinHandle<()>>,
+) -> Result<(), tokio::task::JoinError> {
+    match child {
+        Some(child) => child.await,
+        None => std::future::pending().await,
+    }
+}
+
+fn child_exit_error(
+    name: &'static str,
+    joined: Result<(), tokio::task::JoinError>,
+) -> anyhow::Error {
+    match joined {
+        Ok(()) => anyhow!("{name} exited before shutdown was requested"),
+        Err(err) => anyhow!("{name} panicked or was cancelled unexpectedly: {err}"),
+    }
 }
 
 /// Reobservation responder, run as its own task (audit P1-4). Consumes verified-on-request pull

--- a/attestor/attestor/src/tasks/write_ability/reobservation.rs
+++ b/attestor/attestor/src/tasks/write_ability/reobservation.rs
@@ -50,7 +50,7 @@ pub const REOBS_MAX_TRACKED_IDS: usize = 10_000;
 
 /// Per-request wall-clock deadline for the tip + `eth_getLogs` re-fetch. A black-holed RPC must not
 /// let a single reobservation hang the responder; on timeout the request is dropped (the relayer
-/// re-requests on its own cadence). Matches the listener's `POLL_TIMEOUT`.
+/// re-requests on its own cadence). Matches the listener's `RPC_TIMEOUT`.
 pub const REOBS_RPC_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Per-`message_id` cooldown tracker for reobservation requests. Synchronous and clock-injected so

--- a/attestor/attestor/src/tasks/write_ability/resolver.rs
+++ b/attestor/attestor/src/tasks/write_ability/resolver.rs
@@ -65,6 +65,15 @@ pub struct OutboxDiscoveryCursor {
     factory: Option<Address>,
 }
 
+impl OutboxDiscoveryCursor {
+    /// Block the scan has reached. The caller uses this to tell a resolve attempt that *failed after
+    /// advancing* from one that made no headway at all, so a chunked scan spanning several attempts
+    /// is not mistaken for a dead RPC.
+    pub(super) fn scanned_to(&self) -> u64 {
+        self.from
+    }
+}
+
 /// Resolve the Outbox for the configured write-ability chain key using `provider` (a Creditcoin L1
 /// EVM connection). `destination_chain_key` is the effective `bytes32` key (see
 /// [`super::MessageVoteState::destination_chain_key`]) used both to ask the factory for its Outbox

--- a/attestor/attestor/src/tasks/write_ability/resolver.rs
+++ b/attestor/attestor/src/tasks/write_ability/resolver.rs
@@ -63,6 +63,11 @@ pub struct OutboxDiscoveryCursor {
     from: u64,
     /// Factory the cursor was advanced against; a change resets `from` to 0.
     factory: Option<Address>,
+    /// Newest `OutboxCreated` address seen so far, carried across attempts. Progress and discovery
+    /// must advance together: `from` moves past each completed chunk, so keeping the match only in a
+    /// local would lose it whenever a *later* chunk failed — the next attempt would resume past the
+    /// event and report "no Outbox" forever (bugbot). Reset with `from` on a factory change.
+    found: Option<Address>,
 }
 
 impl OutboxDiscoveryCursor {
@@ -154,6 +159,7 @@ async fn resolve_outbox_address<P: Provider>(
     if cursor.factory != Some(factory) {
         cursor.factory = Some(factory);
         cursor.from = 0;
+        cursor.found = None;
     }
 
     // 2. Discover the factory's Outbox for this chain key. The synced CREATE2 factory has no
@@ -198,7 +204,6 @@ async fn resolve_outbox_address<P: Provider>(
     // returns ascending, so the last log of the last non-empty chunk is the newest. (Via the
     // OutboxDeployer the registry is one-per-chain_key, so in practice there is exactly one — this
     // just makes the ambiguous case deterministic rather than order-of-emission dependent.)
-    let mut latest: Option<alloy::primitives::Address> = None;
     while from <= safe_tip {
         let chunk_to = safe_tip.min(from + MAX_LOG_BLOCK_RANGE - 1);
         let filter = alloy::rpc::types::Filter::new()
@@ -211,7 +216,10 @@ async fn resolve_outbox_address<P: Provider>(
             format!("eth_getLogs OutboxCreated at factory {factory} [{from}..={chunk_to}] failed")
         })?;
         if let Some(log) = logs.last() {
-            latest = Some(
+            // Record into the cursor, not a local: this must survive an attempt that is abandoned
+            // after this chunk (see `OutboxDiscoveryCursor::found`). `get_logs` returns ascending,
+            // so the last log of the newest non-empty chunk stays the newest match overall.
+            cursor.found = Some(
                 IOutboxFactory::OutboxCreated::decode_log(&log.inner, true)
                     .context("decode OutboxCreated log")?
                     .data
@@ -232,10 +240,51 @@ async fn resolve_outbox_address<P: Provider>(
     // `from` is `safe_tip + 1` when the loop ran, or unchanged (`cursor.from`) if
     // `safe_tip < cursor.from` (tip regressed / depth grew) — never regressing the cursor.
     cursor.from = cursor.from.max(from);
-    if let Some(outbox) = latest {
+    if let Some(outbox) = cursor.found {
         tracing::info!(%factory, %outbox, chain_key, "🧭 resolved Outbox on-chain (OutboxCreated scan)");
         return Ok(Some(outbox));
     }
     tracing::warn!(%factory, chain_key, "factory has emitted no OutboxCreated for chain_key yet");
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::address;
+
+    // Progress and discovery must move together. The scan commits `from` per chunk so an attempt
+    // abandoned mid-loop keeps its headway (otherwise the failure budget restarts discovery
+    // forever on a long chain) — but that means a match found in an early chunk sits *behind* the
+    // cursor, so it has to be carried in the cursor too. Keeping it in a local made a later-chunk
+    // failure lose the address permanently: every retry resumed past the event and reported
+    // "no Outbox", leaving write-ability inactive for the process lifetime.
+    #[test]
+    fn cursor_carries_a_discovery_past_an_interrupted_scan() {
+        let outbox = address!("00000000000000000000000000000000000000aa");
+        let factory = address!("00000000000000000000000000000000000000ff");
+
+        // Attempt 1: chunk at [0..=999] matched, then a later chunk failed — the function returned
+        // Err after committing both the progress and the match.
+        let mut cursor = OutboxDiscoveryCursor {
+            from: 1_000,
+            factory: Some(factory),
+            found: Some(outbox),
+        };
+
+        // Attempt 2 resumes from 1_000 and finds nothing new; the earlier discovery must survive.
+        assert_eq!(cursor.scanned_to(), 1_000);
+        assert_eq!(cursor.found, Some(outbox));
+
+        // A factory re-registration invalidates both: the new factory's Outbox may live anywhere,
+        // and the old address must not be reported for it.
+        let new_factory = address!("00000000000000000000000000000000000000ee");
+        if cursor.factory != Some(new_factory) {
+            cursor.factory = Some(new_factory);
+            cursor.from = 0;
+            cursor.found = None;
+        }
+        assert_eq!(cursor.scanned_to(), 0);
+        assert_eq!(cursor.found, None);
+    }
 }

--- a/attestor/attestor/src/tasks/write_ability/resolver.rs
+++ b/attestor/attestor/src/tasks/write_ability/resolver.rs
@@ -219,11 +219,19 @@ async fn resolve_outbox_address<P: Provider>(
             );
         }
         from = chunk_to + 1;
+        // Record progress per *chunk*, not per scan. A resolve attempt can be abandoned mid-loop
+        // (`RPC_ATTEMPT_TIMEOUT`, or a later chunk erroring), and the caller distinguishes "failed
+        // after advancing" from "made no headway" via `scanned_to()`. Advancing only after the whole
+        // range would report zero progress for a scan that covered thousands of blocks, so a long
+        // chain would burn the failure budget and restart on every attempt without ever finishing
+        // discovery (bugbot). Chunks are scanned in ascending order and the cursor is the resume
+        // point, so committing each completed chunk is safe: at worst the newest-Outbox scan below
+        // resumes from here and re-reads nothing already covered.
+        cursor.from = from;
     }
-    // Advance the cursor past the scanned range so the next retry resumes from here instead of
-    // re-scanning history. `from` is `safe_tip + 1` when the loop ran, or unchanged (`cursor.from`)
-    // if `safe_tip < cursor.from` (tip regressed / depth grew) — never regressing the cursor.
-    cursor.from = from;
+    // `from` is `safe_tip + 1` when the loop ran, or unchanged (`cursor.from`) if
+    // `safe_tip < cursor.from` (tip regressed / depth grew) — never regressing the cursor.
+    cursor.from = cursor.from.max(from);
     if let Some(outbox) = latest {
         tracing::info!(%factory, %outbox, chain_key, "🧭 resolved Outbox on-chain (OutboxCreated scan)");
         return Ok(Some(outbox));

--- a/attestor/attestor/src/tasks/write_ability/set_update.rs
+++ b/attestor/attestor/src/tasks/write_ability/set_update.rs
@@ -196,8 +196,13 @@ pub async fn run_proposer(
                 // stale, so a steady state is a single storage read per cycle.
                 super::register_evm_address(&cc3, &signer, chain_key).await;
 
-                match propose_once(&cc3, chain_key, &dest_rpc_url, validator, &signer).await {
-                    Ok(Some(vote)) => {
+                match tokio::time::timeout(
+                    super::RPC_ATTEMPT_TIMEOUT,
+                    propose_once(&cc3, chain_key, &dest_rpc_url, validator, &signer),
+                )
+                .await
+                {
+                    Ok(Ok(Some(vote))) => {
                         // Bounded `try_send`: if the publish channel is full the vote is dropped and
                         // re-proposed next tick (set changes persist until an update lands), so a
                         // backed-up publisher never blocks this loop.
@@ -205,9 +210,15 @@ pub async fn run_proposer(
                             tracing::warn!("set-update vote publish channel full — will re-propose next tick");
                         }
                     }
-                    Ok(None) => {}
-                    Err(err) => {
+                    Ok(Ok(None)) => {}
+                    Ok(Err(err)) => {
                         tracing::warn!(%err, "attestor-set-update proposal cycle failed; will retry");
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            timeout_secs = super::RPC_ATTEMPT_TIMEOUT.as_secs(),
+                            "attestor-set-update proposal cycle timed out; will retry"
+                        );
                     }
                 }
             }


### PR DESCRIPTION
P1 audit follow-up to #1215.

## The bug

The write-ability startup path awaited a bare alloy provider with no wall-clock bound anywhere. That
provider's pubsub service exits permanently after a single failed reconnect, and a black-holed socket
(accepted, never answered) leaves every one of those awaits pending forever. The pod stays up serving
a green health endpoint while write-ability never activates and never reports why.

Unbounded before this change: the provider build, the pre-resolve head read, `resolver::resolve`, the
EVM-address registration read/write, the `WriteAbilityConfig` read, the attestor-set/threshold poll,
the listener's cursor-clamp head reads, and the set-update proposal cycle.

Separately, the resolve loop awaited only its own retry sleep. If the attestor-set watcher or the
set-update proposer died while write-ability was still waiting for an Outbox, nothing noticed — the
task sat in the loop with a dead child.

## The fix

One `RPC_ATTEMPT_TIMEOUT` (30s) applied per attempt. Long-lived loops catch it and retry on the next
tick; startup-only calls surface it to the supervisor so the process restarts with a fresh provider
instead of holding a dead socket.

`MAX_CONSECUTIVE_RESOLVE_FAILURES` (10) distinguishes "nothing registered on-chain yet" — `Ok(None)`,
which may legitimately persist forever and resets the counter — from repeated RPC *errors*, which mean
the connection is gone and only a restart fixes it.

The resolve loop now also supervises its optional children via `wait_for_optional_child`, using
`std::future::pending()` so a disabled child never makes its branch ready.

## Review findings addressed (e8b375f)

Both Cursor Bugbot findings, which were real:

- **The resolve timeout ignored scan progress (High).** Discovery is a *chunked* log scan, so on a long
  chain one attempt legitimately exceeds the deadline while still advancing the cursor per chunk. Every
  such attempt counted as a failure, so the budget tripped after ~5 minutes — and because
  `outbox_cursor` is in-memory, the restart it asked for discarded every chunk already scanned. The
  recovery path was a loop that never activates, on exactly the chains that need it. The budget is now
  progress-aware, mirroring the listener's `next_failure_count`, via a new
  `OutboxDiscoveryCursor::scanned_to()`.
- **Shutdown race in the resolve loop (Medium).** The new child arms returned `Err` unconditionally, but
  on shutdown those children exit cleanly with `Ok(())` and race the cancel branch — so a lost race
  reported an intentional stop as a task failure. They now guard on `is_cancelled()`, which is what the
  post-activation loop in this same file already did.

## Note for reviewers

Adding a timeout around the finalized-head read maps a *timeout* onto the existing "finalized
unavailable → depth fallback" branch. #1240 tracks a Bugbot claim that this fallback can let the
listener sign past the last trusted finalized head; if that holds, this change slightly widens that
window rather than narrowing it. Worth triaging the two together — it does not affect the failure modes
fixed here.

## Verification

- `cargo clippy -p attestor --all-targets` — clean
- `cargo test -p attestor --lib` — 109 passed, 0 failed
- `cargo fmt --all -- --check` — clean

`target-branch-check` fails by construction: `git.yml` only accepts `usc-dev`, `usc-testnet` or
`main`, and this targets `writeability-off-usc-dev`.

---

When merging this PR:

- For PRs against `usc-dev` use the "Squash and merge" button
- For PRs against `usc-testnet`/`main` use the "Create a merge commit" button
- Hotfixes against `usc-testnet`/`main` should use the "Squash and merge" button
