### PR TITLE
fix(attestor): minimal catch-up quota guard (block cache + rate-limit floors)

### DIFF
--- a/attestor/attestor/src/lib.rs
+++ b/attestor/attestor/src/lib.rs
@@ -174,7 +174,17 @@ impl Attestor {
                 return Ok(());
             }
             result = eth::Client::new(self.config.stream.url_eth.as_ref().as_ref(), None) => {
-                result.map_err(Error::Init)?
+                // Block cache: every block this client fetches sits behind `finalization_lag`, so
+                // entries are immutable — exactly the case the cache is documented safe for. The
+                // payoff is on the catch-up error path: `StreamRoots` discards its in-flight window
+                // on any RPC error and refetches from the last ordered height, which against a
+                // rate-limited provider re-bought the same blocks over and over (2026-08-06
+                // cc3-testnet quota lockout). With the cache, a refetch of already-seen blocks is
+                // a memory read instead of 2 RPC calls. 256 blocks comfortably covers the
+                // 10-deep concurrency window plus ordering gaps (~tens of MB for dense blocks).
+                result.map_err(Error::Init)?.with_block_cache(
+                    std::num::NonZeroUsize::new(256).expect("256 is nonzero"),
+                )
             }
         };
 

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -669,6 +669,10 @@ impl Client {
             // overwrite it). Mirrors the old `get_receipts` walker's `Vec`-of-errors behavior.
             let mut transport_errs: Vec<(String, Error)> = Vec::new();
             let mut payload_inconsistent_errs: Vec<(String, Error)> = Vec::new();
+            // Classified at push time: the floor must fire when ANY provider in the sweep was
+            // rate limiting, not only when the propagated (last-popped) error happens to be
+            // the rate-limited one (bugbot).
+            let mut sweep_rate_limited = false;
 
             for (label, provider) in self.providers_with_labels() {
                 match Self::fetch_block_and_receipts_from_provider(provider, number).await {
@@ -731,6 +735,8 @@ impl Client {
                             error = %e,
                             "failed to retrieve block/receipts pair from provider"
                         );
+                        sweep_rate_limited =
+                            sweep_rate_limited || error_looks_rate_limited(&e.to_string());
                         transport_errs.push((label, e));
                     }
                 }
@@ -757,7 +763,7 @@ impl Client {
                 return Err(Interrupt::Cont(err));
             }
 
-            if error_looks_rate_limited(&err.to_string()) {
+            if sweep_rate_limited {
                 delay = delay.max(RATE_LIMIT_DELAY_FLOOR);
                 tracing::warn!(
                     attempt,

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -652,6 +652,11 @@ impl Client {
         const MAX_ATTEMPTS: usize = 5;
         const DELAY_BASE: u64 = 10;
         const DELAY_MAX: u64 = 60;
+        /// Floor applied as soon as any provider error in the sweep looks like rate limiting:
+        /// a provider refusing on quota needs a pause, not a faster retry — every early retry
+        /// spends more of the very budget whose exhaustion caused the failure (the 2026-08-06
+        /// cc3-testnet Sepolia quota lockout).
+        const RATE_LIMIT_DELAY_FLOOR: u64 = 30;
 
         let mut attempt: usize = 0;
         let mut delay = DELAY_BASE;
@@ -750,6 +755,16 @@ impl Client {
                     "⛔ all RPC endpoints failed to return a consistent block+receipts pair after retries"
                 );
                 return Err(Interrupt::Cont(err));
+            }
+
+            if error_looks_rate_limited(&err.to_string()) {
+                delay = delay.max(RATE_LIMIT_DELAY_FLOOR);
+                tracing::warn!(
+                    attempt,
+                    delay_secs = delay,
+                    error = %err,
+                    "🧯 provider is rate limiting — flooring the retry delay"
+                );
             }
 
             tracing::debug!(
@@ -1212,6 +1227,24 @@ fn looks_like_secret_segment(seg: &str) -> bool {
 /// Build a simple Ethereum-compatible Merkle tree from a block
 ///
 /// Uses `KeccakMerkleTree` which matches the POC implementation exactly.
+/// Whether an error string looks like provider rate limiting / quota exhaustion. Providers word
+/// this many ways (HTTP 429, gRPC-ish `resource_exhausted` inside a WS close frame — Google's
+/// Blockchain Node Engine does the latter), so match the phrasings we have actually seen plus the
+/// common ones. A false positive only makes one retry wait longer.
+pub fn error_looks_rate_limited(text: &str) -> bool {
+    let text = text.to_lowercase();
+    [
+        "resource_exhausted",
+        "resource exhausted",
+        "429",
+        "rate limit",
+        "too many requests",
+        "quota",
+    ]
+    .iter()
+    .any(|needle| text.contains(needle))
+}
+
 pub fn simple_merkle_tree(block: &OrderedBlock) -> merkle::KeccakMerkleTree {
     let tx_bytes: Vec<Vec<u8>> = block.items().iter().map(|item| item.to_bytes()).collect();
     merkle::KeccakMerkleTree::new(&tx_bytes)
@@ -1219,6 +1252,25 @@ pub fn simple_merkle_tree(block: &OrderedBlock) -> merkle::KeccakMerkleTree {
 
 #[cfg(test)]
 mod provider_lookup_tests {
+    // Verbatim shapes from the 2026-08-06 cc3-testnet incident (Google Blockchain Node Engine
+    // close frames) plus the common provider phrasings. A false positive only slows one retry.
+    #[test]
+    fn rate_limit_classifier_matches_incident_strings() {
+        assert!(super::error_looks_rate_limited(
+            "Received close frame with data: Request trace id: c3d7ebd72b1d3944, \
+             [ORIGINAL ERROR] generic::resource_exhausted: com.google.apps.framework.request"
+        ));
+        assert!(super::error_looks_rate_limited(
+            "HTTP error 429 Too Many Requests"
+        ));
+        assert!(super::error_looks_rate_limited("daily quota exceeded"));
+        // The 04:51 trigger error is NOT rate limiting — it must keep the normal backoff.
+        assert!(!super::error_looks_rate_limited(
+            "generic::unavailable: Downstream connection unexpectedly closed"
+        ));
+        assert!(!super::error_looks_rate_limited("connection refused"));
+    }
+
     use super::{merge_provider_lookup, redact_url_query, Error, LookupOutcome};
 
     fn err(msg: &str) -> Error {

--- a/common/streams/eth/src/roots.rs
+++ b/common/streams/eth/src/roots.rs
@@ -124,6 +124,17 @@ impl StreamRoots {
                                 // Failed to retrieve source chain block, try and regenerate the
                                 // stream (this can only be an RPC error)
                                 tracing::error!(%err, "Eth connection error");
+
+                                // A rate-limiting provider needs a pause, not a fast reconnect:
+                                // the rebuild below re-dials, re-subscribes and re-fetches every
+                                // discarded in-flight block, so cycling at the reconnect backoff's
+                                // base rate turns quota pushback into a self-sustaining burn (the
+                                // 2026-08-06 cc3-testnet lockout). Interim guard until the flap
+                                // cooldown generalizes here — see common/continuity/src/rpc.rs.
+                                if eth::error_looks_rate_limited(&err.to_string()) {
+                                    tracing::warn!("🧯 provider is rate limiting — cooling down 30s before stream rebuild");
+                                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                                }
                                 heap.clear();
 
                                 // Removes pending root calls
@@ -265,6 +276,7 @@ async fn stream_rpc(
         .max_delay(std::time::Duration::from_millis(5_000))
         .map(tokio_retry::strategy::jitter);
     let (stream_headers, next) = loop {
+        let mut rate_limited = false;
         match config.client.subscribe().await.map_err(Error::Client) {
             Ok(mut stream_headers) => match stream_headers.next().await {
                 Some(header) => break (stream_headers, header.number),
@@ -272,14 +284,20 @@ async fn stream_rpc(
             },
             Err(err) => {
                 tracing::warn!(?err, "Eth subscribe failed — repairing client and retrying");
+                rate_limited = eth::error_looks_rate_limited(&format!("{err:?}"));
             }
         }
         if let Err(err) = config.client.reconnect().await {
+            rate_limited = rate_limited || eth::error_looks_rate_limited(&format!("{err:?}"));
             tracing::warn!(?err, "Eth client reconnect failed");
         }
-        let delay = delays
+        let mut delay = delays
             .next()
             .unwrap_or(std::time::Duration::from_millis(5_000));
+        // Same guard as the stream body: quota pushback gets a real pause, not the backoff base.
+        if rate_limited {
+            delay = delay.max(std::time::Duration::from_secs(30));
+        }
         tokio::time::sleep(delay).await;
     };
 

--- a/common/streams/eth/src/roots.rs
+++ b/common/streams/eth/src/roots.rs
@@ -124,17 +124,6 @@ impl StreamRoots {
                                 // Failed to retrieve source chain block, try and regenerate the
                                 // stream (this can only be an RPC error)
                                 tracing::error!(%err, "Eth connection error");
-
-                                // A rate-limiting provider needs a pause, not a fast reconnect:
-                                // the rebuild below re-dials, re-subscribes and re-fetches every
-                                // discarded in-flight block, so cycling at the reconnect backoff's
-                                // base rate turns quota pushback into a self-sustaining burn (the
-                                // 2026-08-06 cc3-testnet lockout). Interim guard until the flap
-                                // cooldown generalizes here — see common/continuity/src/rpc.rs.
-                                if eth::error_looks_rate_limited(&err.to_string()) {
-                                    tracing::warn!("🧯 provider is rate limiting — cooling down 30s before stream rebuild");
-                                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-                                }
                                 heap.clear();
 
                                 // Removes pending root calls
@@ -145,6 +134,28 @@ impl StreamRoots {
                                             std::panic::resume_unwind(err.into_panic());
                                         }
                                     }
+                                }
+
+                                // Drop the failed inner stream BEFORE any cooldown: its JoinSet of
+                                // in-flight `get_block` tasks keeps running — and spending quota —
+                                // even while the stream is unpolled; dropping the stream aborts
+                                // them (bugbot). `mem::replace` so the drop is explicit (the empty
+                                // placeholder is itself replaced by the reconnect below).
+                                drop(std::mem::replace(
+                                    &mut stream_blocks,
+                                    futures::stream::empty::<Result<eth::OrderedBlock, Error>>()
+                                        .boxed(),
+                                ));
+
+                                // A rate-limiting provider needs a pause, not a fast reconnect:
+                                // the rebuild below re-dials, re-subscribes and re-fetches every
+                                // discarded in-flight block, so cycling at the reconnect backoff's
+                                // base rate turns quota pushback into a self-sustaining burn (the
+                                // 2026-08-06 cc3-testnet lockout). Interim guard until the flap
+                                // cooldown generalizes here — see common/continuity/src/rpc.rs.
+                                if eth::error_looks_rate_limited(&err.to_string()) {
+                                    tracing::warn!("🧯 provider is rate limiting — cooling down 30s before stream rebuild");
+                                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
                                 }
 
                                 let (client, stream) = Self::reconnect(&config, next).await;
@@ -277,10 +288,19 @@ async fn stream_rpc(
         .map(tokio_retry::strategy::jitter);
     let (stream_headers, next) = loop {
         let mut rate_limited = false;
+        let mut suspect_flap = false;
         match config.client.subscribe().await.map_err(Error::Client) {
             Ok(mut stream_headers) => match stream_headers.next().await {
                 Some(header) => break (stream_headers, header.number),
-                None => tracing::warn!("Eth header stream ended before yielding — retrying"),
+                None => {
+                    // Quota pushback often presents as a clean subscription end right after a
+                    // successful subscribe (the provider accepts the handshake, then closes with
+                    // a frame alloy does not surface here) — there is no error to classify, so
+                    // subscribe-then-immediate-end is treated as suspect and gets the same floor
+                    // (bugbot).
+                    tracing::warn!("Eth header stream ended before yielding — retrying");
+                    suspect_flap = true;
+                }
             },
             Err(err) => {
                 tracing::warn!(?err, "Eth subscribe failed — repairing client and retrying");
@@ -295,7 +315,7 @@ async fn stream_rpc(
             .next()
             .unwrap_or(std::time::Duration::from_millis(5_000));
         // Same guard as the stream body: quota pushback gets a real pause, not the backoff base.
-        if rate_limited {
+        if rate_limited || suspect_flap {
             delay = delay.max(std::time::Duration::from_secs(30));
         }
         tokio::time::sleep(delay).await;


### PR DESCRIPTION
## Context

cc3-testnet's Sepolia attestation died 6 Aug: Google's endpoint blipped (`generic::unavailable`), the attestors' catch-up + reconnect machinery turned that into a sustained ~11 req/s per pod burn, and the per-project quota locked out — including fresh keys, which were born throttled. Full anatomy: `StreamRoots` fetches the entire missed range 10-parallel × 2 RPC calls/block with no pacing, and on ANY error discards its in-flight window and refetches from the last ordered height — so quota pushback made it re-buy the same blocks in a loop.

## What this is (and isn't)

This is the **minimal guard**: smallest possible diff that breaks the self-sustaining lockout loop and holds for the next couple of weeks. Built off the usc-dev line for testing there first, then intended for the testnet release. The **structural fix** (catch-up pacing/adaptive concurrency + progress-preserving reconnect + unifying with #1251's flap cooldown) comes after, as a separate PR.

## Three changes

1. **Enable the existing `MemBlockCache`** (opt-in since it was written; never enabled) on the attestor's eth client, 256 blocks. All fetches sit behind `finalization_lag` → immutable → the documented safe case. Discard-and-refetch becomes a memory read instead of 2 RPC calls per re-bought block.
2. **`try_fetch_block`: 30s delay floor when the sweep's errors look like rate limiting** — quota pushback gets a pause, not the 10s base backoff.
3. **`StreamRoots`: 30s cooldown before the discard-and-rebuild cycle** on rate-limit-shaped stream errors, plus the same floor in the subscribe-retry loop.

Shared string classifier `eth::error_looks_rate_limited` (dup of #1251's — deliberately, to keep this patch dependency-free; the good patch unifies them). Unit test pins the verbatim Google close-frame from the incident and keeps `generic::unavailable` (the 04:51 trigger) on the normal fast path.

## Impact math

During a quota lockout, per pod: before — a rebuild cycle every ~1–5 s, each up to 10 blocks × 2 calls refetched; after — one cycle per ≥30 s with refetches served from cache. Across 6 pods that's from ~50+ req/s sustained to well under 1 req/s, which lets a per-minute quota actually recover while the attestors keep probing.

## Testing

`cargo test -p eth -p attestor --lib` — 135 passed (new classifier test included) · clippy `-D warnings` clean · fmt. (Note: `cargo test -p eth` **alone** trips a pre-existing E0512 in a dependency via feature unification — present on the base branch, invisible to CI which tests workspace-level.)