### PR TITLE
fix(write-ability): bind the validator address into the set-update digest

### DIFF
--- a/attestor/attestor/src/tasks/write_ability/set_update.rs
+++ b/attestor/attestor/src/tasks/write_ability/set_update.rs
@@ -61,17 +61,19 @@ pub fn set_needs_update(current: &[Address], candidate: &[Address]) -> bool {
 }
 
 /// Build a signed [`SetUpdateVote`]. `new_attestors` is canonicalized (sorted, de-duped) before
-/// hashing so every attestor signs identical bytes; `chain_id` is the destination `block.chainid`
+/// hashing so every attestor signs identical bytes; `validator` is the target `EOAValidator` (the
+/// contract binds its own address into the preimage), `chain_id` is the destination `block.chainid`
 /// and `nonce` the validator's current `attestorSetUpdateNonce`.
 pub fn build_set_update_vote(
     signer: &MessageSigner,
     chain_key: u64,
+    validator: Address,
     new_attestors: &[Address],
     chain_id: U256,
     nonce: U256,
 ) -> Result<SetUpdateVote> {
     let canonical = canonical_attestor_order(new_attestors);
-    let digest = attestor_set_update_digest(&canonical, chain_id, nonce);
+    let digest = attestor_set_update_digest(validator, &canonical, chain_id, nonce);
     let signature = signer
         .sign(&digest)
         .context("sign attestor-set-update digest")?;
@@ -152,7 +154,7 @@ async fn propose_once(
             .context("read destination chain id")?,
     );
 
-    let vote = build_set_update_vote(signer, chain_key, &candidate, chain_id, nonce)?;
+    let vote = build_set_update_vote(signer, chain_key, validator, &candidate, chain_id, nonce)?;
     tracing::info!(
         proposed = candidate.len(),
         current = current.len(),
@@ -270,7 +272,8 @@ mod tests {
         let chain_id = U256::from(11_155_111u64);
         let nonce = U256::from(3u64);
 
-        let vote = build_set_update_vote(&signer, 2, &[a, b], chain_id, nonce).unwrap();
+        let validator = address!("00000000000000000000000000000000000000e1");
+        let vote = build_set_update_vote(&signer, 2, validator, &[a, b], chain_id, nonce).unwrap();
 
         // Addresses are stored canonically (sorted), not in input order.
         let canonical = canonical_attestor_order(&[a, b]);
@@ -280,7 +283,7 @@ mod tests {
         assert_eq!(vote.nonce, nonce.to_be_bytes::<32>());
 
         // The signature recovers to our address over the digest the relayer will reconstruct.
-        let digest = attestor_set_update_digest(&canonical, chain_id, nonce);
+        let digest = attestor_set_update_digest(validator, &canonical, chain_id, nonce);
         let recovered = recover_signer(&digest, &vote.signature).unwrap();
         assert_eq!(recovered, signer.address());
     }

--- a/common/write-ability/src/envelope.rs
+++ b/common/write-ability/src/envelope.rs
@@ -82,11 +82,13 @@ impl ReobservationRequest {
 /// proposing a new destination `EOAValidator` attestor set (write-ability P2-8).
 ///
 /// Each attestor signs the update digest
-/// ([`attestor_set_update_digest`](crate::hash::attestor_set_update_digest)) over the canonical
-/// (sorted) `new_attestors`, the destination `chain_id`, and the current `attestor_set_update_nonce`.
-/// The relayer snoops the topic, collects a threshold of these, and submits `submitAttestorSetUpdate`
-/// on-chain. `new_attestors` and `nonce` are carried so the relayer can reconstruct the exact digest
-/// and calldata; `chain_id` is not carried (the relayer knows its own destination chain).
+/// ([`attestor_set_update_digest`](crate::hash::attestor_set_update_digest)) over the target
+/// validator address, the canonical (sorted) `new_attestors`, the destination `chain_id`, and the
+/// current `attestor_set_update_nonce`. The relayer snoops the topic, collects a threshold of these,
+/// and submits `submitAttestorSetUpdate` on-chain. `new_attestors` and `nonce` are carried so the
+/// relayer can reconstruct the exact digest and calldata; `chain_id` and the validator address are
+/// not carried — the relayer knows both from its own route config, and taking them from the vote
+/// would let a peer redirect aggregation at an arbitrary contract.
 #[derive(Clone, Debug, Eq, PartialEq, Encode, Decode)]
 pub struct SetUpdateVote {
     /// USC chain_key this vote is scoped to. Must match the gossipsub topic prefix.

--- a/common/write-ability/src/hash.rs
+++ b/common/write-ability/src/hash.rs
@@ -45,17 +45,29 @@ pub fn message_hash(
 }
 
 /// Compute the attestor-set-update digest exactly as the `EOAValidator` recomputes it:
-/// `keccak256(abi.encode(newAttestors, chainId, nonce))`.
+/// `keccak256(abi.encode(address(this), newAttestors, chainId, nonce))`.
+///
+/// `validator` is the destination `EOAValidator` the update targets. The contract binds its own
+/// address into the preimage, so an update signed for one validator instance cannot be replayed
+/// against another instance on the same chain — and since instances share an `AttestorRegistry`,
+/// overlapping signer sets at the same nonce are the norm rather than the exception. Omitting it
+/// here (as the pre-registry contract did) makes every signature the fleet produces unverifiable:
+/// the contract recovers over a different preimage and rejects the whole batch.
 ///
 /// `new_attestors` MUST be in the exact order the relayer will submit on-chain (the contract hashes
 /// that order), so every attestor and the relayer agree on a **canonical** ordering — see
 /// `canonical_attestor_order`. `chain_id` is the destination chain's `block.chainid`, and `nonce`
 /// is the validator's current `attestorSetUpdateNonce` (replay/rollback protection).
 #[must_use]
-pub fn attestor_set_update_digest(new_attestors: &[Address], chain_id: U256, nonce: U256) -> B256 {
+pub fn attestor_set_update_digest(
+    validator: Address,
+    new_attestors: &[Address],
+    chain_id: U256,
+    nonce: U256,
+) -> B256 {
     // Same head-of-tuple encoding as `message_hash`: `abi_encode_params` on the tuple reproduces
-    // Solidity `abi.encode(address[], uint256, uint256)` byte-for-byte.
-    let encoded = (new_attestors.to_vec(), chain_id, nonce).abi_encode_params();
+    // Solidity `abi.encode(address, address[], uint256, uint256)` byte-for-byte.
+    let encoded = (validator, new_attestors.to_vec(), chain_id, nonce).abi_encode_params();
     keccak256(&encoded)
 }
 
@@ -108,33 +120,84 @@ mod tests {
         assert_ne!(h1, h2);
     }
 
+    /// Golden vector: the digest must equal Solidity
+    /// `keccak256(abi.encode(address(this), newAttestors, block.chainid, attestorSetUpdateNonce))`
+    /// as `EOAValidator.submitAttestorSetUpdate` computes it. Pinned by hand-encoding the same
+    /// preimage here — if either side's field order or types drift, the fleet's signatures stop
+    /// verifying on-chain and every set update fails, so the contract shape is worth nailing down
+    /// in a test rather than a comment.
     #[test]
-    fn set_update_digest_is_deterministic_and_binds_nonce_and_chain() {
+    fn set_update_digest_matches_hand_encoded_solidity_preimage() {
+        use alloy::primitives::keccak256;
+
+        let validator = address!("71a21ea8d28d3a0618d61d478ee20dcb64be8082");
+        let attestors = [
+            address!("00000000000000000000000000000000000000aa"),
+            address!("00000000000000000000000000000000000000bb"),
+        ];
+        let chain_id = U256::from(11_155_111u64); // Sepolia
+        let nonce = U256::from(3u64);
+
+        // abi.encode(address, address[], uint256, uint256):
+        //   head: validator | offset-to-array (0x80) | chain_id | nonce
+        //   tail: array length | element 0 | element 1
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&validator.into_word()[..]);
+        expected.extend_from_slice(&U256::from(0x80u64).to_be_bytes::<32>());
+        expected.extend_from_slice(&chain_id.to_be_bytes::<32>());
+        expected.extend_from_slice(&nonce.to_be_bytes::<32>());
+        expected.extend_from_slice(&U256::from(attestors.len()).to_be_bytes::<32>());
+        for a in &attestors {
+            expected.extend_from_slice(&a.into_word()[..]);
+        }
+
+        assert_eq!(
+            attestor_set_update_digest(validator, &attestors, chain_id, nonce),
+            keccak256(&expected),
+            "digest no longer matches abi.encode(address, address[], uint256, uint256)"
+        );
+    }
+
+    #[test]
+    fn set_update_digest_is_deterministic_and_binds_validator_nonce_and_chain() {
         let addrs = [
             address!("00000000000000000000000000000000000000aa"),
             address!("00000000000000000000000000000000000000bb"),
         ];
-        let base = attestor_set_update_digest(&addrs, U256::from(42u64), U256::from(7u64));
+        let validator = address!("00000000000000000000000000000000000000e1");
+        let base =
+            attestor_set_update_digest(validator, &addrs, U256::from(42u64), U256::from(7u64));
         // Deterministic.
         assert_eq!(
             base,
-            attestor_set_update_digest(&addrs, U256::from(42u64), U256::from(7u64))
+            attestor_set_update_digest(validator, &addrs, U256::from(42u64), U256::from(7u64))
+        );
+        // Validator-sensitive (no cross-instance replay on the same chain).
+        let other_validator = address!("00000000000000000000000000000000000000e2");
+        assert_ne!(
+            base,
+            attestor_set_update_digest(
+                other_validator,
+                &addrs,
+                U256::from(42u64),
+                U256::from(7u64)
+            )
         );
         // Nonce-sensitive (rollback protection).
         assert_ne!(
             base,
-            attestor_set_update_digest(&addrs, U256::from(42u64), U256::from(8u64))
+            attestor_set_update_digest(validator, &addrs, U256::from(42u64), U256::from(8u64))
         );
         // Chain-id-sensitive (cross-chain isolation).
         assert_ne!(
             base,
-            attestor_set_update_digest(&addrs, U256::from(43u64), U256::from(7u64))
+            attestor_set_update_digest(validator, &addrs, U256::from(43u64), U256::from(7u64))
         );
         // Order-sensitive (why canonical ordering is mandatory).
         let reversed = [addrs[1], addrs[0]];
         assert_ne!(
             base,
-            attestor_set_update_digest(&reversed, U256::from(42u64), U256::from(7u64))
+            attestor_set_update_digest(validator, &reversed, U256::from(42u64), U256::from(7u64))
         );
     }
 


### PR DESCRIPTION
Hard blocker for write-ability in production: **attestor-driven attestor-set rotation does not work against the deployed validator.**

## The bug

The registry-based `EOAValidator` (usc-contracts post-#23) computes

```solidity
bytes32 updateHash = keccak256(
    abi.encode(address(this), newAttestors, block.chainid, attestorSetUpdateNonce)
);
```

It binds its own address deliberately — instances share an `AttestorRegistry`, so overlapping signer sets at the same nonce are the norm, and without the binding an update signed for one instance replays against another.

Our digest omitted that field. Every signature the fleet produces therefore recovers over a different preimage, and `submitAttestorSetUpdate` rejects the whole batch. On usc-dev this is why validator-set changes have been applied by hand through the registry owner since we swapped in the new validator stack — the automated path has been silently dead, and it would stay dead in production, where manual rotation is not an option.

## The fix

`validator` becomes the leading field of `attestor_set_update_digest`, threaded through the proposer (which already holds the address it targets).

The encoding is pinned by a **golden vector** that hand-builds the Solidity preimage (head: `validator | offset | chain_id | nonce`, tail: `length | elements`) and asserts equality. For a cross-repo, cross-language signing contract a comment is not enough — this is exactly the class of drift that produces valid-looking signatures the chain refuses.

## Coordinated change — read before merging

`gluwa/usc-message-relayer` recomputes this digest to recover signers and aggregate votes. The matching PR is **gluwa/usc-message-relayer#33**; it also stops taking the validator from the vote (a peer-supplied address could redirect aggregation at an arbitrary contract) and takes it from route config instead.

Deploy order: both, together. A mixed fleet — old attestors with a new relayer, or the reverse — aggregates nothing, which fails the same way the current bug does.

## Verification

- `cargo test -p attestor -p write-ability`: 128 passed
- clippy clean, `cargo fmt --all` applied
- new: validator-sensitivity assertion + the golden vector

Not yet exercised end-to-end on devnet: the deployed attestors need this build first. Worth a live rotation test on usc-dev once both sides ship — I can drive that.
