### PR TITLE
fix(ci): wire up should-run's changes output so the Linode build is a…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
     needs:
       - should-run
     # extrinsics check below needs the build unconditionally on usc-dev, regardless of path filters
-    if: ${{ toJSON(needs.should-run.outputs.changes) != '[]' || github.base_ref == 'usc-dev' }}
+    if: ${{ needs.should-run.outputs.changes != '[]' || github.base_ref == 'usc-dev' }}
     strategy:
       fail-fast: false
       matrix:
@@ -137,7 +137,7 @@ jobs:
     needs:
       - should-run
       - deploy-runner-build-creditcoin-for-testing
-    if: ${{ toJSON(needs.should-run.outputs.changes) != '[]' || github.base_ref == 'usc-dev' }}
+    if: ${{ needs.should-run.outputs.changes != '[]' || github.base_ref == 'usc-dev' }}
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release --features=fast-runtime"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   should-run:
     runs-on: ubuntu-26.04
     outputs:
+      changes: ${{ steps.filter.outputs.changes }}
       archiver: ${{ steps.filter.outputs.archiver }}
       attestor_cli_testing: ${{ steps.filter.outputs.attestor_cli_testing }}
       attestor_network_testing: ${{ steps.filter.outputs.attestor_network_testing }}
@@ -117,7 +118,8 @@ jobs:
   deploy-runner-build-creditcoin-for-testing:
     needs:
       - should-run
-    if: toJSON(needs.should-run.outputs.changes) != '[]'
+    # extrinsics check below needs the build unconditionally on usc-dev, regardless of path filters
+    if: ${{ toJSON(needs.should-run.outputs.changes) != '[]' || github.base_ref == 'usc-dev' }}
     strategy:
       fail-fast: false
       matrix:
@@ -135,6 +137,7 @@ jobs:
     needs:
       - should-run
       - deploy-runner-build-creditcoin-for-testing
+    if: ${{ toJSON(needs.should-run.outputs.changes) != '[]' || github.base_ref == 'usc-dev' }}
     uses: ./.github/workflows/build-native.yml
     with:
       build-options: "--release --features=fast-runtime"


### PR DESCRIPTION
…ctually conditional

# Description of proposed changes

wire up should-run's changes output so the Linode build is actually conditional

Reduces wasted linode vm time as noted in the report
---

When merging this PR:

- For PRs against `usc-dev` use the "Squash and merge" button
- For PRs against `usc-testnet`/`main` use the "Create a merge commit" button
- Hotfixes against `usc-testnet`/`main` should use the "Squash and merge" button

---

Practical tips for PR review:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
