### PR TITLE
feat(attestor): pace the write-ability destination watchers under rate limiting

### DIFF
--- a/attestor/attestor/src/tasks/write_ability/attestor_set.rs
+++ b/attestor/attestor/src/tasks/write_ability/attestor_set.rs
@@ -68,6 +68,12 @@ pub async fn watch(
     // destination RPC), so this first tick reads the real set + threshold and swaps them in.
     let mut tick = tokio::time::interval(Duration::from_secs(ATTESTOR_SET_POLL_SECS));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // Rate-limit pacing: every attestor in the fleet runs this poll on the same cadence against
+    // the same (often shared, RPS-capped) destination endpoint, colliding with the fleet's
+    // synchronized per-block fetches. When the provider rejects on rate limits, escalate this
+    // loop's cooldown instead of colliding again next tick (observed live 2026-08-07, Chainstack
+    // -32005 on usc-dev; mirrors the relayer's pacing module).
+    let mut pacer = eth::RateLimitPacer::default();
 
     // The threshold currently applied to the aggregator. Tracked so a threshold-ONLY change (same
     // membership) is still detected and applied (audit P3-2) — membership equality alone would skip
@@ -81,6 +87,13 @@ pub async fn watch(
                 return;
             }
             _ = tick.tick() => {
+                // Rate-limit pacing: skip the poll while a deferral window is active (armed only
+                // by rate-limited failures; clean polls decay the level and are never slowed).
+                if let Some(remaining) = pacer.deferring() {
+                    tracing::debug!(remaining_ms = remaining.as_millis() as u64,
+                        "⏸️ pacing attestor-set watcher — skipping poll");
+                    continue;
+                }
                 // Fresh connection each poll — see the fn doc. A dead/transiently-unreachable RPC
                 // fails only this tick and is retried on the next, instead of wedging the watcher.
                 let (set, onchain_threshold) = match tokio::time::timeout(
@@ -89,9 +102,22 @@ pub async fn watch(
                 )
                 .await
                 {
-                    Ok(Ok(v)) => v,
+                    Ok(Ok(v)) => {
+                        pacer.after(false);
+                        v
+                    }
                     Ok(Err(err)) => {
                         tracing::warn!(%validator, %err, "failed to read on-chain attestor set/threshold; will retry");
+                        let rate_limited = eth::error_looks_rate_limited(&format!("{err:#}"));
+                        pacer.after(rate_limited);
+                        if rate_limited {
+                            if let Some(window) = pacer.deferring() {
+                                tracing::warn!(
+                                    defer_ms = window.as_millis() as u64,
+                                    "🧯 provider is rate limiting — deferring attestor-set polls"
+                                );
+                            }
+                        }
                         continue;
                     }
                     Err(_) => {

--- a/attestor/attestor/src/tasks/write_ability/attestor_set.rs
+++ b/attestor/attestor/src/tasks/write_ability/attestor_set.rs
@@ -72,8 +72,10 @@ pub async fn watch(
     // the same (often shared, RPS-capped) destination endpoint, colliding with the fleet's
     // synchronized per-block fetches. When the provider rejects on rate limits, escalate this
     // loop's cooldown instead of colliding again next tick (observed live 2026-08-07, Chainstack
-    // -32005 on usc-dev; mirrors the relayer's pacing module).
-    let mut pacer = eth::RateLimitPacer::default();
+    // -32005 on usc-dev; mirrors the relayer's pacing module). Base the window on this loop's own
+    // poll interval — a shorter window would expire before the next tick and never actually skip
+    // a poll, so the fleet would keep colliding on the first few escalations (bugbot).
+    let mut pacer = eth::RateLimitPacer::new(Duration::from_secs(ATTESTOR_SET_POLL_SECS));
 
     // The threshold currently applied to the aggregator. Tracked so a threshold-ONLY change (same
     // membership) is still detected and applied (audit P3-2) — membership equality alone would skip

--- a/attestor/attestor/src/tasks/write_ability/set_update.rs
+++ b/attestor/attestor/src/tasks/write_ability/set_update.rs
@@ -181,6 +181,10 @@ pub async fn run_proposer(
     tracing::info!(%validator, "🗳️ attestor-set-update proposer online");
     let mut tick = tokio::time::interval(Duration::from_secs(SET_UPDATE_POLL_SECS));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // Rate-limit pacing — see the attestor-set watcher: same shared-endpoint collision, same
+    // damper. Only genuine rate-limit rejections escalate; timeouts and other errors keep the
+    // base cadence.
+    let mut pacer = eth::RateLimitPacer::default();
 
     loop {
         tokio::select! {
@@ -189,6 +193,13 @@ pub async fn run_proposer(
                 return;
             }
             _ = tick.tick() => {
+                // Rate-limit pacing: skip the cycle while a deferral window is active (armed only
+                // by rate-limited failures; clean cycles decay the level and are never slowed).
+                if let Some(remaining) = pacer.deferring() {
+                    tracing::debug!(remaining_ms = remaining.as_millis() as u64,
+                        "⏸️ pacing set-update proposer — skipping cycle");
+                    continue;
+                }
                 // Ensure this attestor's own EVM address is registered on-chain, every cycle. The
                 // startup registration in `lib.rs` is best-effort and one-shot; re-checking here
                 // recovers not only from a transient startup RPC blip (review P2-8 #2) but also from
@@ -205,6 +216,7 @@ pub async fn run_proposer(
                 .await
                 {
                     Ok(Ok(Some(vote))) => {
+                        pacer.after(false);
                         // Bounded `try_send`: if the publish channel is full the vote is dropped and
                         // re-proposed next tick (set changes persist until an update lands), so a
                         // backed-up publisher never blocks this loop.
@@ -212,9 +224,21 @@ pub async fn run_proposer(
                             tracing::warn!("set-update vote publish channel full — will re-propose next tick");
                         }
                     }
-                    Ok(Ok(None)) => {}
+                    Ok(Ok(None)) => {
+                        pacer.after(false);
+                    }
                     Ok(Err(err)) => {
                         tracing::warn!(%err, "attestor-set-update proposal cycle failed; will retry");
+                        let rate_limited = eth::error_looks_rate_limited(&format!("{err:#}"));
+                        pacer.after(rate_limited);
+                        if rate_limited {
+                            if let Some(window) = pacer.deferring() {
+                                tracing::warn!(
+                                    defer_ms = window.as_millis() as u64,
+                                    "🧯 provider is rate limiting — deferring set-update cycles"
+                                );
+                            }
+                        }
                     }
                     Err(_) => {
                         tracing::warn!(

--- a/attestor/attestor/src/tasks/write_ability/set_update.rs
+++ b/attestor/attestor/src/tasks/write_ability/set_update.rs
@@ -183,8 +183,9 @@ pub async fn run_proposer(
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     // Rate-limit pacing — see the attestor-set watcher: same shared-endpoint collision, same
     // damper. Only genuine rate-limit rejections escalate; timeouts and other errors keep the
-    // base cadence.
-    let mut pacer = eth::RateLimitPacer::default();
+    // base cadence. Base the window on this loop's own poll interval, same reasoning as the
+    // attestor-set watcher (bugbot).
+    let mut pacer = eth::RateLimitPacer::new(Duration::from_secs(SET_UPDATE_POLL_SECS));
 
     loop {
         tokio::select! {

--- a/attestor/attestor/src/tasks/write_ability/set_update.rs
+++ b/attestor/attestor/src/tasks/write_ability/set_update.rs
@@ -193,21 +193,26 @@ pub async fn run_proposer(
                 return;
             }
             _ = tick.tick() => {
-                // Rate-limit pacing: skip the cycle while a deferral window is active (armed only
-                // by rate-limited failures; clean cycles decay the level and are never slowed).
-                if let Some(remaining) = pacer.deferring() {
-                    tracing::debug!(remaining_ms = remaining.as_millis() as u64,
-                        "⏸️ pacing set-update proposer — skipping cycle");
-                    continue;
-                }
                 // Ensure this attestor's own EVM address is registered on-chain, every cycle. The
                 // startup registration in `lib.rs` is best-effort and one-shot; re-checking here
                 // recovers not only from a transient startup RPC blip (review P2-8 #2) but also from
                 // the mapping later disappearing while the process runs — e.g. a chain-removal purge
                 // (bugbot: don't latch on first success). Idempotent and cheap: `register_evm_address`
                 // reads the on-chain value first and only submits an extrinsic when it is missing or
-                // stale, so a steady state is a single storage read per cycle.
+                // stale, so a steady state is a single storage read per cycle. Runs unconditionally,
+                // ahead of the destination-pacing check below: it only talks to the Creditcoin chain
+                // (`cc3`), never the rate-limited destination RPC, so destination throttling must not
+                // also stall these registration retries (bugbot).
                 super::register_evm_address(&cc3, &signer, chain_key).await;
+
+                // Rate-limit pacing: skip the destination-RPC part of the cycle while a deferral
+                // window is active (armed only by rate-limited failures; clean cycles decay the
+                // level and are never slowed).
+                if let Some(remaining) = pacer.deferring() {
+                    tracing::debug!(remaining_ms = remaining.as_millis() as u64,
+                        "⏸️ pacing set-update proposer — skipping cycle");
+                    continue;
+                }
 
                 match tokio::time::timeout(
                     super::RPC_ATTEMPT_TIMEOUT,

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -1265,7 +1265,7 @@ pub struct RateLimitPacer {
 }
 
 impl RateLimitPacer {
-    const LEVEL_CAP: u32 = 5;
+    const LEVEL_CAP: u32 = 6;
     const BASE: std::time::Duration = std::time::Duration::from_secs(5);
 
     /// Record an iteration outcome. Rate-limited failures escalate + arm a window; clean passes
@@ -1331,13 +1331,13 @@ mod provider_lookup_tests {
             last = d;
         }
         assert!(
-            last <= Duration::from_secs(80),
+            last <= Duration::from_secs(160),
             "window capped at BASE << (CAP-1)"
         );
-        assert!(last > Duration::from_secs(40), "reached the cap");
+        assert!(last > Duration::from_secs(80), "reached the cap");
         // Clean passes decay the level but never arm windows.
         p.after(false);
-        assert!(p.deferring().is_none_or(|d| d <= Duration::from_secs(80)));
+        assert!(p.deferring().is_none_or(|d| d <= Duration::from_secs(160)));
     }
 
     use super::{merge_provider_lookup, redact_url_query, Error, LookupOutcome};

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -1212,6 +1212,82 @@ fn looks_like_secret_segment(seg: &str) -> bool {
 /// Build a simple Ethereum-compatible Merkle tree from a block
 ///
 /// Uses `KeccakMerkleTree` which matches the POC implementation exactly.
+/// Whether an error string looks like provider rate limiting / quota exhaustion. Matches the
+/// phrasings observed live — Chainstack's `-32005 … RPS limit` (2026-08-07), Google Blockchain
+/// Node Engine's `resource_exhausted` close frames (2026-08-06) — plus HTTP 429 and generic quota
+/// wording. Numeric tokens ("429", "32005") are matched with non-alphanumeric boundaries so block
+/// numbers and hex ids containing those digit runs never misclassify (Sepolia heights currently
+/// start 11429…). A false positive only makes one retry wait longer.
+pub fn error_looks_rate_limited(text: &str) -> bool {
+    let text = text.to_lowercase();
+    [
+        "resource_exhausted",
+        "resource exhausted",
+        "rate limit",
+        "rps limit",
+        "too many requests",
+        "quota",
+    ]
+    .iter()
+    .any(|needle| text.contains(needle))
+        || contains_standalone(&text, "429")
+        || contains_standalone(&text, "32005")
+}
+
+/// `needle` bounded by non-alphanumerics (or string edges) — a status/error code, not a digit run
+/// inside a block number or hex id.
+fn contains_standalone(text: &str, needle: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut start = 0;
+    while let Some(pos) = text[start..].find(needle) {
+        let i = start + pos;
+        let before_ok = i == 0 || !bytes[i - 1].is_ascii_alphanumeric();
+        let after = i + needle.len();
+        let after_ok = after >= bytes.len() || !bytes[after].is_ascii_alphanumeric();
+        if before_ok && after_ok {
+            return true;
+        }
+        start = i + 1;
+    }
+    false
+}
+
+/// Per-loop rate-limit damper for periodic RPC read loops (mirrors the relayer's
+/// `pacing::RateLimitPacer`, post-review shape): a rate-limited failure escalates the level and
+/// arms a DEFERRAL WINDOW (5s doubling to 160s cap) that the loop checks at tick start; a clean
+/// pass decays one level and never slows anything. Deferral-not-sleep so a `select!` arm never
+/// blocks its siblings and a long cooldown can never hold a task past external liveness deadlines
+/// (the relayer's Bugbot review caught both failure modes — keep the designs in lockstep).
+#[derive(Debug, Default)]
+pub struct RateLimitPacer {
+    level: u32,
+    defer_until: Option<std::time::Instant>,
+}
+
+impl RateLimitPacer {
+    const LEVEL_CAP: u32 = 5;
+    const BASE: std::time::Duration = std::time::Duration::from_secs(5);
+
+    /// Record an iteration outcome. Rate-limited failures escalate + arm a window; clean passes
+    /// decay one level (gradual, so a loop colliding every other tick stays damped).
+    pub fn after(&mut self, rate_limited: bool) {
+        if rate_limited {
+            self.level = (self.level + 1).min(Self::LEVEL_CAP);
+            self.defer_until =
+                Some(std::time::Instant::now() + Self::BASE * 2u32.pow(self.level - 1));
+        } else {
+            self.level = self.level.saturating_sub(1);
+        }
+    }
+
+    /// Time remaining in an active deferral window; `None` when the loop should run its tick.
+    pub fn deferring(&self) -> Option<std::time::Duration> {
+        let until = self.defer_until?;
+        let now = std::time::Instant::now();
+        (now < until).then(|| until - now)
+    }
+}
+
 pub fn simple_merkle_tree(block: &OrderedBlock) -> merkle::KeccakMerkleTree {
     let tx_bytes: Vec<Vec<u8>> = block.items().iter().map(|item| item.to_bytes()).collect();
     merkle::KeccakMerkleTree::new(&tx_bytes)
@@ -1219,6 +1295,51 @@ pub fn simple_merkle_tree(block: &OrderedBlock) -> merkle::KeccakMerkleTree {
 
 #[cfg(test)]
 mod provider_lookup_tests {
+    // Rate-limit pacing helpers — phrasings verbatim from the 2026-08-06 (Google BNE) and
+    // 2026-08-07 (Chainstack) incidents; numeric tokens must NOT match inside block numbers.
+    #[test]
+    fn rate_limit_classifier_and_pacer() {
+        use std::time::Duration;
+        assert!(super::error_looks_rate_limited(
+            "server returned an error response: error code -32005: You've exceeded the RPS limit \
+             available on the current plan."
+        ));
+        assert!(super::error_looks_rate_limited(
+            "[ORIGINAL ERROR] generic::resource_exhausted: com.google.apps.framework.request"
+        ));
+        assert!(super::error_looks_rate_limited(
+            "HTTP 429 Too Many Requests"
+        ));
+        assert!(!super::error_looks_rate_limited(
+            "eth_getLogs from 11429000 to 11429060 failed"
+        ));
+        assert!(!super::error_looks_rate_limited(
+            "nonce 3200529 already used"
+        ));
+        assert!(!super::error_looks_rate_limited(
+            "generic::unavailable: Downstream connection unexpectedly closed"
+        ));
+
+        let mut p = super::RateLimitPacer::default();
+        p.after(false);
+        assert!(p.deferring().is_none(), "clean iterations never defer");
+        let mut last = Duration::ZERO;
+        for _ in 0..8 {
+            p.after(true);
+            let d = p.deferring().expect("rate-limited failure arms a window");
+            assert!(d >= last.saturating_sub(Duration::from_millis(50)));
+            last = d;
+        }
+        assert!(
+            last <= Duration::from_secs(80),
+            "window capped at BASE << (CAP-1)"
+        );
+        assert!(last > Duration::from_secs(40), "reached the cap");
+        // Clean passes decay the level but never arm windows.
+        p.after(false);
+        assert!(p.deferring().is_none_or(|d| d <= Duration::from_secs(80)));
+    }
+
     use super::{merge_provider_lookup, redact_url_query, Error, LookupOutcome};
 
     fn err(msg: &str) -> Error {

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -1254,19 +1254,40 @@ fn contains_standalone(text: &str, needle: &str) -> bool {
 
 /// Per-loop rate-limit damper for periodic RPC read loops (mirrors the relayer's
 /// `pacing::RateLimitPacer`, post-review shape): a rate-limited failure escalates the level and
-/// arms a DEFERRAL WINDOW (5s doubling to 160s cap) that the loop checks at tick start; a clean
-/// pass decays one level and never slows anything. Deferral-not-sleep so a `select!` arm never
-/// blocks its siblings and a long cooldown can never hold a task past external liveness deadlines
-/// (the relayer's Bugbot review caught both failure modes — keep the designs in lockstep).
-#[derive(Debug, Default)]
+/// arms a DEFERRAL WINDOW that the loop checks at tick start; a clean pass decays one level and
+/// never slows anything. Deferral-not-sleep so a `select!` arm never blocks its siblings and a long
+/// cooldown can never hold a task past external liveness deadlines (the relayer's Bugbot review
+/// caught both failure modes — keep the designs in lockstep).
+///
+/// The window doubles from `base` (level 1) up to `base << (LEVEL_CAP - 1)` (level `LEVEL_CAP`).
+/// Construct with [`RateLimitPacer::new`], passing the **caller loop's own poll interval** as
+/// `base`: a window shorter than that interval expires before the loop wakes up again and so never
+/// actually defers a poll, letting the fleet collide again on the very next tick (bugbot).
+#[derive(Debug)]
 pub struct RateLimitPacer {
     level: u32,
     defer_until: Option<std::time::Instant>,
+    base: std::time::Duration,
+}
+
+impl Default for RateLimitPacer {
+    fn default() -> Self {
+        Self::new(std::time::Duration::from_secs(5))
+    }
 }
 
 impl RateLimitPacer {
     const LEVEL_CAP: u32 = 6;
-    const BASE: std::time::Duration = std::time::Duration::from_secs(5);
+
+    /// `base` is the level-1 deferral window — pass the caller loop's own poll interval so the
+    /// first classified failure already defers at least the next tick (see the type docs).
+    pub fn new(base: std::time::Duration) -> Self {
+        Self {
+            level: 0,
+            defer_until: None,
+            base,
+        }
+    }
 
     /// Record an iteration outcome. Rate-limited failures escalate + arm a window; clean passes
     /// decay one level (gradual, so a loop colliding every other tick stays damped).
@@ -1274,7 +1295,7 @@ impl RateLimitPacer {
         if rate_limited {
             self.level = (self.level + 1).min(Self::LEVEL_CAP);
             self.defer_until =
-                Some(std::time::Instant::now() + Self::BASE * 2u32.pow(self.level - 1));
+                Some(std::time::Instant::now() + self.base * 2u32.pow(self.level - 1));
         } else {
             self.level = self.level.saturating_sub(1);
         }
@@ -1338,6 +1359,24 @@ mod provider_lookup_tests {
         // Clean passes decay the level but never arm windows.
         p.after(false);
         assert!(p.deferring().is_none_or(|d| d <= Duration::from_secs(160)));
+    }
+
+    #[test]
+    fn pacer_base_must_cover_the_callers_own_poll_interval() {
+        use std::time::Duration;
+        // A window shorter than the caller's poll interval expires before the loop wakes up
+        // again and never actually defers anything — `new` must be given that interval as `base`
+        // so a single classified failure already skips at least the next tick.
+        let interval = Duration::from_secs(30);
+        let mut p = super::RateLimitPacer::new(interval);
+        p.after(true);
+        let d = p
+            .deferring()
+            .expect("first classified failure arms a window");
+        assert!(
+            d >= interval.saturating_sub(Duration::from_millis(50)),
+            "level-1 window ({d:?}) must cover at least the poll interval ({interval:?})"
+        );
     }
 
     use super::{merge_provider_lookup, redact_url_query, Error, LookupOutcome};


### PR DESCRIPTION
Attestor-side twin of usc-message-relayer #35, for the two Sepolia-facing watchers every attestor runs: the **attestor-set watcher** (30 s `attestors()`+`threshold()` poll) and the **set-update proposer** cycle. Nine pods run these in phase and also fetch each new Sepolia block simultaneously, so on a shared RPS-capped key the polls landing inside a burst-second get rejected — observed live on usc-dev 2026-08-07 (Chainstack `-32005`) right after the Google BNE migration.

## Design (deferral, not sleep — post-review shape from #35)

`eth::RateLimitPacer`: a rate-limited failure escalates a level and arms a **deferral window** (5 s → 160 s cap) that the loop checks at tick start and skips cheaply; clean iterations decay one level and are never slowed, logged, or deferred. No `select!` arm ever sleeps — this incorporates all four findings Bugbot raised on the relayer twin (blocked sibling arms, watchdog-deadline overrun → restart storm, skipped decay on the common success path, false rate-limit logging during decay) *before* they could recur here.

`eth::error_looks_rate_limited`: matches both incidents' verbatim phrasings (Chainstack `-32005 … RPS limit`, Google `resource_exhausted`, HTTP 429, quota), numeric tokens boundary-checked so Sepolia heights (`11429…`) never misclassify. Named identically to #1253's classifier on the usc-dev base — this is the fixed reference implementation the trunk reconciliation should keep.

## Impact when calm

Zero — level 0 arms nothing; a lone classified error costs one 5 s window.

## Testing

`cargo test -p eth -p attestor --lib` — 135 passed (pacer window/decay + classifier incl. both incident strings) · clippy `-D warnings --all-features` clean · fmt

Non-goal: the block-fetch catch-up pacing (the big burst source) stays with #1253 + the structural patch; this PR only stops the fixed-cadence watchers from colliding repeatedly.