### PR TITLE
fix(node): correct USC local testnet EVM chain ID in chain_spec

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -123,7 +123,6 @@ fn properties() -> Properties {
 }
 
 const UNITS: Balance = 1_000_000_000_000_000_000;
-const EVM_CHAINID: u64 = 102030;
 
 /// CC3 chainspec configurations
 pub fn devnet_config() -> Result<ChainSpec, String> {
@@ -236,6 +235,9 @@ pub fn usc_development_config(_enable_manual_seal: Option<bool>) -> ChainSpec {
 pub fn usc_local_testnet_config() -> ChainSpec {
     let wasm_binary = WASM_BINARY.expect("WASM not available");
 
+    // Matches `uscTestnetSpec.json` EVM chain ID.
+    const USC_TESTNET_EVM_CHAIN_ID: u64 = 102036;
+
     const SUDO: &str = "5FTtKTjpLBeYxMFbrG3eMMpMQgj4uaQ2tsy3PZSemFDZTEZw";
     const VALIDATOR_SR25519: &str = "5HQZj4t8mJ7gn6a4Jbcsh6iEBQAZy348QZdDbGtmscSJiBKp";
     const VALIDATOR_ED25519: &str = "5CS8RgyWmk3JJpJGQ9PN3L4Wfbt5z28LW8JrGc1QboT1bZN6";
@@ -249,7 +251,7 @@ pub fn usc_local_testnet_config() -> ChainSpec {
         vec![sudo_account, validator.0.clone()],
         vec![],
         vec![validator],
-        EVM_CHAINID,
+        USC_TESTNET_EVM_CHAIN_ID,
         vec![AttestationChainConfiguration {
             chain_key: 1,
             attestation_interval: 10,


### PR DESCRIPTION
# Description of proposed changes

`usc_local_testnet_config` was wiring genesis with a module-level `EVM_CHAINID` of **102030**, which does not match the published USC testnet chainspec (`uscTestnetSpec.json` uses **102036**). Anyone booting a local USC testnet from this helper would get the wrong EVM chain ID for wallet/RPC tooling.

It would also confuse anyone reading this PR and misslead to think that it needs to be changed to the network that is being released that why you see many changes from 102030 <-> 102036 in git history.

This PR:
- moves the constant into `usc_local_testnet_config` (its only caller) and renames it to `USC_TESTNET_EVM_CHAIN_ID`
- sets the value to **102036** to align with `uscTestnetSpec.json`

---

When merging this PR:

- For PRs against `usc-dev` use the "Squash and merge" button
- For PRs against `usc-testnet`/`main` use the "Create a merge commit" button
- Hotfixes against `usc-testnet`/`main` should use the "Squash and merge" button

---

Practical tips for PR review:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
