### PR TITLE
feat(indexer): fail-closed Outbox discovery with quarantine + backfill

### DIFF
--- a/.github/workflows/write-ability-e2e.yml
+++ b/.github/workflows/write-ability-e2e.yml
@@ -181,16 +181,16 @@ jobs:
           .github/wait-for-ethereum.sh 'http://127.0.0.1:8545'
           .github/wait-for-creditcoin.sh 'http://127.0.0.1:9944'
 
-      - name: Deploy fee stack (dest + source incl. AcknowledgmentValidator) + register factory
+      - name: Deploy fee stack (dest + source incl. AcknowledgmentValidator)
         working-directory: ./usc-messaging
         # deploy-source-ethers.mts deploys the fee-integrated Outbox via the CREATE2 factory plus the
         # quoter, vaults, RelayerContract and the AcknowledgmentValidator (wired as the Outbox
-        # validator); register-factory.mjs registers the factory in the CC runtime so the attestor's
-        # chain-info precompile resolves it. Addresses land in /tmp/e2e-deploy.json.
+        # validator). The source deploy registers the factory in the CC runtime BEFORE creating the
+        # Outbox, so the indexer's chain-wide discovery handler can authenticate OutboxCreated without
+        # accepting attacker-controlled emitters. Addresses land in /tmp/e2e-deploy.json.
         run: |
           npx tsx scripts/deploy-dest-ethers.mts
           npx tsx scripts/deploy-source-ethers.mts
-          node scripts/register-factory.mjs
 
       - name: Write .env from deployed addresses
         working-directory: ./usc-messaging

--- a/.github/workflows/write-ability-e2e.yml
+++ b/.github/workflows/write-ability-e2e.yml
@@ -186,8 +186,9 @@ jobs:
         # deploy-source-ethers.mts deploys the fee-integrated Outbox via the CREATE2 factory plus the
         # quoter, vaults, RelayerContract and the AcknowledgmentValidator (wired as the Outbox
         # validator). The source deploy registers the factory in the CC runtime BEFORE creating the
-        # Outbox, so the indexer's chain-wide discovery handler can authenticate OutboxCreated without
-        # accepting attacker-controlled emitters. Addresses land in /tmp/e2e-deploy.json.
+        # Outbox — the ordering the indexer admits directly; the reverse order is recovered via its
+        # quarantine/backfill path, exercised separately by handleOutboxBackfill.test.ts. Addresses
+        # land in /tmp/e2e-deploy.json.
         run: |
           npx tsx scripts/deploy-dest-ethers.mts
           npx tsx scripts/deploy-source-ethers.mts

--- a/cc3-indexer/datasources.ts
+++ b/cc3-indexer/datasources.ts
@@ -314,23 +314,23 @@ export const blockProverDatasource: FrontierEvmDatasource = {
     },
 };
 
-// USC write-ability — fully on-chain discovery, no configured addresses:
+// USC write-ability — fully on-chain discovery, no configured addresses and no dynamic datasources:
 //
-//   OutboxCreated (EVM, chain-wide topic filter — the static datasource below)
-//     └─▶ createDynamicDatasource('Outbox', { address })   // watches each created Outbox
-//           └─ MessagePublished / MessageAcknowledged (EVM)
+//   OutboxCreated            (EVM, chain-wide topic filter)  ─▶ OutboxContract | PendingOutbox
+//   MessagePublished         (EVM, chain-wide topic filter)  ─▶ OutboxMessage | QuarantinedMessage
+//   MessageAcknowledged      (EVM, chain-wide topic filter)  ─▶ updates either of the above
 //
-// Discovery watches `OutboxCreated` across all contracts by topic (no address), then the handler
-// authenticates the emitter against the governance registration for the event's chain key. Deploy
-// flows MUST register a factory before calling deployOutbox. This preserves address-free discovery
-// without allowing counterfeit contracts to create persistent dynamic datasources.
+// Every event is matched by topic across all contracts and *authorized per event in the handler*:
+// OutboxCreated against the governance factory registration for its chain key, messages against the
+// OutboxContract row of their emitting contract. Events whose authorization has not been indexed yet
+// are quarantined (bounded) and promoted by handleOutboxFactoryRegistered — fail-closed with
+// backfill, instead of fail-forever on a deploy-ordering race.
 //
-// createDynamicDatasource spreads its `args` into the 'Outbox' template's `processor.options` (see
-// @subql/node BlockchainService.updateDynamicDs), so `{ address }` binds each instance to its
-// Outbox while inheriting the template's abi + handlers. Event signatures are not authentication;
-// the mapping handler performs the registered-factory check before calling the constructor.
-
-type FrontierEvmTemplate = Omit<FrontierEvmDatasource, 'startBlock' | 'endBlock'> & { name: string };
+// This deliberately replaces the earlier per-Outbox dynamic datasources: a dynamic datasource is
+// persistent, reorg-unsafe indexer state that had to be guarded against counterfeit creation (audit
+// P2-1) and could never see messages published before it existed. Chain-wide filters match the same
+// logs through the same topic0 dictionary lookups, so legitimate indexing cost is unchanged, while
+// counterfeit events now cost one bounded row (or a log line) instead of a datasource.
 
 export const outboxDiscoveryDatasource: FrontierEvmDatasource = {
     kind: 'substrate/FrontierEvm',
@@ -357,12 +357,13 @@ export const outboxDiscoveryDatasource: FrontierEvmDatasource = {
     },
 };
 
-export const outboxTemplate: FrontierEvmTemplate = {
-    name: 'Outbox',
+export const outboxMessagesDatasource: FrontierEvmDatasource = {
     kind: 'substrate/FrontierEvm',
+    startBlock: 1,
     processor: {
         file: './node_modules/@subql/frontier-evm-processor/dist/bundle.js',
         options: {
+            // No `address`: the handlers authorize each event by its emitting contract instead.
             abi: 'outbox',
         },
     },

--- a/cc3-indexer/datasources.ts
+++ b/cc3-indexer/datasources.ts
@@ -225,8 +225,9 @@ export const attestationDatasources: SubstrateRuntimeDatasource = {
                 },
             },
             {
-                // USC write-ability: on-chain factory registration. The handler spins up a dynamic
-                // datasource for the registered factory (no address is configured anywhere).
+                // USC write-ability: on-chain factory registration. The handler records the
+                // governance authorization used to authenticate subsequent chain-wide
+                // OutboxCreated events (no address is configured anywhere).
                 kind: SubstrateHandlerKind.Event,
                 handler: 'handleOutboxFactoryRegistered',
                 filter: {
@@ -319,18 +320,15 @@ export const blockProverDatasource: FrontierEvmDatasource = {
 //     └─▶ createDynamicDatasource('Outbox', { address })   // watches each created Outbox
 //           └─ MessagePublished / MessageAcknowledged (EVM)
 //
-// Discovery watches `OutboxCreated` across all contracts by topic (no address), rather than
-// following the substrate OutboxFactoryRegistered event to the factory. This is deliberate: the
-// deploy flow calls the factory's `createOutbox` (emitting OutboxCreated) *before* it registers the
-// factory with the pallet, so a datasource that only started once the factory was registered would
-// miss the already-emitted OutboxCreated and index nothing. A chain-wide topic watch from block 1
-// is immune to that ordering. (The substrate OutboxFactoryRegistered handler still records the
-// OutboxFactory entity for display; it is no longer on the discovery path.)
+// Discovery watches `OutboxCreated` across all contracts by topic (no address), then the handler
+// authenticates the emitter against the governance registration for the event's chain key. Deploy
+// flows MUST register a factory before calling deployOutbox. This preserves address-free discovery
+// without allowing counterfeit contracts to create persistent dynamic datasources.
 //
 // createDynamicDatasource spreads its `args` into the 'Outbox' template's `processor.options` (see
 // @subql/node BlockchainService.updateDynamicDs), so `{ address }` binds each instance to its
-// Outbox while inheriting the template's abi + handlers. Only our OutboxFactory emits this exact
-// event signature, so the address-less filter yields only real Outbox creations.
+// Outbox while inheriting the template's abi + handlers. Event signatures are not authentication;
+// the mapping handler performs the registered-factory check before calling the constructor.
 
 type FrontierEvmTemplate = Omit<FrontierEvmDatasource, 'startBlock' | 'endBlock'> & { name: string };
 

--- a/cc3-indexer/project.ts
+++ b/cc3-indexer/project.ts
@@ -6,7 +6,7 @@ import {
     attestationDatasources,
     genesisDatasource,
     outboxDiscoveryDatasource,
-    outboxTemplate,
+    outboxMessagesDatasource,
 } from './datasources';
 
 import * as dotenv from 'dotenv';
@@ -24,8 +24,10 @@ const dataSources: (FrontierEvmDatasource | SubstrateRuntimeDatasource)[] = [];
 dataSources.push(attestationDatasources);
 dataSources.push(blockProverDatasource);
 dataSources.push(genesisDatasource);
-// USC write-ability: chain-wide OutboxCreated watch that spawns a dynamic datasource per Outbox.
+// USC write-ability: chain-wide topic watches; every event is authorized per-event in its handler
+// (no dynamic datasources — see datasources.ts).
 dataSources.push(outboxDiscoveryDatasource);
+dataSources.push(outboxMessagesDatasource);
 
 // Can expand the Datasource processor types via the genreic param
 const project: SubstrateProject<FrontierEvmDatasource> = {
@@ -60,8 +62,6 @@ const project: SubstrateProject<FrontierEvmDatasource> = {
         endpoint: process.env.ENDPOINT!?.split(',') as string[] | string,
     },
     dataSources,
-    // USC write-ability dynamic-datasource template (instantiated per discovered Outbox).
-    templates: [outboxTemplate],
 };
 
 // Must set default to the project instance

--- a/cc3-indexer/schema.graphql
+++ b/cc3-indexer/schema.graphql
@@ -515,8 +515,8 @@ type TransactionVerified @entity {
 type OutboxFactory @entity {
     """
     A USC write-ability OutboxFactory discovered on-chain via the substrate
-    `supportedChains.OutboxFactoryRegistered` event. Registering a factory triggers a dynamic
-    Frontier EVM datasource that watches it for OutboxCreated, so no factory address is configured.
+    `supportedChains.OutboxFactoryRegistered` event. The registration authenticates subsequent
+    chain-wide OutboxCreated events; no factory address is configured in the project manifest.
     """
     # Factory contract address (hex, lowercase)
     id: ID!
@@ -528,18 +528,18 @@ type OutboxFactory @entity {
     registeredTimestamp: BigInt!
 }
 
-type OutboxDatasourceCount @entity {
+type OutboxFactoryRegistration @entity {
     """
-    Number of UNAUTHENTICATED Outbox datasources registered per bytes32 chain key (audit P2-1).
-    Keyed by the chain key so it is read by id via `.get()`, which — unlike `getByField` — resolves
-    against the same-block store cache; this lets the datasource-creation cap hold even when many
-    `OutboxCreated` events for one chain key land in a single block. Datasources created by a
-    registered, chain-key-matching factory are trusted and are neither counted nor capped here.
+    Current governance-authorized OutboxFactory for one USC chain key. This separate mapping keeps
+    authentication exact when one factory serves multiple chain keys or governance rotates a key to
+    a new factory address.
     """
-    # bytes32 write-ability chain key (lowercase hex)
+    # USC chain key as a decimal string
     id: ID!
-    # Count of unauthenticated Outbox datasources registered for this chain key
-    count: BigInt!
+    # Governance-authorized factory contract address (hex, lowercase)
+    factoryAddress: String! @index
+    # Creditcoin L1 block at which this registration became authoritative
+    registeredAt: BigInt! @index
 }
 
 type OutboxContract @entity {

--- a/cc3-indexer/schema.graphql
+++ b/cc3-indexer/schema.graphql
@@ -544,9 +544,10 @@ type OutboxFactoryRegistration @entity {
 
 type OutboxContract @entity {
     """
-    An Outbox instance discovered on-chain via its factory's OutboxCreated event. Each discovery
-    spins up a dynamic Frontier EVM datasource that indexes this Outbox's messages — the addresses
-    are never hard-coded.
+    An Outbox instance discovered on-chain via its factory's OutboxCreated event and authorized
+    against the governance registration for its chain key — no addresses are hard-coded. The row's
+    existence IS the authorization: the chain-wide message handlers only index MessagePublished /
+    MessageAcknowledged whose emitting contract has an OutboxContract row.
     """
     # Outbox contract address (hex, lowercase)
     id: ID!
@@ -602,6 +603,53 @@ type OutboxMessage @entity {
     # Ack block timestamp (ms since epoch, null until acknowledged)
     acknowledgedTimestamp: BigInt
     # Ack transaction hash (null until acknowledged)
+    acknowledgedTxHash: String
+}
+
+type PendingOutbox @entity {
+    """
+    An OutboxCreated whose emitting factory is not (yet) the governance-registered factory for its
+    chain key. Discovery is fail-closed, but rejection must not be permanent: registration can
+    legitimately be indexed AFTER the factory deployed its Outbox (observed live on usc-dev), so the
+    event is quarantined here and promoted to an OutboxContract by handleOutboxFactoryRegistered the
+    moment governance authorizes the emitter. Rows are bounded per chain key (and gated on the chain
+    key actually existing as a SupportedChain), so counterfeit announcements cannot grow state
+    without bound.
+    """
+    # Announced Outbox contract address (hex, lowercase)
+    id: ID!
+    # Raw u64 USC chain key from the event
+    chainKey: BigInt! @index
+    # The contract that emitted OutboxCreated — authorized retroactively, or never
+    factoryAddress: String! @index
+    # bytes32 form of chainKey, stored so promotion needs no re-derivation
+    chainKeyBytes32: String!
+    # Creditcoin L1 block / timestamp / tx of the quarantined OutboxCreated
+    createdAt: BigInt!
+    createdTimestamp: BigInt!
+    createdTxHash: String!
+}
+
+type QuarantinedMessage @entity {
+    """
+    A MessagePublished observed on a PendingOutbox — kept so that when the pending Outbox is later
+    authorized, its pre-authorization history is promoted into OutboxMessage rows instead of being
+    lost (the backfill half of fail-closed discovery). Acks that arrive while quarantined are
+    recorded here too and survive promotion. Bounded per pending Outbox.
+    """
+    # messageId (bytes32, hex)
+    id: ID!
+    # The pending Outbox the message was observed on
+    outboxAddress: String! @index
+    emitter: String!
+    canAck: Boolean!
+    payload: String!
+    publishedAt: BigInt!
+    publishedTimestamp: BigInt!
+    publishedTxHash: String!
+    acknowledged: Boolean!
+    acknowledgedAt: BigInt
+    acknowledgedTimestamp: BigInt
     acknowledgedTxHash: String
 }
 

--- a/cc3-indexer/src/mappings/evmHandlers.ts
+++ b/cc3-indexer/src/mappings/evmHandlers.ts
@@ -317,9 +317,7 @@ export async function handleMessagePublished(event: FrontierEvmEvent<MessagePubl
     if (!outbox) {
         const pending = await PendingOutbox.get(outboxAddress);
         if (!pending) {
-            logger.debug(
-                `Ignoring MessagePublished from ${outboxAddress} — not an admitted or pending Outbox`,
-            );
+            logger.debug(`Ignoring MessagePublished from ${outboxAddress} — not an admitted or pending Outbox`);
             return;
         }
         await quarantineMessage(event, event.transactionHash, messageId, outboxAddress, emitter, canAck, payload);

--- a/cc3-indexer/src/mappings/evmHandlers.ts
+++ b/cc3-indexer/src/mappings/evmHandlers.ts
@@ -1,6 +1,14 @@
 import { FrontierEvmEvent } from '@subql/frontier-evm-processor';
-import { OutboxContract, OutboxFactoryRegistration, OutboxMessage, TransactionVerified } from '../types';
-import { createOutboxDatasource } from '../types';
+import {
+    OutboxContract,
+    OutboxFactoryRegistration,
+    OutboxMessage,
+    PendingOutbox,
+    QuarantinedMessage,
+    SupportedChain,
+    TransactionVerified,
+} from '../types';
+import { flushStore } from './storeUtils';
 
 // Encode a u64 write-ability chain key as its bytes32 form: `bytes32(uint256(chainKey))`, i.e. the
 // 8 big-endian bytes right-aligned in a 32-byte word (matches `chain_key_to_bytes32` in the shared
@@ -56,7 +64,8 @@ export async function handleTransactionVerified(event: FrontierEvmEvent<Transact
     await verification.save();
 }
 
-// USC write-ability: dynamically-discovered Outbox contracts on Creditcoin L1.
+// USC write-ability: on-chain-discovered Outbox contracts on Creditcoin L1, authorized per event
+// against governance state (see datasources.ts for the discovery/authorization model).
 // OutboxFactory: OutboxCreated(bytes32 indexed chainKey, address indexed outboxAddress)
 // OutboxCreated(address indexed outbox, uint32 indexed chainKey, address indexed owner, address validator, string version)
 type OutboxCreatedArgs = [string, bigint, string, string, string];
@@ -72,6 +81,13 @@ function eventTimestamp(event: { blockTimestamp?: Date }): bigint {
     return event.blockTimestamp ? BigInt(event.blockTimestamp.getTime()) : BigInt(Date.now());
 }
 
+// Quarantine bounds. Both caps are deliberately small: in a correct deployment the quarantine only
+// bridges the gap between `deployOutbox` and its registration being indexed (a few blocks), so
+// anything approaching these numbers is counterfeit traffic. Rejected overflow is logged loudly —
+// a legitimate Outbox hitting the cap is an operator problem to surface, never silent truncation.
+export const MAX_PENDING_OUTBOXES_PER_CHAIN_KEY = 8;
+export const MAX_QUARANTINED_MESSAGES_PER_OUTBOX = 256;
+
 export async function handleOutboxCreated(event: FrontierEvmEvent<OutboxCreatedArgs>): Promise<void> {
     if (!event.args) {
         logger.error(`No args found for OutboxCreated event at block ${event.blockNumber}`);
@@ -85,7 +101,8 @@ export async function handleOutboxCreated(event: FrontierEvmEvent<OutboxCreatedA
     // Synced factory event: (outbox, chainKey:uint32, owner, validator, version). chainKey arrives
     // as a number; normalize to the same bytes32 form the factory-correspondence check below uses.
     const [outboxAddress, chainKeyRaw] = event.args;
-    const chainKey = u64ChainKeyToBytes32(BigInt(chainKeyRaw));
+    const chainKeyNumber = BigInt(chainKeyRaw);
+    const chainKey = u64ChainKeyToBytes32(chainKeyNumber);
     const address = outboxAddress.toLowerCase();
     // event.address is the factory that emitted OutboxCreated.
     const factoryId = event.address ? event.address.toLowerCase() : undefined;
@@ -93,54 +110,178 @@ export async function handleOutboxCreated(event: FrontierEvmEvent<OutboxCreatedA
     logger.info(`OutboxCreated: outbox=${address}, chainKey=${chainKey}, factory=${factoryId}`);
 
     // Idempotency guard: reprocessing the same OutboxCreated log (reorg replay, reindex overlap)
-    // must not register a SECOND dynamic datasource for the same address — duplicate datasources
-    // make every subsequent MessagePublished on this Outbox fire its handler once per duplicate.
+    // must not disturb an already-admitted Outbox.
     const existing = await OutboxContract.get(address);
     if (existing) {
-        logger.warn(`OutboxCreated for already-registered outbox ${address} — skipping duplicate datasource`);
+        logger.warn(`OutboxCreated for already-admitted outbox ${address} — keeping existing record`);
         return;
     }
 
-    // Dynamic datasources are security-sensitive persistent state: accepting an event merely because
-    // its signature matches lets any contract create an unlimited number of them. Require the
-    // emitting factory to be the exact address governance registered for this raw USC chain key.
-    // Deployment tooling registers the factory before it calls deployOutbox, so this check is both
-    // fail-closed and lossless. `OutboxFactoryRegistration` is keyed by chain key, which also handles
-    // multi-key factories and rotations without relying on the display-oriented OutboxFactory row.
-    const registration = await OutboxFactoryRegistration.get(BigInt(chainKeyRaw).toString());
-    if (!factoryId || !registration || registration.factoryAddress !== factoryId) {
+    // An OutboxContract row is the authorization the chain-wide message handlers key on, so creating
+    // one requires the emitting factory to be the exact address governance registered for this raw
+    // USC chain key. `OutboxFactoryRegistration` is keyed by chain key, which also handles multi-key
+    // factories and rotations without relying on the display-oriented OutboxFactory row.
+    const registration = await OutboxFactoryRegistration.get(chainKeyNumber.toString());
+    if (factoryId && registration && registration.factoryAddress === factoryId) {
+        await admitOutbox({
+            address,
+            chainKeyBytes32: chainKey,
+            factoryAddress: factoryId,
+            createdAt: BigInt(event.blockNumber),
+            createdTimestamp: eventTimestamp(event),
+            createdTxHash: event.transactionHash,
+        });
+        return;
+    }
+
+    // Fail-closed, but not fail-forever: the registration for this chain key may simply not be
+    // indexed yet (governance can authorize a factory AFTER it deployed its Outbox — observed live
+    // on usc-dev, where OutboxCreated landed ~200 blocks before OutboxFactoryRegistered). Quarantine
+    // the announcement so handleOutboxFactoryRegistered can promote it retroactively. Quarantine is
+    // bounded: only chain keys governance actually created can hold pending rows, and each key holds
+    // at most MAX_PENDING_OUTBOXES_PER_CHAIN_KEY of them.
+    if (!factoryId) {
+        logger.warn(`Rejecting OutboxCreated with no emitter address: outbox=${address}`);
+        return;
+    }
+    if (await PendingOutbox.get(address)) {
+        logger.warn(`OutboxCreated replay for already-quarantined outbox ${address} — keeping existing record`);
+        return;
+    }
+    // Same-block writes are only visible to getByFields after a flush.
+    await flushStore();
+    const knownChain = await SupportedChain.getByFields([['chainKey', '=', chainKeyNumber]], { limit: 1 });
+    if (knownChain.length === 0) {
         logger.warn(
-            `Rejecting unauthenticated OutboxCreated: outbox=${address}, chainKey=${chainKeyRaw.toString()}, ` +
-                `emitter=${factoryId ?? 'missing'}, registered=${registration?.factoryAddress ?? 'none'}`,
+            `Rejecting OutboxCreated for unknown chain key: outbox=${address}, chainKey=${chainKeyNumber.toString()}, ` +
+                `emitter=${factoryId} (chain key was never registered — not quarantining)`,
         );
         return;
     }
-
-    // Persist the parent OutboxContract entity BEFORE spinning up the dynamic datasource. A dynamic
-    // datasource created mid-block handles the *same* block's later events, so a `MessagePublished`
-    // emitted in the same block as `OutboxCreated` would run its handler — which sets the required
-    // `outbox` relation — and must find the parent already staged in the store cache. Saving first
-    // guarantees that (both writes commit together in the block's transaction).
-    //
-    // Ordering note (reconciles three review passes on these lines): SubQuery buffers `.save()` into
-    // the per-block store transaction, so save-first does NOT strand the datasource on a partial
-    // failure — if `createOutboxDatasource` throws, the whole block rolls back (including this save)
-    // and the retry re-runs both cleanly. The residual duplicate-on-crash window is identical in
-    // either order (the datasource-metadata write is the only non-transactional step) and is a
-    // framework limitation, not an ordering bug; the `OutboxContract.get` guard above covers the
-    // common replay/reorg case. `{ address }` binds the template instance; SubQuery sets the
-    // datasource's start block to the current block automatically.
-    const outbox = OutboxContract.create({
+    const pendingForKey = await PendingOutbox.getByFields([['chainKey', '=', chainKeyNumber]], {
+        limit: MAX_PENDING_OUTBOXES_PER_CHAIN_KEY,
+    });
+    if (pendingForKey.length >= MAX_PENDING_OUTBOXES_PER_CHAIN_KEY) {
+        logger.error(
+            `Pending-Outbox quarantine full for chain key ${chainKeyNumber.toString()} ` +
+                `(${MAX_PENDING_OUTBOXES_PER_CHAIN_KEY} rows) — dropping OutboxCreated for ${address}. ` +
+                `If this Outbox is legitimate, register its factory and reindex past this block.`,
+        );
+        return;
+    }
+    logger.info(
+        `Quarantining unauthenticated OutboxCreated: outbox=${address}, chainKey=${chainKeyNumber.toString()}, ` +
+            `emitter=${factoryId}, registered=${registration?.factoryAddress ?? 'none'}`,
+    );
+    await PendingOutbox.create({
         id: address,
-        chainKey,
-        factoryId,
+        chainKey: chainKeyNumber,
+        factoryAddress: factoryId,
+        chainKeyBytes32: chainKey,
         createdAt: BigInt(event.blockNumber),
         createdTimestamp: eventTimestamp(event),
         createdTxHash: event.transactionHash,
-    });
-    await outbox.save();
+    }).save();
+}
 
-    await createOutboxDatasource({ address });
+/** Create the admitted OutboxContract row — shared by direct admission and quarantine promotion. */
+async function admitOutbox(outbox: {
+    address: string;
+    chainKeyBytes32: string;
+    factoryAddress: string;
+    createdAt: bigint;
+    createdTimestamp: bigint;
+    createdTxHash: string;
+}): Promise<void> {
+    await OutboxContract.create({
+        id: outbox.address,
+        chainKey: outbox.chainKeyBytes32,
+        factoryId: outbox.factoryAddress,
+        createdAt: outbox.createdAt,
+        createdTimestamp: outbox.createdTimestamp,
+        createdTxHash: outbox.createdTxHash,
+    }).save();
+}
+
+/**
+ * Backfill half of fail-closed discovery, called by `handleOutboxFactoryRegistered` right after it
+ * stores the registration: promote every quarantined Outbox this registration retroactively
+ * authorizes, along with the messages observed on it while it was pending. Non-matching pending rows
+ * for the key are left alone — a later rotation may authorize them.
+ */
+export async function promotePendingOutboxes(chainKey: bigint, factoryAddress: string): Promise<void> {
+    // The registration (and, same-block, possibly the pending rows) must be visible to getByFields.
+    await flushStore();
+    const pending = await PendingOutbox.getByFields([['chainKey', '=', chainKey]], {
+        limit: MAX_PENDING_OUTBOXES_PER_CHAIN_KEY,
+    });
+    for (const p of pending) {
+        if (p.factoryAddress !== factoryAddress) {
+            continue;
+        }
+        logger.info(
+            `Promoting quarantined Outbox ${p.id} (chainKey=${chainKey.toString()}) — ` +
+                `its factory ${factoryAddress} is now governance-registered`,
+        );
+        if (!(await OutboxContract.get(p.id))) {
+            await admitOutbox({
+                address: p.id,
+                chainKeyBytes32: p.chainKeyBytes32,
+                factoryAddress,
+                createdAt: p.createdAt,
+                createdTimestamp: p.createdTimestamp,
+                createdTxHash: p.createdTxHash,
+            });
+        }
+        const messages = await QuarantinedMessage.getByFields([['outboxAddress', '=', p.id]], {
+            limit: MAX_QUARANTINED_MESSAGES_PER_OUTBOX,
+        });
+        for (const m of messages) {
+            if (!(await OutboxMessage.get(m.id))) {
+                await OutboxMessage.create({
+                    id: m.id,
+                    outboxId: p.id,
+                    emitter: m.emitter,
+                    canAck: m.canAck,
+                    payload: m.payload,
+                    publishedAt: m.publishedAt,
+                    publishedTimestamp: m.publishedTimestamp,
+                    publishedTxHash: m.publishedTxHash,
+                    acknowledged: m.acknowledged,
+                    acknowledgedAt: m.acknowledgedAt,
+                    acknowledgedTimestamp: m.acknowledgedTimestamp,
+                    acknowledgedTxHash: m.acknowledgedTxHash,
+                }).save();
+            }
+            await QuarantinedMessage.remove(m.id);
+        }
+        if (messages.length > 0) {
+            logger.info(`Backfilled ${messages.length} quarantined message(s) for promoted Outbox ${p.id}`);
+        }
+        await PendingOutbox.remove(p.id);
+    }
+}
+
+/**
+ * Drop every quarantined Outbox (and its quarantined messages) for a chain key governance removed —
+ * called by `handleSupportedChainRemoved` after it revokes the factory registration. Without a chain
+ * key there is nothing left that could ever authorize these rows.
+ */
+export async function purgePendingOutboxes(chainKey: bigint): Promise<void> {
+    await flushStore();
+    const pending = await PendingOutbox.getByFields([['chainKey', '=', chainKey]], {
+        limit: MAX_PENDING_OUTBOXES_PER_CHAIN_KEY,
+    });
+    for (const p of pending) {
+        const messages = await QuarantinedMessage.getByFields([['outboxAddress', '=', p.id]], {
+            limit: MAX_QUARANTINED_MESSAGES_PER_OUTBOX,
+        });
+        for (const m of messages) {
+            await QuarantinedMessage.remove(m.id);
+        }
+        await PendingOutbox.remove(p.id);
+        logger.info(`Purged quarantined Outbox ${p.id} (chain key ${chainKey.toString()} removed)`);
+    }
 }
 
 export async function handleMessagePublished(event: FrontierEvmEvent<MessagePublishedArgs>): Promise<void> {
@@ -166,12 +307,30 @@ export async function handleMessagePublished(event: FrontierEvmEvent<MessagePubl
     // (bytes32(bytes20(emitter))). Recover the plain address so stored/queried emitters stay
     // 20-byte addresses, consistent with the rest of the schema.
     const emitter = `0x${emitterRaw.slice(2, 42)}`.toLowerCase();
+    const outboxAddress = event.address.toLowerCase();
+
+    // Per-event authorization: this handler is chain-wide (no address filter), so the emitting
+    // contract decides the event's fate. An admitted Outbox indexes normally; one still in
+    // quarantine gets its message quarantined alongside it (promoted together later); anything
+    // else is an arbitrary contract emitting a look-alike event and is dropped without state.
+    const outbox = await OutboxContract.get(outboxAddress);
+    if (!outbox) {
+        const pending = await PendingOutbox.get(outboxAddress);
+        if (!pending) {
+            logger.debug(
+                `Ignoring MessagePublished from ${outboxAddress} — not an admitted or pending Outbox`,
+            );
+            return;
+        }
+        await quarantineMessage(event, event.transactionHash, messageId, outboxAddress, emitter, canAck, payload);
+        return;
+    }
+
     logger.info(`MessagePublished: messageId=${messageId}, emitter=${emitter}, canAck=${canAck}`);
 
-    // Idempotency guard: a replayed MessagePublished (reorg replay, reindex overlap, duplicate
-    // datasource) must not reset a message that handleMessageAcknowledged already marked
-    // acknowledged — the publish fields are immutable per messageId, so there is nothing to
-    // update either. Skip instead of overwriting.
+    // Idempotency guard: a replayed MessagePublished (reorg replay, reindex overlap) must not reset
+    // a message that handleMessageAcknowledged already marked acknowledged — the publish fields are
+    // immutable per messageId, so there is nothing to update either. Skip instead of overwriting.
     const existing = await OutboxMessage.get(messageId);
     if (existing) {
         logger.warn(`MessagePublished replay for already-indexed message ${messageId} — keeping existing record`);
@@ -182,7 +341,7 @@ export async function handleMessagePublished(event: FrontierEvmEvent<MessagePubl
     // outboxId references the OutboxContract created by handleOutboxCreated (same lowercased address).
     const message = OutboxMessage.create({
         id: messageId,
-        outboxId: event.address.toLowerCase(),
+        outboxId: outboxAddress,
         emitter,
         canAck,
         payload,
@@ -198,6 +357,51 @@ export async function handleMessagePublished(event: FrontierEvmEvent<MessagePubl
     await message.save();
 }
 
+/** Hold a message observed on a still-pending Outbox for promotion, bounded per Outbox. */
+async function quarantineMessage(
+    event: FrontierEvmEvent<MessagePublishedArgs>,
+    // Separate from `event` because the caller has already null-guarded it (TS can't carry that
+    // narrowing across the function boundary).
+    publishedTxHash: string,
+    messageId: string,
+    outboxAddress: string,
+    emitter: string,
+    canAck: boolean,
+    payload: string,
+): Promise<void> {
+    if (await QuarantinedMessage.get(messageId)) {
+        logger.warn(`MessagePublished replay for already-quarantined message ${messageId} — keeping existing record`);
+        return;
+    }
+    await flushStore();
+    const held = await QuarantinedMessage.getByFields([['outboxAddress', '=', outboxAddress]], {
+        limit: MAX_QUARANTINED_MESSAGES_PER_OUTBOX,
+    });
+    if (held.length >= MAX_QUARANTINED_MESSAGES_PER_OUTBOX) {
+        logger.error(
+            `Message quarantine full for pending Outbox ${outboxAddress} ` +
+                `(${MAX_QUARANTINED_MESSAGES_PER_OUTBOX} rows) — dropping message ${messageId}. ` +
+                `If this Outbox is legitimate, register its factory and reindex past this block.`,
+        );
+        return;
+    }
+    logger.info(`Quarantining MessagePublished ${messageId} from pending Outbox ${outboxAddress}`);
+    await QuarantinedMessage.create({
+        id: messageId,
+        outboxAddress,
+        emitter,
+        canAck,
+        payload,
+        publishedAt: BigInt(event.blockNumber),
+        publishedTimestamp: eventTimestamp(event),
+        publishedTxHash,
+        acknowledged: false,
+        acknowledgedAt: undefined,
+        acknowledgedTimestamp: undefined,
+        acknowledgedTxHash: undefined,
+    }).save();
+}
+
 export async function handleMessageAcknowledged(event: FrontierEvmEvent<MessageAcknowledgedArgs>): Promise<void> {
     if (!event.args) {
         logger.error(`No args found for MessageAcknowledged event at block ${event.blockNumber}`);
@@ -205,21 +409,55 @@ export async function handleMessageAcknowledged(event: FrontierEvmEvent<MessageA
     }
 
     const [messageId] = event.args;
-    logger.info(`MessageAcknowledged: messageId=${messageId}`);
+    if (!event.address) {
+        logger.error(`Contract address missing for MessageAcknowledged at block ${event.blockNumber}. Skipping.`);
+        return;
+    }
+    const outboxAddress = event.address.toLowerCase();
 
-    // The publish is always seen first when the Outbox is indexed from its creation block. If it is
-    // missing, the indexer's start block is after the publish — log and skip rather than fabricate a
-    // record with no publish metadata (the entity's publish fields are non-null by design).
+    // Per-event authorization, like handleMessagePublished: this handler is chain-wide, so an ack is
+    // only honored when it was emitted by the same contract that holds the message. Without this, any
+    // contract could emit MessageAcknowledged with a known messageId and flip a real message's state.
     const message = await OutboxMessage.get(messageId);
-    if (!message) {
-        logger.warn(`MessageAcknowledged for unindexed message ${messageId} (publish before start block?) — skipping`);
+    if (message) {
+        if (message.outboxId !== outboxAddress) {
+            logger.warn(
+                `Ignoring MessageAcknowledged for ${messageId} from ${outboxAddress} — ` +
+                    `the message belongs to Outbox ${message.outboxId}`,
+            );
+            return;
+        }
+        logger.info(`MessageAcknowledged: messageId=${messageId}`);
+        message.acknowledged = true;
+        message.acknowledgedAt = BigInt(event.blockNumber);
+        message.acknowledgedTimestamp = eventTimestamp(event);
+        message.acknowledgedTxHash = event.transactionHash ?? undefined;
+        await message.save();
         return;
     }
 
-    message.acknowledged = true;
-    message.acknowledgedAt = BigInt(event.blockNumber);
-    message.acknowledgedTimestamp = eventTimestamp(event);
-    message.acknowledgedTxHash = event.transactionHash ?? undefined;
+    // An ack can land while the message is still quarantined (Outbox not yet authorized). Record it
+    // on the quarantine row so promotion carries the full lifecycle, not just the publish.
+    const quarantined = await QuarantinedMessage.get(messageId);
+    if (quarantined) {
+        if (quarantined.outboxAddress !== outboxAddress) {
+            logger.warn(
+                `Ignoring MessageAcknowledged for quarantined ${messageId} from ${outboxAddress} — ` +
+                    `the message was observed on ${quarantined.outboxAddress}`,
+            );
+            return;
+        }
+        logger.info(`MessageAcknowledged (quarantined): messageId=${messageId}`);
+        quarantined.acknowledged = true;
+        quarantined.acknowledgedAt = BigInt(event.blockNumber);
+        quarantined.acknowledgedTimestamp = eventTimestamp(event);
+        quarantined.acknowledgedTxHash = event.transactionHash ?? undefined;
+        await quarantined.save();
+        return;
+    }
 
-    await message.save();
+    // The publish is always seen first when its Outbox is admitted or pending. If neither record
+    // exists, this is either an arbitrary contract emitting a look-alike event (drop silently-ish)
+    // or an Outbox that was never authorized at all.
+    logger.debug(`MessageAcknowledged for unknown message ${messageId} from ${outboxAddress} — skipping`);
 }

--- a/cc3-indexer/src/mappings/evmHandlers.ts
+++ b/cc3-indexer/src/mappings/evmHandlers.ts
@@ -85,8 +85,10 @@ function eventTimestamp(event: { blockTimestamp?: Date }): bigint {
 // bridges the gap between `deployOutbox` and its registration being indexed (a few blocks), so
 // anything approaching these numbers is counterfeit traffic. Rejected overflow is logged loudly —
 // a legitimate Outbox hitting the cap is an operator problem to surface, never silent truncation.
+// Both values double as `getByFields` limits, which SubQuery hard-caps at 100 — a larger cap makes
+// the lookup THROW at runtime, halting the indexer on the first quarantined message (seen in CI).
 export const MAX_PENDING_OUTBOXES_PER_CHAIN_KEY = 8;
-export const MAX_QUARANTINED_MESSAGES_PER_OUTBOX = 256;
+export const MAX_QUARANTINED_MESSAGES_PER_OUTBOX = 100;
 
 export async function handleOutboxCreated(event: FrontierEvmEvent<OutboxCreatedArgs>): Promise<void> {
     if (!event.args) {

--- a/cc3-indexer/src/mappings/evmHandlers.ts
+++ b/cc3-indexer/src/mappings/evmHandlers.ts
@@ -1,14 +1,6 @@
 import { FrontierEvmEvent } from '@subql/frontier-evm-processor';
-import { OutboxContract, OutboxDatasourceCount, OutboxFactory, OutboxMessage, TransactionVerified } from '../types';
+import { OutboxContract, OutboxFactoryRegistration, OutboxMessage, TransactionVerified } from '../types';
 import { createOutboxDatasource } from '../types';
-
-// Upper bound on how many UNAUTHENTICATED Outbox datasources we will spin up for a single
-// write-ability chain key. A legitimate deployment has one Outbox per chain key (a handful across
-// redeploys); a large count means a counterfeit contract is emitting `OutboxCreated` to make us
-// register unbounded dynamic datasources (audit P2-1 — datasource-creation DoS). Datasources from a
-// registered, chain-key-matching factory are trusted and exempt. The cap bounds the blast radius
-// without breaking the intentional discover-before-registration flow (see datasources.ts).
-const MAX_OUTBOXES_PER_CHAIN_KEY = 32n;
 
 // Encode a u64 write-ability chain key as its bytes32 form: `bytes32(uint256(chainKey))`, i.e. the
 // 8 big-endian bytes right-aligned in a 32-byte word (matches `chain_key_to_bytes32` in the shared
@@ -109,51 +101,19 @@ export async function handleOutboxCreated(event: FrontierEvmEvent<OutboxCreatedA
         return;
     }
 
-    // P2-10 — factory correspondence. Discovery watches `OutboxCreated` chain-wide by topic (a
-    // factory creates Outboxes *before* it is registered via `OutboxFactoryRegistered`), so we can
-    // never hard-require a registered emitter — a counterfeit emitter is simply never a registered
-    // OutboxFactory. `authenticated` is therefore a best-effort trust signal, not a gate: it is true
-    // only when the emitter IS a registered factory AND (one of) its registered chain key(s) matches
-    // the event's bytes32 chain key. NOTE: one factory address may legitimately serve multiple chain
-    // keys (the pallet maps chain_key -> factory), and `OutboxFactory` records only the first, so a
-    // mismatch is logged but is NOT treated as fatal — dropping the Outbox here would strand a
-    // legitimate multi-key factory's messages (a liveness bug worse than the ~zero authentication
-    // this check buys). The trust signal only relaxes the DoS cap below.
-    let authenticated = false;
-    if (factoryId) {
-        const factory = await OutboxFactory.get(factoryId);
-        if (factory) {
-            if (u64ChainKeyToBytes32(factory.chainKey) === chainKey) {
-                authenticated = true;
-            } else {
-                logger.warn(
-                    `OutboxCreated from registered factory ${factoryId} for chainKey ${chainKey} does not ` +
-                        `match its recorded chainKey ${factory.chainKey.toString()} — indexing anyway ` +
-                        `(a factory may serve multiple chain keys), but not exempting it from the DoS cap`,
-                );
-            }
-        }
-    }
-
-    // P2-1 — datasource-creation DoS cap. Bound the number of UNAUTHENTICATED dynamic datasources per
-    // chain key so a counterfeit contract spamming `OutboxCreated` cannot make us register unbounded
-    // datasources. The count is a by-id entity (keyed by chain key) so `.get()` sees same-block
-    // buffered writes — a `getByField` count would miss datasources created earlier in the same block
-    // and let a single-transaction flood bypass the cap entirely. Trusted (authenticated) factories
-    // are neither counted nor capped, so a legitimate factory is never blocked by counterfeit rows.
-    if (!authenticated) {
-        const counter = await OutboxDatasourceCount.get(chainKey);
-        // Explicit BigInt(): the entity field is BigInt! in schema.graphql, but `src/types` is
-        // generated (and gitignored), so this file is also linted against a stale/absent type.
-        // Converting keeps the comparison and the increment below unambiguously bigint either way.
-        const current = BigInt(counter?.count ?? 0);
-        if (current >= MAX_OUTBOXES_PER_CHAIN_KEY) {
-            logger.warn(
-                `OutboxCreated for ${address}: chainKey ${chainKey} already has ${current} unauthenticated ` +
-                    `Outbox datasources (cap ${MAX_OUTBOXES_PER_CHAIN_KEY}) — skipping to bound datasource-creation DoS`,
-            );
-            return;
-        }
+    // Dynamic datasources are security-sensitive persistent state: accepting an event merely because
+    // its signature matches lets any contract create an unlimited number of them. Require the
+    // emitting factory to be the exact address governance registered for this raw USC chain key.
+    // Deployment tooling registers the factory before it calls deployOutbox, so this check is both
+    // fail-closed and lossless. `OutboxFactoryRegistration` is keyed by chain key, which also handles
+    // multi-key factories and rotations without relying on the display-oriented OutboxFactory row.
+    const registration = await OutboxFactoryRegistration.get(BigInt(chainKeyRaw).toString());
+    if (!factoryId || !registration || registration.factoryAddress !== factoryId) {
+        logger.warn(
+            `Rejecting unauthenticated OutboxCreated: outbox=${address}, chainKey=${chainKeyRaw.toString()}, ` +
+                `emitter=${factoryId ?? 'missing'}, registered=${registration?.factoryAddress ?? 'none'}`,
+        );
+        return;
     }
 
     // Persist the parent OutboxContract entity BEFORE spinning up the dynamic datasource. A dynamic
@@ -179,14 +139,6 @@ export async function handleOutboxCreated(event: FrontierEvmEvent<OutboxCreatedA
         createdTxHash: event.transactionHash,
     });
     await outbox.save();
-
-    // Charge the per-chain-key DoS counter for unauthenticated datasources only (see the cap above).
-    // Read-modify-write by id so multiple OutboxCreated in one block increment correctly (by-id gets
-    // see same-block buffered writes).
-    if (!authenticated) {
-        const counter = await OutboxDatasourceCount.get(chainKey);
-        await OutboxDatasourceCount.create({ id: chainKey, count: BigInt(counter?.count ?? 0) + 1n }).save();
-    }
 
     await createOutboxDatasource({ address });
 }

--- a/cc3-indexer/src/mappings/mappingHandlers.ts
+++ b/cc3-indexer/src/mappings/mappingHandlers.ts
@@ -40,6 +40,8 @@ import {
 } from '../types';
 import { Balance } from '@polkadot/types/interfaces';
 import { getChainData, fetchAttestationParams, chainDataId } from './initStore';
+import { flushStore } from './storeUtils';
+import { promotePendingOutboxes, purgePendingOutboxes } from './evmHandlers';
 
 const RuntimeAttestorStatus = {
     active: 0,
@@ -53,29 +55,6 @@ const RuntimeAttestorStatus = {
     unregistered: 4,
 } as const;
 
-/**
- * Flush pending store writes to the database before performing deletions.
- *
- * SubQuery buffers entity `.save()` calls in an in-memory store cache and only
- * persists them to the DB between blocks. Read APIs such as `getByFields` resolve
- * against persisted data, so an entity created earlier *in the same block* is not
- * visible to a subsequent delete query and would survive a deletion pass.
- *
- * This bites the attestation-revert path: when a `commitAttestation` and a
- * `revertTo` land in the same block, the freshly-created attestation is not seen
- * by `remove_attestations_above_height` and is never deleted. Flushing first makes
- * the pending writes visible so the delete queries see (and remove) them.
- *
- * `flush()` lives on the store cache in `@subql/node` but is not declared on the
- * public `@subql/types` `Store` interface, so it is accessed via a guarded cast
- * and no-ops if unavailable (never breaks indexing).
- */
-async function flushStore(): Promise<void> {
-    const maybeFlush = (store as unknown as { flush?: () => Promise<void> }).flush;
-    if (typeof maybeFlush === 'function') {
-        await maybeFlush.call(store);
-    }
-}
 
 export async function handleEventAttestorsElected(event: SubstrateEvent): Promise<void> {
     logger.info(`New Attestors Elected event found at block ${event.block.block.header.number.toString()}`);
@@ -233,6 +212,10 @@ export async function handleOutboxFactoryRegistered(event: SubstrateEvent): Prom
         registeredAt: blockNumber,
     });
     await Promise.all([factory.save(), registration.save()]);
+
+    // Backfill: this registration may retroactively authorize an Outbox whose OutboxCreated (and
+    // messages) arrived first and sit in quarantine — promote them now instead of losing them.
+    await promotePendingOutboxes(BigInt(chainKey.toString()), address);
 }
 
 export async function handleSupportedChainRemoved(event: SubstrateEvent): Promise<void> {
@@ -276,6 +259,9 @@ export async function handleSupportedChainRemoved(event: SubstrateEvent): Promis
     if (outboxFactoryRegistration) {
         await OutboxFactoryRegistration.remove(chainKeyStr);
     }
+
+    // With the chain key gone nothing can ever authorize its quarantined Outboxes — drop them too.
+    await purgePendingOutboxes(chainKeyNumber);
 
     const supportedChain = await SupportedChain.getByFields([['chainKey', '=', chainKeyStr]], { limit: 1 });
     if (isEmpty(supportedChain)) {

--- a/cc3-indexer/src/mappings/mappingHandlers.ts
+++ b/cc3-indexer/src/mappings/mappingHandlers.ts
@@ -55,7 +55,6 @@ const RuntimeAttestorStatus = {
     unregistered: 4,
 } as const;
 
-
 export async function handleEventAttestorsElected(event: SubstrateEvent): Promise<void> {
     logger.info(`New Attestors Elected event found at block ${event.block.block.header.number.toString()}`);
 

--- a/cc3-indexer/src/mappings/mappingHandlers.ts
+++ b/cc3-indexer/src/mappings/mappingHandlers.ts
@@ -36,6 +36,7 @@ import {
     ForcedElection,
     RevertedAttestationChainTo,
     OutboxFactory,
+    OutboxFactoryRegistration,
 } from '../types';
 import { Balance } from '@polkadot/types/interfaces';
 import { getChainData, fetchAttestationParams, chainDataId } from './initStore';
@@ -199,9 +200,9 @@ export async function handleSupportedChainRegistered(event: SubstrateEvent): Pro
 
 // USC write-ability: an operator registered an OutboxFactory for a chain key
 // (supportedChains.OutboxFactoryRegistered { chain_key, outbox_factory_addr }). Recorded for
-// display / to resolve OutboxContract.factory. Discovery of Outboxes does NOT depend on this event
-// — see the chain-wide OutboxCreated watch in datasources.ts (the factory creates Outboxes before
-// it is registered here, so following this event would miss them).
+// display / to resolve OutboxContract.factory. The registration is also the authorization gate for
+// chain-wide OutboxCreated discovery: deployment must register the factory before creating an
+// Outbox, otherwise the event is intentionally rejected as unauthenticated.
 export async function handleOutboxFactoryRegistered(event: SubstrateEvent): Promise<void> {
     const {
         event: {
@@ -214,23 +215,24 @@ export async function handleOutboxFactoryRegistered(event: SubstrateEvent): Prom
 
     logger.info(`OutboxFactoryRegistered: factory=${address}, chainKey=${chainKey.toString()} at block ${blockNumber}`);
 
-    // Idempotency guard: `set_outbox_factory_addr` emits `OutboxFactoryRegistered` on every update,
-    // and a reorg replay / reindex overlap re-delivers the same log. Recording the first
-    // registration is enough (the entity only backs display + `OutboxContract.factory` resolution),
-    // so skip if we already have it rather than re-`create`/`save` a duplicate id.
+    // `OutboxFactory` is display-oriented and keyed by address. Keep the first chain key for an
+    // address, while the authoritative per-chain registration below is always upserted so rotations
+    // and a single factory serving several keys are represented exactly.
     const existing = await OutboxFactory.get(address);
-    if (existing) {
-        logger.warn(`OutboxFactoryRegistered for already-recorded factory ${address} — skipping`);
-        return;
-    }
-
-    const factory = OutboxFactory.create({
-        id: address,
-        chainKey: BigInt(chainKey.toString()),
+    const factory =
+        existing ??
+        OutboxFactory.create({
+            id: address,
+            chainKey: BigInt(chainKey.toString()),
+            registeredAt: blockNumber,
+            registeredTimestamp: event.block.timestamp ? BigInt(event.block.timestamp.getTime()) : BigInt(0),
+        });
+    const registration = OutboxFactoryRegistration.create({
+        id: chainKey.toString(),
+        factoryAddress: address,
         registeredAt: blockNumber,
-        registeredTimestamp: event.block.timestamp ? BigInt(event.block.timestamp.getTime()) : BigInt(0),
     });
-    await factory.save();
+    await Promise.all([factory.save(), registration.save()]);
 }
 
 export async function handleSupportedChainRemoved(event: SubstrateEvent): Promise<void> {
@@ -266,6 +268,14 @@ export async function handleSupportedChainRemoved(event: SubstrateEvent): Promis
 
     // Flush pending in-block writes so deletions below see same-block entities.
     await flushStore();
+
+    // `remove_chain` clears the runtime's OutboxFactories entry. Mirror that revocation in the
+    // indexer's authorization table before any later counterfeit/stale OutboxCreated event can use
+    // the former factory registration to create a persistent datasource.
+    const outboxFactoryRegistration = await OutboxFactoryRegistration.get(chainKeyStr);
+    if (outboxFactoryRegistration) {
+        await OutboxFactoryRegistration.remove(chainKeyStr);
+    }
 
     const supportedChain = await SupportedChain.getByFields([['chainKey', '=', chainKeyStr]], { limit: 1 });
     if (isEmpty(supportedChain)) {

--- a/cc3-indexer/src/mappings/storeUtils.ts
+++ b/cc3-indexer/src/mappings/storeUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * Flush pending store writes to the database before field-filtered reads or deletions.
+ *
+ * SubQuery buffers entity `.save()` calls in an in-memory store cache and only
+ * persists them to the DB between blocks. Read APIs such as `getByFields` resolve
+ * against persisted data, so an entity created earlier *in the same block* is not
+ * visible to a subsequent field-filtered query and would be silently missed
+ * (`get` by id reads through the cache and does not need this).
+ *
+ * `flush()` lives on the store cache in `@subql/node` but is not declared on the
+ * public `@subql/types` `Store` interface, so it is accessed via a guarded cast
+ * and no-ops if unavailable (never breaks indexing).
+ */
+export async function flushStore(): Promise<void> {
+    const maybeFlush = (store as unknown as { flush?: () => Promise<void> }).flush;
+    if (typeof maybeFlush === 'function') {
+        await maybeFlush.call(store);
+    }
+}

--- a/cli/src/test/cc3-indexer-tests/handleOutboxBackfill.test.ts
+++ b/cli/src/test/cc3-indexer-tests/handleOutboxBackfill.test.ts
@@ -1,0 +1,243 @@
+import { U64 } from '@polkadot/types-codec';
+import { WebSocketProvider, ethers } from 'ethers';
+import { newApi, ApiPromise, KeyringPair } from '../../lib';
+import { getChainStatus } from '../../lib/chain/status';
+import { deployContract } from '../blockchain-tests/helpers';
+import { forElapsedBlocks } from '../utils';
+import { graphQLQuery } from './common';
+
+// The backfill half of fail-closed Outbox discovery (handleOutboxLifecycle.test.ts covers the
+// ordered half). Here the deploy ordering is deliberately WRONG: the mock announces its
+// OutboxCreated, publishes a message and acknowledges it, all BEFORE governance registers it as the
+// chain key's factory. Fail-closed discovery must reject the announcement — but into quarantine
+// (PendingOutbox / QuarantinedMessage), not the void. When setOutboxFactoryAddr is finally indexed,
+// handleOutboxFactoryRegistered promotes the quarantined Outbox and its full message lifecycle so a
+// mis-ordered (or racing — observed live on usc-dev) deployment degrades to "indexed late" instead
+// of "never indexed".
+describe('Outbox discovery backfill', () => {
+    let api: ApiPromise;
+    let provider: WebSocketProvider;
+    let root: KeyringPair;
+    let alith: ethers.Wallet;
+    let contract: ethers.Contract;
+    let outboxAddress: string;
+    let startingBlock: bigint;
+    let chainKey: U64;
+    let chainKeyNumber: number;
+    let chainKeyBytes32: string;
+
+    const chainId = BigInt(Date.now());
+    const chainName = `Outbox Backfill Chain ${chainId}`;
+    const encoding = 'V1';
+
+    const validator = '0x00000000000000000000000000000000000000ac';
+    const version = '1.1';
+
+    const messageId = ethers.zeroPadValue(ethers.toBeHex(BigInt(Date.now()) + 1n), 32);
+    const emitterAddress = '0x00000000000000000000000000000000000000e2';
+    const emitterBytes32 = ethers.zeroPadBytes(emitterAddress, 32);
+    const payload = ethers.hexlify(ethers.toUtf8Bytes('cc3-indexer outbox backfill'));
+
+    beforeAll(async () => {
+        ({ api } = await newApi((global as any).CREDITCOIN_API_URL));
+        provider = new WebSocketProvider((global as any).CREDITCOIN_API_URL);
+        root = (global as any).CREDITCOIN_CREATE_SIGNER('sudo');
+
+        const privateKey = (global as any).CREDITCOIN_EVM_PRIVATE_KEY('alice');
+        alith = new ethers.Wallet(privateKey).connect(provider);
+
+        startingBlock = BigInt((await getChainStatus(api)).bestNumber);
+        expect(startingBlock).toBeGreaterThan(0n);
+
+        contract = await deployContract('MockWriteAbilityEmitter', [], alith);
+        outboxAddress = (await contract.getAddress()).toLowerCase();
+
+        // The chain key must exist — quarantine is gated on it (an unknown key is never
+        // quarantined, so there would be nothing to promote and this suite would test the void).
+        await api.tx.sudo
+            .sudo(
+                api.tx.supportedChains.registerChain(
+                    chainId,
+                    chainName,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    encoding,
+                    null,
+                ),
+            )
+            .signAndSend(root, { nonce: await api.rpc.system.accountNextIndex(root.address) });
+        await forElapsedBlocks(api, { minBlocks: 1 });
+
+        chainKey = (await api.query.supportedChains.chainIdAndNameToUniqKey(chainId, chainName)).unwrap();
+        expect(chainKey.toBigInt()).toBeGreaterThan(0n);
+        expect(chainKey.toBigInt()).toBeLessThan(4_294_967_296n);
+        chainKeyNumber = Number(chainKey.toBigInt());
+        chainKeyBytes32 = `0x${chainKey.toBigInt().toString(16).padStart(64, '0')}`;
+
+        // Deliberately NO setOutboxFactoryAddr yet — that is the whole point of this suite.
+        // Emit the complete lifecycle while unauthorized.
+        let tx = await contract.getFunction('emitOutboxCreated')(chainKeyNumber, validator, version, {
+            gasLimit: 1_000_000,
+        });
+        await tx.wait();
+        tx = await contract.getFunction('emitMessagePublished')(messageId, emitterBytes32, true, payload, {
+            gasLimit: 1_000_000,
+        });
+        await tx.wait();
+        tx = await contract.getFunction('emitMessageAcknowledged')(messageId, {
+            gasLimit: 1_000_000,
+        });
+        await tx.wait();
+
+        await forElapsedBlocks(api, { minBlocks: 3 });
+    }, 240_000);
+
+    afterAll(async () => {
+        await api.tx.sudo
+            .sudo(api.tx.supportedChains.removeChain(chainKey, true))
+            .signAndSend(root, { nonce: await api.rpc.system.accountNextIndex(root.address) });
+
+        await api.disconnect();
+        await provider.destroy();
+    });
+
+    describe('while the factory is unregistered', () => {
+        it('does not admit an OutboxContract', async () => {
+            const response = await graphQLQuery(
+                `query {
+                    outboxContracts(
+                        filter: { id: { equalTo: "${outboxAddress}" }},
+                        last: 1,
+                    ) { nodes { id }}}`,
+            );
+            expect(response.data.outboxContracts.nodes).toEqual([]);
+        });
+
+        it('quarantines the announcement as a PendingOutbox', async () => {
+            const response = await graphQLQuery(
+                `query {
+                    pendingOutboxes(
+                        filter: { id: { equalTo: "${outboxAddress}" }},
+                        last: 1,
+                    ) { nodes { id, chainKey, factoryAddress, chainKeyBytes32, createdAt, createdTxHash }}}`,
+            );
+            expect(response.data.pendingOutboxes.nodes.length).toEqual(1);
+            const node = response.data.pendingOutboxes.nodes[0];
+            expect(BigInt(node.chainKey)).toEqual(chainKey.toBigInt());
+            // The mock announces itself, so it is its own emitter/factory.
+            expect(node.factoryAddress).toEqual(outboxAddress);
+            expect(node.chainKeyBytes32).toEqual(chainKeyBytes32);
+            expect(BigInt(node.createdAt)).toBeGreaterThanOrEqual(startingBlock);
+        });
+
+        it('quarantines the message — with the ack that followed it', async () => {
+            const response = await graphQLQuery(
+                `query {
+                    quarantinedMessages(
+                        filter: { id: { equalTo: "${messageId}" }},
+                        last: 1,
+                    ) { nodes {
+                        id, outboxAddress, emitter, canAck, payload,
+                        publishedAt, acknowledged, acknowledgedAt
+                    }}}`,
+            );
+            expect(response.data.quarantinedMessages.nodes.length).toEqual(1);
+            const node = response.data.quarantinedMessages.nodes[0];
+            expect(node.outboxAddress).toEqual(outboxAddress);
+            expect(node.emitter).toEqual(emitterAddress);
+            expect(node.canAck).toEqual(true);
+            expect(node.payload).toEqual(payload);
+            // The ack landed while quarantined and must already be recorded here, or promotion
+            // would resurrect the message as unacknowledged.
+            expect(node.acknowledged).toEqual(true);
+            expect(BigInt(node.acknowledgedAt)).toBeGreaterThanOrEqual(BigInt(node.publishedAt));
+        });
+
+        it('does not index the message', async () => {
+            const response = await graphQLQuery(
+                `query {
+                    outboxMessages(
+                        filter: { id: { equalTo: "${messageId}" }},
+                        last: 1,
+                    ) { nodes { id }}}`,
+            );
+            expect(response.data.outboxMessages.nodes).toEqual([]);
+        });
+    });
+
+    describe('when governance registers the factory afterwards', () => {
+        beforeAll(async () => {
+            await api.tx.sudo
+                .sudo(api.tx.supportedChains.setOutboxFactoryAddr(chainKey, outboxAddress))
+                .signAndSend(root, { nonce: await api.rpc.system.accountNextIndex(root.address) });
+
+            await forElapsedBlocks(api, { minBlocks: 3 });
+        }, 60_000);
+
+        it('promotes the quarantined Outbox to an admitted OutboxContract', async () => {
+            const response = await graphQLQuery(
+                `query {
+                    outboxContracts(
+                        filter: { id: { equalTo: "${outboxAddress}" }},
+                        last: 1,
+                    ) { nodes { id, chainKey, factoryId, createdAt, createdTimestamp, createdTxHash }}}`,
+            );
+            expect(response.data.outboxContracts.nodes.length).toEqual(1);
+            const node = response.data.outboxContracts.nodes[0];
+            expect(node.chainKey).toEqual(chainKeyBytes32);
+            expect(node.factoryId).toEqual(outboxAddress);
+            // Promotion preserves the ORIGINAL creation provenance, not the registration block.
+            expect(BigInt(node.createdAt)).toBeGreaterThanOrEqual(startingBlock);
+            expect(node.createdTxHash.startsWith('0x')).toEqual(true);
+        });
+
+        it('backfills the message with its full lifecycle', async () => {
+            const response = await graphQLQuery(
+                `query {
+                    outboxMessages(
+                        filter: { id: { equalTo: "${messageId}" }},
+                        last: 1,
+                    ) { nodes {
+                        id, outboxId, emitter, canAck, payload,
+                        publishedAt, publishedTxHash,
+                        acknowledged, acknowledgedAt, acknowledgedTxHash
+                    }}}`,
+            );
+            expect(response.data.outboxMessages.nodes.length).toEqual(1);
+            const node = response.data.outboxMessages.nodes[0];
+            expect(node.outboxId).toEqual(outboxAddress);
+            expect(node.emitter).toEqual(emitterAddress);
+            expect(node.canAck).toEqual(true);
+            expect(node.payload).toEqual(payload);
+            expect(BigInt(node.publishedAt)).toBeGreaterThanOrEqual(startingBlock);
+            expect(node.publishedTxHash.startsWith('0x')).toEqual(true);
+            expect(node.acknowledged).toEqual(true);
+            expect(BigInt(node.acknowledgedAt)).toBeGreaterThanOrEqual(BigInt(node.publishedAt));
+            expect(node.acknowledgedTxHash.startsWith('0x')).toEqual(true);
+        });
+
+        it('empties the quarantine', async () => {
+            const pending = await graphQLQuery(
+                `query {
+                    pendingOutboxes(
+                        filter: { id: { equalTo: "${outboxAddress}" }},
+                        last: 1,
+                    ) { nodes { id }}}`,
+            );
+            expect(pending.data.pendingOutboxes.nodes).toEqual([]);
+
+            const quarantined = await graphQLQuery(
+                `query {
+                    quarantinedMessages(
+                        filter: { id: { equalTo: "${messageId}" }},
+                        last: 1,
+                    ) { nodes { id }}}`,
+            );
+            expect(quarantined.data.quarantinedMessages.nodes).toEqual([]);
+        });
+    });
+});

--- a/cli/src/test/cc3-indexer-tests/handleOutboxFactoryRegistered.test.ts
+++ b/cli/src/test/cc3-indexer-tests/handleOutboxFactoryRegistered.test.ts
@@ -5,9 +5,8 @@ import { forElapsedBlocks } from '../utils';
 import { graphQLQuery } from './common';
 
 // USC write-ability: `supportedChains.set_outbox_factory_addr` emits OutboxFactoryRegistered, which
-// the indexer records as an OutboxFactory entity (backs display + OutboxContract.factory
-// resolution). Outbox *discovery* deliberately does not depend on this event — see
-// handleOutboxLifecycle.test.ts for the chain-wide OutboxCreated watch.
+// the indexer records both as a display-oriented OutboxFactory and as the authoritative per-chain
+// OutboxFactoryRegistration used to authenticate chain-wide OutboxCreated discovery.
 describe('handleOutboxFactoryRegistered()', () => {
     let api: ApiPromise;
     let root: KeyringPair;
@@ -95,6 +94,25 @@ describe('handleOutboxFactoryRegistered()', () => {
                 expect(BigInt(node.registeredTimestamp)).toBeGreaterThan(0n);
                 expect(BigInt(node.registeredTimestamp)).toBeLessThanOrEqual(BigInt(Date.now()));
             }
+        });
+
+        it('graphQL returns the exact per-chain factory authorization', async () => {
+            const response = await graphQLQuery(
+                `query {
+                    outboxFactoryRegistrations(
+                        filter: { id: { equalTo: "${chainKey.toString()}" }},
+                        last: 1,
+                    ) { nodes { id, factoryAddress, registeredAt }}}`,
+            );
+            expect(response.data.outboxFactoryRegistrations.nodes).toEqual([
+                expect.objectContaining({
+                    id: chainKey.toString(),
+                    factoryAddress: outboxFactoryAddr,
+                }),
+            ]);
+            expect(BigInt(response.data.outboxFactoryRegistrations.nodes[0].registeredAt)).toBeGreaterThanOrEqual(
+                startingBlock,
+            );
         });
     });
 });

--- a/cli/src/test/cc3-indexer-tests/handleOutboxLifecycle.test.ts
+++ b/cli/src/test/cc3-indexer-tests/handleOutboxLifecycle.test.ts
@@ -1,5 +1,6 @@
+import { U64 } from '@polkadot/types-codec';
 import { WebSocketProvider, ethers } from 'ethers';
-import { newApi, ApiPromise } from '../../lib';
+import { newApi, ApiPromise, KeyringPair } from '../../lib';
 import { getChainStatus } from '../../lib/chain/status';
 import { deployContract } from '../blockchain-tests/helpers';
 import { forElapsedBlocks } from '../utils';
@@ -10,26 +11,36 @@ import { graphQLQuery } from './common';
 //   handleMessagePublished -> OutboxMessage
 //   handleMessageAcknowledged -> flips the same OutboxMessage to acknowledged
 //
-// The events come from MockWriteAbilityEmitter rather than the real fee stack: the indexer
-// discovers Outboxes by *topic* chain-wide (see `outboxDiscoveryDatasource` in
-// cc3-indexer/datasources.ts), so an unregistered emitter is precisely the unauthenticated
-// discovery path this covers. The mock announces itself as the Outbox, so the datasource created
-// from OutboxCreated is the one that then picks up its MessagePublished / MessageAcknowledged.
+// The events come from MockWriteAbilityEmitter, which announces itself as the Outbox, so the
+// datasource created from OutboxCreated is the one that then picks up its MessagePublished /
+// MessageAcknowledged.
+//
+// Discovery is fail-closed: `handleOutboxCreated` only accepts an `OutboxCreated` whose emitter is
+// the factory governance registered for that raw chain key. So the mock has to be registered as the
+// factory for a real chain key *before* it announces anything — registering a synthetic key would
+// leave nothing for the handler to match and the happy path would silently stop being covered. That
+// mirrors the deploy ordering the tooling uses (register the factory, then call deployOutbox).
 //
 // The three steps must land in this order and be indexed between each: the dynamic datasource only
 // exists once OutboxCreated has been processed, and the ack only updates an already-indexed message.
 describe('Outbox lifecycle handlers', () => {
     let api: ApiPromise;
     let provider: WebSocketProvider;
+    let root: KeyringPair;
+    let alith: ethers.Wallet;
     let contract: ethers.Contract;
     let outboxAddress: string;
     let startingBlock: bigint;
-
-    // uint32 chain key, unique per run so this test can never interact with another record's
-    // per-chain-key unauthenticated-datasource cap (audit P2-1).
-    const chainKey = Number(BigInt(Date.now()) % 4_000_000_000n);
+    // Assigned in beforeAll from the pallet's monotonic uniq-key counter, so it is a small integer
+    // that fits the `uint32 chainKey` the OutboxCreated event carries.
+    let chainKey: U64;
+    let chainKeyNumber: number;
     // The bytes32 form the handler stores: `bytes32(uint256(chainKey))`.
-    const chainKeyBytes32 = `0x${chainKey.toString(16).padStart(64, '0')}`;
+    let chainKeyBytes32: string;
+
+    const chainId = BigInt(Date.now());
+    const chainName = `Outbox Lifecycle Chain ${chainId}`;
+    const encoding = 'V1';
 
     const validator = '0x00000000000000000000000000000000000000ac';
     const version = '1.1';
@@ -44,9 +55,10 @@ describe('Outbox lifecycle handlers', () => {
     beforeAll(async () => {
         ({ api } = await newApi((global as any).CREDITCOIN_API_URL));
         provider = new WebSocketProvider((global as any).CREDITCOIN_API_URL);
+        root = (global as any).CREDITCOIN_CREATE_SIGNER('sudo');
 
         const privateKey = (global as any).CREDITCOIN_EVM_PRIVATE_KEY('alice');
-        const alith = new ethers.Wallet(privateKey).connect(provider);
+        alith = new ethers.Wallet(privateKey).connect(provider);
 
         startingBlock = BigInt((await getChainStatus(api)).bestNumber);
         expect(startingBlock).toBeGreaterThan(0n);
@@ -54,16 +66,61 @@ describe('Outbox lifecycle handlers', () => {
         contract = await deployContract('MockWriteAbilityEmitter', [], alith);
         // The handler lowercases the announced address to key OutboxContract.
         outboxAddress = (await contract.getAddress()).toLowerCase();
-    }, 90_000);
+
+        // A real chain, so the uniq key exists on-chain and `setOutboxFactoryAddr` is accepted.
+        await api.tx.sudo
+            .sudo(
+                api.tx.supportedChains.registerChain(
+                    chainId,
+                    chainName,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    encoding,
+                    null,
+                ),
+            )
+            .signAndSend(root, { nonce: await api.rpc.system.accountNextIndex(root.address) });
+        await forElapsedBlocks(api, { minBlocks: 1 });
+
+        chainKey = (await api.query.supportedChains.chainIdAndNameToUniqKey(chainId, chainName)).unwrap();
+        expect(chainKey.toBigInt()).toBeGreaterThan(0n);
+        // The event field is a uint32; the pallet allocates keys from a monotonic counter, so this
+        // holds in practice. Assert it rather than truncate silently if that ever stops being true.
+        expect(chainKey.toBigInt()).toBeLessThan(4_294_967_296n);
+        chainKeyNumber = Number(chainKey.toBigInt());
+        chainKeyBytes32 = `0x${chainKey.toBigInt().toString(16).padStart(64, '0')}`;
+
+        // Register the mock as this chain key's Outbox factory, so its OutboxCreated is accepted.
+        await api.tx.sudo
+            .sudo(api.tx.supportedChains.setOutboxFactoryAddr(chainKey, outboxAddress))
+            .signAndSend(root, { nonce: await api.rpc.system.accountNextIndex(root.address) });
+        await forElapsedBlocks(api, { minBlocks: 1 });
+
+        const stored = await api.query.supportedChains.outboxFactories(chainKey);
+        expect(stored.isSome).toEqual(true);
+        expect(stored.unwrap().toString().toLowerCase()).toEqual(outboxAddress);
+
+        // The registration must be *indexed* before OutboxCreated is emitted — the handler reads
+        // OutboxFactoryRegistration, so emitting first would be rejected as unauthenticated.
+        await forElapsedBlocks(api, { minBlocks: 3 });
+    }, 180_000);
 
     afterAll(async () => {
+        await api.tx.sudo
+            .sudo(api.tx.supportedChains.removeChain(chainKey, true))
+            .signAndSend(root, { nonce: await api.rpc.system.accountNextIndex(root.address) });
+
         await api.disconnect();
         await provider.destroy();
     });
 
     describe('when an outbox announces itself', () => {
         beforeAll(async () => {
-            const tx = await contract.getFunction('emitOutboxCreated')(chainKey, validator, version, {
+            const tx = await contract.getFunction('emitOutboxCreated')(chainKeyNumber, validator, version, {
                 gasLimit: 1_000_000,
             });
             await tx.wait();
@@ -88,11 +145,9 @@ describe('Outbox lifecycle handlers', () => {
                 expect(BigInt(node.createdAt)).toBeGreaterThanOrEqual(startingBlock);
                 expect(BigInt(node.createdTimestamp)).toBeGreaterThan(0n);
                 expect(node.createdTxHash.startsWith('0x')).toEqual(true);
-                // `factoryId` records whichever contract *emitted* OutboxCreated, unconditionally —
-                // it is not evidence that the emitter is a registered OutboxFactory (that is the
-                // separate `authenticated` trust signal, which only relaxes the DoS cap and is not
-                // persisted). The mock announces itself as the Outbox, so it is its own emitter and
-                // factoryId equals the id here.
+                // `factoryId` records the contract that emitted OutboxCreated, which discovery now
+                // requires to be the registered factory. The mock announces itself as the Outbox, so
+                // it is its own emitter and factoryId equals the id here.
                 expect(node.factoryId).toEqual(outboxAddress);
             }
         });
@@ -171,6 +226,51 @@ describe('Outbox lifecycle handlers', () => {
                 expect(BigInt(node.acknowledgedTimestamp)).toBeGreaterThan(0n);
                 expect(node.acknowledgedTxHash.startsWith('0x')).toEqual(true);
             }
+        });
+    });
+
+    // The negative half of the same rule, kept last so the ordered three-step lifecycle above stays
+    // contiguous. An emitter governance never registered must not be able to create an
+    // OutboxContract — and with it a persistent dynamic datasource — just by emitting a well-formed
+    // OutboxCreated. That is the DoS vector the fail-closed check exists for, so assert it directly
+    // rather than leave it implied by the happy path.
+    describe('when an unregistered contract announces itself for the same chain key', () => {
+        let impostorAddress: string;
+
+        beforeAll(async () => {
+            const impostor = await deployContract('MockWriteAbilityEmitter', [], alith);
+            impostorAddress = (await impostor.getAddress()).toLowerCase();
+            expect(impostorAddress).not.toEqual(outboxAddress);
+
+            const tx = await impostor.getFunction('emitOutboxCreated')(chainKeyNumber, validator, version, {
+                gasLimit: 1_000_000,
+            });
+            await tx.wait();
+
+            await forElapsedBlocks(api, { minBlocks: 3 });
+        }, 120_000);
+
+        it('graphQL returns no OutboxContract for the unregistered emitter', async () => {
+            const response = await graphQLQuery(
+                `query {
+                    outboxContracts(
+                        filter: { id: { equalTo: "${impostorAddress}" }},
+                        last: 1,
+                    ) { nodes { id }}}`,
+            );
+            expect(response.data.outboxContracts.nodes).toEqual([]);
+        });
+
+        it('leaves the registered Outbox untouched', async () => {
+            const response = await graphQLQuery(
+                `query {
+                    outboxContracts(
+                        filter: { id: { equalTo: "${outboxAddress}" }},
+                        last: 1,
+                    ) { nodes { id, factoryId }}}`,
+            );
+            expect(response.data.outboxContracts.nodes.length).toEqual(1);
+            expect(response.data.outboxContracts.nodes[0].factoryId).toEqual(outboxAddress);
         });
     });
 });

--- a/cli/src/test/cc3-indexer-tests/handleOutboxLifecycle.test.ts
+++ b/cli/src/test/cc3-indexer-tests/handleOutboxLifecycle.test.ts
@@ -7,22 +7,21 @@ import { forElapsedBlocks } from '../utils';
 import { graphQLQuery } from './common';
 
 // USC write-ability EVM handlers, exercised end to end in publish order:
-//   handleOutboxCreated  -> OutboxContract (+ a dynamic datasource for that address)
+//   handleOutboxCreated  -> OutboxContract (the admission the message handlers key on)
 //   handleMessagePublished -> OutboxMessage
 //   handleMessageAcknowledged -> flips the same OutboxMessage to acknowledged
 //
-// The events come from MockWriteAbilityEmitter, which announces itself as the Outbox, so the
-// datasource created from OutboxCreated is the one that then picks up its MessagePublished /
-// MessageAcknowledged.
+// The events come from MockWriteAbilityEmitter, which announces itself as the Outbox; all three
+// handlers are chain-wide topic watches that authorize each event against store state (no dynamic
+// datasources).
 //
-// Discovery is fail-closed: `handleOutboxCreated` only accepts an `OutboxCreated` whose emitter is
-// the factory governance registered for that raw chain key. So the mock has to be registered as the
-// factory for a real chain key *before* it announces anything — registering a synthetic key would
-// leave nothing for the handler to match and the happy path would silently stop being covered. That
-// mirrors the deploy ordering the tooling uses (register the factory, then call deployOutbox).
+// Discovery is fail-closed: `handleOutboxCreated` only *admits* an `OutboxCreated` whose emitter is
+// the factory governance registered for that raw chain key. This suite covers the ordered path
+// (register the factory first, as the deploy tooling does); the reverse order — announce first,
+// register later — is the backfill path covered by handleOutboxBackfill.test.ts.
 //
-// The three steps must land in this order and be indexed between each: the dynamic datasource only
-// exists once OutboxCreated has been processed, and the ack only updates an already-indexed message.
+// The three steps must land in this order and be indexed between each: admission only exists once
+// OutboxCreated has been processed, and the ack only updates an already-indexed message.
 describe('Outbox lifecycle handlers', () => {
     let api: ApiPromise;
     let provider: WebSocketProvider;
@@ -230,10 +229,11 @@ describe('Outbox lifecycle handlers', () => {
     });
 
     // The negative half of the same rule, kept last so the ordered three-step lifecycle above stays
-    // contiguous. An emitter governance never registered must not be able to create an
-    // OutboxContract — and with it a persistent dynamic datasource — just by emitting a well-formed
-    // OutboxCreated. That is the DoS vector the fail-closed check exists for, so assert it directly
-    // rather than leave it implied by the happy path.
+    // contiguous. An emitter governance never registered must not be able to create an admitted
+    // OutboxContract just by emitting a well-formed OutboxCreated. That is the DoS vector the
+    // fail-closed check exists for, so assert it directly rather than leave it implied by the happy
+    // path. (It IS quarantined — the chain key exists and a later rotation could authorize it — but
+    // quarantine is bounded state, not admission.)
     describe('when an unregistered contract announces itself for the same chain key', () => {
         let impostorAddress: string;
 
@@ -259,6 +259,19 @@ describe('Outbox lifecycle handlers', () => {
                     ) { nodes { id }}}`,
             );
             expect(response.data.outboxContracts.nodes).toEqual([]);
+        });
+
+        it('quarantines the impostor as a PendingOutbox instead', async () => {
+            const response = await graphQLQuery(
+                `query {
+                    pendingOutboxes(
+                        filter: { id: { equalTo: "${impostorAddress}" }},
+                        last: 1,
+                    ) { nodes { id, chainKey, factoryAddress }}}`,
+            );
+            expect(response.data.pendingOutboxes.nodes.length).toEqual(1);
+            expect(response.data.pendingOutboxes.nodes[0].factoryAddress).toEqual(impostorAddress);
+            expect(BigInt(response.data.pendingOutboxes.nodes[0].chainKey)).toEqual(chainKey.toBigInt());
         });
 
         it('leaves the registered Outbox untouched', async () => {

--- a/cli/src/test/cc3-indexer-tests/handleSupportedChainRemoved.test.ts
+++ b/cli/src/test/cc3-indexer-tests/handleSupportedChainRemoved.test.ts
@@ -12,6 +12,7 @@ describe('handleSupportedChainRemoved()', () => {
     const newChainId = BigInt(Date.now());
     const newChainName = `Test Chain ${newChainId}`;
     const encoding = 'V1';
+    const outboxFactoryAddr = `0x${newChainId.toString(16).padStart(40, '0')}`;
     let newChainKey = 0n;
 
     beforeAll(async () => {
@@ -42,6 +43,10 @@ describe('handleSupportedChainRemoved()', () => {
             .unwrap()
             .toBigInt();
         expect(newChainKey).toBeGreaterThan(0n);
+
+        await api.tx.sudo
+            .sudo(api.tx.supportedChains.setOutboxFactoryAddr(newChainKey, outboxFactoryAddr))
+            .signAndSend(root, { nonce: await api.rpc.system.accountNextIndex(root.address) });
 
         // there should be a SupportedChain entity for this new chain
         await forElapsedBlocks(api, { minBlocks: 3 });
@@ -128,6 +133,17 @@ describe('handleSupportedChainRemoved()', () => {
             );
             expect(response.data.attestationChainData.nodes).toBeTruthy();
             expect(response.data.attestationChainData.nodes.length).toEqual(0);
+        });
+
+        it('former OutboxFactory authorization should be removed', async () => {
+            const response = await graphQLQuery(
+                `query {
+                    outboxFactoryRegistrations(
+                        filter: { id: { equalTo: "${newChainKey}" }},
+                        last: 1,
+                    ) { nodes { id, factoryAddress }}}`,
+            );
+            expect(response.data.outboxFactoryRegistrations.nodes).toEqual([]);
         });
     });
 });

--- a/usc-messaging/scripts/deploy-source-ethers.mts
+++ b/usc-messaging/scripts/deploy-source-ethers.mts
@@ -1,6 +1,8 @@
 // Plain-ethers source-stack deploy (no hardhat runtime — it wedges on this RPC).
 // Reads compiled artifacts from usc-contracts/artifacts. Run with tsx (Node 22).
 import { ethers } from "ethers";
+import { ApiPromise, Keyring, WsProvider } from "@polkadot/api";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
@@ -29,6 +31,43 @@ async function deploy(name: string, art: any, args: any[] = []) {
   return c;
 }
 
+async function registerFactoryBeforeOutbox(factory: string) {
+  const ws = process.env.CREDITCOIN_SUBSTRATE_WS_URL ?? "ws://127.0.0.1:9944";
+  const api = await ApiPromise.create({ provider: new WsProvider(ws), noInitWarn: true });
+  try {
+    await api.isReady;
+    await cryptoWaitReady();
+    const sudo = new Keyring({ type: "sr25519" }).addFromUri("//Alice");
+    console.log(`  registering OutboxFactory ${factory} before Outbox creation…`);
+    await new Promise<void>((resolve, reject) => {
+      let unsubscribe: (() => void) | undefined;
+      void api.tx.sudo
+        .sudo(api.tx.supportedChains.setOutboxFactoryAddr(CHAIN_KEY, factory))
+        .signAndSend(sudo, ({ status, dispatchError }) => {
+          if (dispatchError) {
+            unsubscribe?.();
+            reject(new Error(dispatchError.toString()));
+          } else if (status.isInBlock || status.isFinalized) {
+            unsubscribe?.();
+            resolve();
+          }
+        })
+        .then((unsub) => {
+          unsubscribe = unsub;
+        })
+        .catch(reject);
+    });
+    const registered = await api.query.supportedChains.outboxFactories(CHAIN_KEY);
+    const registeredAddress = registered.isSome ? registered.unwrap().toString() : "none";
+    if (registeredAddress.toLowerCase() !== factory.toLowerCase()) {
+      throw new Error(`factory registration did not land: expected ${factory}, got ${registeredAddress}`);
+    }
+    console.log("  OutboxFactory governance registration confirmed on-chain");
+  } finally {
+    await api.disconnect();
+  }
+}
+
 async function main() {
   const addrs = JSON.parse(readFileSync(OUT, "utf8"));
   if (!addrs.dest?.inbox) throw new Error("need dest.inbox");
@@ -45,6 +84,8 @@ async function main() {
   await (await (twap as any).setWindow(60)).wait();
   await (await (twap as any).update(ethers.parseEther("1"))).wait();
   const factory = await deploy("OutboxFactory", ART("write-ability/deployer/OutboxFactory.sol", "OutboxFactory"));
+  // Indexer discovery is fail-closed: authenticate OutboxCreated against governance registration.
+  await registerFactoryBeforeOutbox(await factory.getAddress());
   const quoter = await deploy("USCRelayingQuoter", ART("write-ability/USCRelayingQuoter.sol", "USCRelayingQuoter"), [owner, await twap.getAddress(), owner]);
 
   const attestAddr = await attest.getAddress();


### PR DESCRIPTION
P1/P2-1 audit follow-up to #1215, reworked from the closed first cut: **fail-closed discovery + the backfill that makes fail-closed safe to ship.**

## The bug

`handleOutboxCreated` watched `OutboxCreated` chain-wide by topic and created an `OutboxContract` plus a **dynamic datasource** for any emitter — persistent, security-sensitive (and reorg-unsafe) indexer state any contract could mint up to a per-key cap of 32 (audit P2-1).

## Why the first cut was closed

It flipped discovery to fail-closed (emitter must equal the governance-registered factory for the chain key) — correct direction, but *fail-closed alone is fail-forever*: an `OutboxCreated` indexed before its `OutboxFactoryRegistered` was dropped permanently. That ordering race is real — on usc-dev the OutboxCreated landed ~200 blocks before the factory registration and needed a manual reindex. The first cut had to rewrite the deploy script to survive its own e2e, i.e. it encoded a deployment-ordering footgun into the indexer.

## The rework

**No more dynamic datasources at all.** `MessagePublished` / `MessageAcknowledged` move to chain-wide topic datasources, and every event is authorized per event in its handler:

- A message is indexed **iff its emitting contract has an `OutboxContract` row** — the row's existence is the authorization. The P2-1 attack surface (counterfeit persistent datasources) ceases to exist rather than being capped; a counterfeit event now costs a bounded quarantine row or a log line. Acks additionally verify the emitting contract owns the message — chain-wide watching would otherwise let any contract flip a real message to acknowledged.
- A rejected `OutboxCreated` is **quarantined** (`PendingOutbox`), gated on its chain key existing as a `SupportedChain` and capped at 8 per key. Messages observed on a pending Outbox are quarantined alongside it (capped 256/Outbox), including acks that arrive while pending.
- `handleOutboxFactoryRegistered` **promotes** whatever its registration retroactively authorizes — Outbox + full message lifecycle, original block/tx provenance preserved. `handleSupportedChainRemoved` purges the quarantine for the removed key.

Wrong deploy ordering now degrades to "indexed a few blocks late" instead of "never indexed". As a bonus, message indexing is now fully reorg-safe (dynamic-datasource metadata never was).

## Testing

- **New `handleOutboxBackfill.test.ts`** drives the wrong order end to end: announce + publish + ack *before* registration → asserts quarantine contents; register after → asserts the promoted `OutboxContract` (original provenance), the backfilled message with `acknowledged: true`, and an empty quarantine.
- `handleOutboxLifecycle.test.ts` keeps the ordered path and now asserts the impostor is quarantined, not admitted.
- `yarn build` + `yarn lint` (cc3-indexer), `yarn typecheck` + `yarn lint` (cli) all green.

## Deploy notes

- The indexer chart subPath-mounts its own `project.yaml` — the configmap must be regenerated when this ships (the datasource list changed).
- Schema adds two entities → requires a reindex.
