### PR TITLE
ci: fast-forward branch promotion and release tag resolution

### DIFF
--- a/.github/check-promotion-is-safe.sh
+++ b/.github/check-promotion-is-safe.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Guard for branch promotions (usc-dev -> usc-testnet -> main).
+#
+# Usage: check-promotion-is-safe.sh <last-ref> <target-branch>
+#
+# The promotion model is that the target branch only ever moves forward along
+# the line of history that usc-dev builds. Anything on the target that is NOT
+# in <last-ref> is about to be dropped by the rebase that follows, silently.
+#
+# Dropping an empty merge commit is fine and expected: GitHub's "Create a merge
+# commit" button mints one on every promotion, and it carries no changes. But a
+# commit with real content on the target means someone landed work directly on
+# usc-testnet or main, and promoting would silently revert it. That is what this
+# script is here to catch.
+
+set -euo pipefail
+
+LAST_REF="${1:?usage: $0 <last-ref> <target-branch>}"
+TARGET_BRANCH="${2:?usage: $0 <last-ref> <target-branch>}"
+TARGET_REF="refs/remotes/origin/$TARGET_BRANCH"
+
+if ! git rev-parse -q --verify "$TARGET_REF" >/dev/null; then
+    echo "INFO: origin/$TARGET_BRANCH not present locally, fetching it"
+    git fetch --quiet origin "+refs/heads/$TARGET_BRANCH:$TARGET_REF"
+fi
+
+echo "INFO: promoting '$LAST_REF' onto '$TARGET_BRANCH'"
+
+if git merge-base --is-ancestor "$TARGET_REF" "$LAST_REF"; then
+    echo "PASS: origin/$TARGET_BRANCH is already an ancestor of $LAST_REF"
+    echo "      This promotion is a clean fast-forward, nothing will be dropped."
+    exit 0
+fi
+
+# Walk everything the target has that the promotion does not, and split it into
+# commits that change nothing (safe to drop) and commits that do (not safe).
+WITH_CONTENT=""
+WITHOUT_CONTENT=0
+
+while read -r sha; do
+    [ -n "$sha" ] || continue
+
+    tree=$(git rev-parse "${sha}^{tree}")
+    is_empty=""
+
+    # A merge whose tree matches any parent introduced no changes of its own.
+    for parent in $(git rev-list --parents -n1 "$sha" | cut -d" " -f2-); do
+        if [ "$(git rev-parse "${parent}^{tree}")" = "$tree" ]; then
+            is_empty="yes"
+            break
+        fi
+    done
+
+    if [ -n "$is_empty" ]; then
+        WITHOUT_CONTENT=$((WITHOUT_CONTENT + 1))
+    else
+        WITH_CONTENT="$WITH_CONTENT $sha"
+    fi
+done <<< "$(git rev-list "$LAST_REF..$TARGET_REF")"
+
+echo "INFO: $WITHOUT_CONTENT empty commit(s) on $TARGET_BRANCH will be dropped (harmless)"
+
+if [ -z "$WITH_CONTENT" ]; then
+    echo "PASS: nothing with real content would be lost by this promotion"
+    exit 0
+fi
+
+echo "FAIL: origin/$TARGET_BRANCH has commits with real content that are missing"
+echo "      from $LAST_REF. Promoting would silently revert them:"
+echo
+for sha in $WITH_CONTENT; do
+    git --no-pager log -1 --format="      %h %s" "$sha"
+done
+echo
+echo "      Every change must enter at usc-dev and be promoted upward. Backport"
+echo "      the commits above to usc-dev first, then re-run this workflow."
+exit 1

--- a/.github/check-tag-suffix-vs-origin-branch.sh
+++ b/.github/check-tag-suffix-vs-origin-branch.sh
@@ -1,36 +1,59 @@
 #!/bin/bash
 
+# Verify that a release tag was cut from the branch its suffix names:
+#
+#     *-devnet   ->  usc-dev
+#     *-testnet  ->  usc-testnet
+#     *-mainnet  ->  main
+#
+# We ask "is this commit contained in the branch the suffix names?" rather than
+# "which branch is this commit on?". Once branches are promoted by fast-forward
+# a release commit is reachable from many branches at once, so asking which
+# branch it is "on" has no single answer.
+
 set -euo pipefail
 
-GIT_TAG=$(git describe --tag)
+# In CI the tag comes from the ref that triggered the workflow. Fall back to
+# `git describe` so the script stays runnable by hand on a tagged checkout.
+GIT_TAG="${TAG_NAME:-$(git describe --tag)}"
 SUFFIX_FROM_GIT_TAG=$(echo "$GIT_TAG" | cut -d"-" -f2,99)
 
-echo "----- DEBUG -----"
-git branch -a --contains
-echo "----- DEBUG -----"
-git branch -a --contains | grep remotes/origin
-echo "----- END -----"
+case "$SUFFIX_FROM_GIT_TAG" in
+    devnet)  EXPECTED_BRANCH="usc-dev" ;;
+    testnet) EXPECTED_BRANCH="usc-testnet" ;;
+    mainnet) EXPECTED_BRANCH="main" ;;
+    *)
+        echo "FAIL: '$GIT_TAG' has no recognized network suffix"
+        echo "      expected one of: devnet, testnet, mainnet; got '$SUFFIX_FROM_GIT_TAG'"
+        exit 1
+        ;;
+esac
 
-NEAREST_GIT_BRANCH=$(git branch -a --contains | grep remotes/origin | cut -f3 -d/)
+# Resolve the tag to a commit; on a detached checkout of the tag HEAD will do.
+if git rev-parse -q --verify "${GIT_TAG}^{commit}" >/dev/null; then
+    TAGGED_COMMIT=$(git rev-parse "${GIT_TAG}^{commit}")
+else
+    TAGGED_COMMIT=$(git rev-parse "HEAD^{commit}")
+    echo "INFO: tag '$GIT_TAG' not present locally, falling back to HEAD"
+fi
+
+# Shallow clones and tag-only fetches may not carry the branch we need.
+if ! git rev-parse -q --verify "refs/remotes/origin/$EXPECTED_BRANCH" >/dev/null; then
+    echo "INFO: origin/$EXPECTED_BRANCH not present locally, fetching it"
+    git fetch --quiet origin "+refs/heads/$EXPECTED_BRANCH:refs/remotes/origin/$EXPECTED_BRANCH"
+fi
 
 echo "INFO: git tag: '$GIT_TAG'"
 echo "INFO: suffix from git tag: '$SUFFIX_FROM_GIT_TAG'"
-echo "INFO: nearest git branch '$NEAREST_GIT_BRANCH'"
+echo "INFO: expected branch: 'origin/$EXPECTED_BRANCH'"
+echo "INFO: tagged commit: '$TAGGED_COMMIT'"
 
-if [[ "$SUFFIX_FROM_GIT_TAG" == "devnet" && "$NEAREST_GIT_BRANCH" == "usc-dev" ]]; then
-    echo "PASS: good match for -devnet releases"
+if git merge-base --is-ancestor "$TAGGED_COMMIT" "refs/remotes/origin/$EXPECTED_BRANCH"; then
+    echo "PASS: $GIT_TAG is contained in origin/$EXPECTED_BRANCH"
     exit 0
 fi
 
-if [[ "$SUFFIX_FROM_GIT_TAG" == "testnet" && "$NEAREST_GIT_BRANCH" == "usc-testnet" ]]; then
-    echo "PASS: good match for -testnet releases"
-    exit 0
-fi
-
-if [[ "$SUFFIX_FROM_GIT_TAG" == "mainnet" && "$NEAREST_GIT_BRANCH" == "main" ]]; then
-    echo "PASS: good match for -mainnet releases"
-    exit 0
-fi
-
-echo "FAIL: Looks like tag name doesn't match the branch it came from"
+echo "FAIL: $GIT_TAG is not contained in origin/$EXPECTED_BRANCH"
+echo "      A '$SUFFIX_FROM_GIT_TAG' release must be tagged on a commit that is"
+echo "      already merged into $EXPECTED_BRANCH. Promote the branch first, then tag."
 exit 1

--- a/.github/check-version-vs-git-tag.sh
+++ b/.github/check-version-vs-git-tag.sh
@@ -3,13 +3,19 @@
 set -xeuo pipefail
 
 VERSION_FROM_CARGO_TOML=$(grep "^version =" Cargo.toml  | cut -f2 -d'=' | tr -d "' \"")
-VERSION_FROM_GIT_TAG=$(git describe --tag)
+# In CI the tag comes from the ref that triggered the workflow; `git describe`
+# is only a fallback for running this by hand, since a commit can carry several
+# release tags at once and describe reports just one of them.
+VERSION_FROM_GIT_TAG="${TAG_NAME:-$(git describe --tag)}"
 
 # when releasing version strings in Cargo.toml and git tags must be in sync
 echo "INFO: Cargo.toml version is $VERSION_FROM_CARGO_TOML"
 echo "INFO: git tag version is $VERSION_FROM_GIT_TAG"
 
-if [[ ! "$VERSION_FROM_GIT_TAG" =~ "$VERSION_FROM_CARGO_TOML"* ]]; then
+# Anchored literal prefix plus a mandatory "-<suffix>". The previous test used
+# =~ with an unanchored pattern, so Cargo.toml 3.13.0 matched tag 3.131.0-mainnet
+# ('.' matching any character, trailing '*' applying to the final '0' only).
+if [[ "$VERSION_FROM_GIT_TAG" != "$VERSION_FROM_CARGO_TOML"-* ]]; then
     echo "FAIL: Versions in Cargo.toml and git tag are not in sync"
     exit 2
 fi

--- a/.github/workflows/promote-branch.yml
+++ b/.github/workflows/promote-branch.yml
@@ -13,8 +13,10 @@ name: Promote Branch (fast-forward)
 # invariant (main subset-of usc-testnet subset-of usc-dev) holds by
 # construction rather than by discipline.
 #
-# Manual dispatch only. Releases are infrequent enough that a deliberate click
-# per promotion is cheaper than the divergence the merge button leaves behind.
+# Promoting is manual dispatch only. Releases are infrequent enough that a
+# deliberate click per promotion is cheaper than the divergence the merge button
+# leaves behind. The pull_request trigger below never promotes; it is a
+# report-only self-test, described where it is declared.
 
 "on":
   # Allows you to run this workflow manually from the Actions tab
@@ -39,19 +41,40 @@ name: Promote Branch (fast-forward)
         default: true
         description: Run every check and report what would move, without moving it.
 
+  # Self-test. A workflow_dispatch trigger only registers from the default
+  # branch, so without this there is no way to exercise this file until it has
+  # already been merged. On a pull request touching the promotion machinery,
+  # run every gate for real - real runner, real token, real LFS checkout - with
+  # DRY_RUN forced on so no ref can move.
+  #
+  # Report-only: the gate steps are continue-on-error under pull_request. Gate 3
+  # legitimately fails until the one-time reconcile merges have been run, so
+  # enforcing it here would mean a permanently red check that tells us nothing.
+  # What the self-test proves is that the workflow wires up and the gates reach
+  # a verdict; the verdicts themselves are printed in the job summary.
+  pull_request:
+    paths:
+      - '.github/workflows/promote-branch.yml'
+      - '.github/check-promotion-is-safe.sh'
+
 permissions: read-all
 
 # Two promotions racing each other would make the ancestry checks meaningless.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 # Security: don't use inputs directly, pass them through ENV, see:
 # https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable
 env:
-  SOURCE_REF: ${{ inputs.SOURCE_REF }}
-  TARGET_BRANCH: ${{ inputs.TARGET_BRANCH }}
-  DRY_RUN: ${{ inputs.DRY_RUN }}
+  # inputs.* are empty on the pull_request self-test, hence the fallbacks.
+  SOURCE_REF: ${{ inputs.SOURCE_REF || 'usc-dev' }}
+  TARGET_BRANCH: ${{ inputs.TARGET_BRANCH || 'usc-testnet' }}
+  # Anything that is not a manual dispatch must not be able to move a ref.
+  # Written as 'A != x || B' rather than the usual 'A == x && B || C' ternary:
+  # that form collapses to C whenever B is false, which would quietly turn an
+  # explicit DRY_RUN=false back into true and make real promotion impossible.
+  DRY_RUN: ${{ github.event_name != 'workflow_dispatch' || inputs.DRY_RUN }}
 
 jobs:
   promote:
@@ -96,6 +119,8 @@ jobs:
           echo "SOURCE_SHA=$SOURCE_SHA" >> "$GITHUB_ENV"
 
       - name: Check the promotion comes from usc-dev
+        id: gate-source
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: |
           # Every change enters at usc-dev and is promoted upward. Enforcing that
           # here also means the commit is already on origin, so the push moves a
@@ -115,6 +140,8 @@ jobs:
           exit 1
 
       - name: Check nothing is lost by promoting to ${{ env.TARGET_BRANCH }}
+        id: gate-safe
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: |
           # Runs first because it gives the actionable message: if the target
           # carries real work that never went through usc-dev, this names the
@@ -122,6 +149,8 @@ jobs:
           .github/check-promotion-is-safe.sh "$SOURCE_SHA" "$TARGET_BRANCH"
 
       - name: Check the promotion is a fast-forward
+        id: gate-ff
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: |
           # check-promotion-is-safe.sh tolerates dropping empty commits, because
           # the rebase-based promotion path legitimately does that. A push
@@ -152,6 +181,8 @@ jobs:
           exit 1
 
       - name: Promote ${{ env.SOURCE_REF }} to ${{ env.TARGET_BRANCH }}
+        id: push
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: |
           # No --force, no --force-with-lease. Push refusing a non-fast-forward
           # is the safety mechanism, not an obstacle to work around.
@@ -164,8 +195,35 @@ jobs:
               echo "INFO: origin/$TARGET_BRANCH now points at $SOURCE_SHA"
           fi
 
+      - name: Self-test summary
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GATE_SOURCE: ${{ steps.gate-source.outcome }}
+          GATE_SAFE: ${{ steps.gate-safe.outcome }}
+          GATE_FF: ${{ steps.gate-ff.outcome }}
+          GATE_PUSH: ${{ steps.push.outcome }}
+        run: |
+          {
+              echo "### Promotion self-test: $SOURCE_REF -> $TARGET_BRANCH"
+              echo
+              echo "Report-only. DRY_RUN was forced on, so nothing was pushed."
+              echo
+              echo "| gate | outcome |"
+              echo "| --- | --- |"
+              echo "| 1. source is contained in usc-dev | $GATE_SOURCE |"
+              echo "| 2. nothing with content is lost | $GATE_SAFE |"
+              echo "| 3. promotion is a fast-forward | $GATE_FF |"
+              echo "| 4. dry-run push | $GATE_PUSH |"
+              echo
+              if [[ "$GATE_FF" != "success" ]]; then
+                  echo "Gate 3 failing is expected until the one-time reconcile"
+                  echo "merges have been run on usc-dev. See the gate's own output"
+                  echo "for the exact commands."
+              fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Report result to Slack
-        if: always()
+        if: always() && github.event_name == 'workflow_dispatch'
         uses: act10ns/slack@v2
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/promote-branch.yml
+++ b/.github/workflows/promote-branch.yml
@@ -85,7 +85,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           lfs: true
-          token: ${{ secrets.GLUWA_BOT_TOKEN }}
+          # pull_request runs the PR's own version of this workflow, before
+          # review - a real push token has no business being in scope there.
+          # Read-only gates never need more than the default token.
+          token: ${{ github.event_name == 'workflow_dispatch' && secrets.GLUWA_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Resolve refs

--- a/.github/workflows/promote-branch.yml
+++ b/.github/workflows/promote-branch.yml
@@ -118,26 +118,39 @@ jobs:
 
           echo "SOURCE_SHA=$SOURCE_SHA" >> "$GITHUB_ENV"
 
-      - name: Check the promotion comes from usc-dev
+      - name: Check the promotion source has cleared the required stages
         id: gate-source
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: |
           # Every change enters at usc-dev and is promoted upward. Enforcing that
           # here also means the commit is already on origin, so the push moves a
           # label over objects the remote (LFS included) already has.
-          if git merge-base --is-ancestor "$SOURCE_SHA" "refs/remotes/origin/usc-dev"; then
-              echo "PASS: $SOURCE_SHA is contained in origin/usc-dev"
-              exit 0
+          if ! git merge-base --is-ancestor "$SOURCE_SHA" "refs/remotes/origin/usc-dev"; then
+              echo "FAIL: $SOURCE_SHA is not contained in origin/usc-dev."
+              echo "      Every change must enter at usc-dev and be promoted upward,"
+              echo "      so only a commit already on usc-dev can be promoted."
+              echo
+              echo "      If this is a mainnet hotfix that cannot wait, cut a"
+              echo "      release/x.y.z-mainnet branch from main, ship from there, and"
+              echo "      let the normal promotion carry the fix later."
+              exit 1
           fi
+          echo "PASS: $SOURCE_SHA is contained in origin/usc-dev"
 
-          echo "FAIL: $SOURCE_SHA is not contained in origin/usc-dev."
-          echo "      Every change must enter at usc-dev and be promoted upward,"
-          echo "      so only a commit already on usc-dev can be promoted."
-          echo
-          echo "      If this is a mainnet hotfix that cannot wait, cut a"
-          echo "      release/x.y.z-mainnet branch from main, ship from there, and"
-          echo "      let the normal promotion carry the fix later."
-          exit 1
+          # main is the last stage of usc-dev -> usc-testnet -> main. Containment
+          # in usc-dev alone isn't enough here, or a source that skipped
+          # usc-testnet entirely would ship straight to mainnet unvalidated.
+          if [[ "$TARGET_BRANCH" == "main" ]]; then
+              if ! git merge-base --is-ancestor "$SOURCE_SHA" "refs/remotes/origin/usc-testnet"; then
+                  echo "FAIL: $SOURCE_SHA is not contained in origin/usc-testnet."
+                  echo "      A promotion to main must already have gone through"
+                  echo "      usc-testnet. Promote to usc-testnet first, then re-run"
+                  echo "      this workflow with SOURCE_REF=usc-testnet (or a ref"
+                  echo "      reachable from it)."
+                  exit 1
+              fi
+              echo "PASS: $SOURCE_SHA is contained in origin/usc-testnet"
+          fi
 
       - name: Check nothing is lost by promoting to ${{ env.TARGET_BRANCH }}
         id: gate-safe

--- a/.github/workflows/promote-branch.yml
+++ b/.github/workflows/promote-branch.yml
@@ -1,0 +1,174 @@
+---
+name: Promote Branch (fast-forward)
+
+# Moves a branch label forward along history that already exists:
+#
+#     usc-dev  ->  usc-testnet  ->  main
+#
+# A promotion is not a merge. None of GitHub's merge modes can express it:
+# every one of them mints a new commit on the target, which is why the target
+# kept reading as "N commits behind" the source after each release. A plain
+# `git push <sha>:<branch>` is the only operation that moves the label without
+# adding anything, and it refuses a non-fast-forward by default, so the
+# invariant (main subset-of usc-testnet subset-of usc-dev) holds by
+# construction rather than by discipline.
+#
+# Manual dispatch only. Releases are infrequent enough that a deliberate click
+# per promotion is cheaper than the divergence the merge button leaves behind.
+
+"on":
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      SOURCE_REF:
+        required: true
+        type: string
+        default: 'usc-dev'
+        description: "Ref to promote FROM. WARNING: edit this field, not the one above!"
+      TARGET_BRANCH:
+        required: true
+        type: choice
+        options:
+          - usc-testnet
+          - main
+        default: 'usc-testnet'
+        description: Branch to promote INTO. Fast-forward only, never usc-dev.
+      DRY_RUN:
+        required: false
+        type: boolean
+        default: true
+        description: Run every check and report what would move, without moving it.
+
+permissions: read-all
+
+# Two promotions racing each other would make the ancestry checks meaningless.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+# Security: don't use inputs directly, pass them through ENV, see:
+# https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable
+env:
+  SOURCE_REF: ${{ inputs.SOURCE_REF }}
+  TARGET_BRANCH: ${{ inputs.TARGET_BRANCH }}
+  DRY_RUN: ${{ inputs.DRY_RUN }}
+
+jobs:
+  promote:
+    runs-on: ubuntu-26.04
+    # checkov:skip=CKV2_GHA_1:We need this to push the promoted ref
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          lfs: true
+          token: ${{ secrets.GLUWA_BOT_TOKEN }}
+          fetch-depth: 0
+
+      - name: Resolve refs
+        run: |
+          # The choice input already constrains this, but keep the allowlist in
+          # the job too: usc-dev is where changes enter, never a promotion target.
+          case "$TARGET_BRANCH" in
+              usc-testnet|main) ;;
+              *)
+                  echo "FAIL: '$TARGET_BRANCH' is not a promotion target"
+                  echo "      expected one of: usc-testnet, main"
+                  exit 1
+                  ;;
+          esac
+
+          # Accept a branch name, a tag or a raw SHA. Prefer the remote-tracking
+          # branch so 'usc-dev' means origin's usc-dev, not a stale local copy.
+          if git rev-parse -q --verify "refs/remotes/origin/$SOURCE_REF^{commit}" >/dev/null; then
+              SOURCE_SHA=$(git rev-parse "refs/remotes/origin/$SOURCE_REF^{commit}")
+          elif git rev-parse -q --verify "$SOURCE_REF^{commit}" >/dev/null; then
+              SOURCE_SHA=$(git rev-parse "$SOURCE_REF^{commit}")
+          else
+              echo "FAIL: cannot resolve '$SOURCE_REF' to a commit"
+              exit 1
+          fi
+
+          echo "INFO: promoting '$SOURCE_REF' ($SOURCE_SHA) into '$TARGET_BRANCH'"
+          git --no-pager log -1 --format="INFO: source tip: %h %s" "$SOURCE_SHA"
+          git --no-pager log -1 --format="INFO: target tip: %h %s" "refs/remotes/origin/$TARGET_BRANCH"
+
+          echo "SOURCE_SHA=$SOURCE_SHA" >> "$GITHUB_ENV"
+
+      - name: Check the promotion comes from usc-dev
+        run: |
+          # Every change enters at usc-dev and is promoted upward. Enforcing that
+          # here also means the commit is already on origin, so the push moves a
+          # label over objects the remote (LFS included) already has.
+          if git merge-base --is-ancestor "$SOURCE_SHA" "refs/remotes/origin/usc-dev"; then
+              echo "PASS: $SOURCE_SHA is contained in origin/usc-dev"
+              exit 0
+          fi
+
+          echo "FAIL: $SOURCE_SHA is not contained in origin/usc-dev."
+          echo "      Every change must enter at usc-dev and be promoted upward,"
+          echo "      so only a commit already on usc-dev can be promoted."
+          echo
+          echo "      If this is a mainnet hotfix that cannot wait, cut a"
+          echo "      release/x.y.z-mainnet branch from main, ship from there, and"
+          echo "      let the normal promotion carry the fix later."
+          exit 1
+
+      - name: Check nothing is lost by promoting to ${{ env.TARGET_BRANCH }}
+        run: |
+          # Runs first because it gives the actionable message: if the target
+          # carries real work that never went through usc-dev, this names the
+          # commits instead of letting the push fail with a bare rejection.
+          .github/check-promotion-is-safe.sh "$SOURCE_SHA" "$TARGET_BRANCH"
+
+      - name: Check the promotion is a fast-forward
+        run: |
+          # check-promotion-is-safe.sh tolerates dropping empty commits, because
+          # the rebase-based promotion path legitimately does that. A push
+          # cannot: the target tip must already be an ancestor of the source.
+          if git merge-base --is-ancestor \
+              "refs/remotes/origin/$TARGET_BRANCH" "$SOURCE_SHA"; then
+              echo "PASS: origin/$TARGET_BRANCH is an ancestor of $SOURCE_REF"
+              exit 0
+          fi
+
+          echo "FAIL: origin/$TARGET_BRANCH is not an ancestor of $SOURCE_REF, so"
+          echo "      this promotion is not a fast-forward and will not be pushed."
+          echo
+          echo "      Commits on $TARGET_BRANCH that $SOURCE_REF does not have:"
+          echo
+          git --no-pager log --format="      %h %s" \
+              "$SOURCE_SHA..refs/remotes/origin/$TARGET_BRANCH"
+          echo
+          echo "      The check above found none of them carry content, so nothing"
+          echo "      would be lost, but the label still cannot move forward over"
+          echo "      them. Reconcile once, from a clone with push rights:"
+          echo
+          echo "          git checkout usc-dev"
+          echo "          git merge --no-ff origin/$TARGET_BRANCH"
+          echo "          git push origin usc-dev"
+          echo
+          echo "      then re-run this workflow."
+          exit 1
+
+      - name: Promote ${{ env.SOURCE_REF }} to ${{ env.TARGET_BRANCH }}
+        run: |
+          # No --force, no --force-with-lease. Push refusing a non-fast-forward
+          # is the safety mechanism, not an obstacle to work around.
+          if [[ "$DRY_RUN" == "true" ]]; then
+              echo "INFO: DRY_RUN is set, reporting only"
+              git push --dry-run origin "$SOURCE_SHA:refs/heads/$TARGET_BRANCH"
+              echo "INFO: nothing was pushed. Re-run with DRY_RUN unchecked to promote."
+          else
+              git push origin "$SOURCE_SHA:refs/heads/$TARGET_BRANCH"
+              echo "INFO: origin/$TARGET_BRANCH now points at $SOURCE_SHA"
+          fi
+
+      - name: Report result to Slack
+        if: always()
+        uses: act10ns/slack@v2
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: ${{ job.status }}
+          channel: "#protocol-internal"
+          message: "promote ${{ env.SOURCE_REF }} -> ${{ env.TARGET_BRANCH }} (dry-run: ${{ env.DRY_RUN }}): ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/rebase-branch-and-propose-pr.yml
+++ b/.github/workflows/rebase-branch-and-propose-pr.yml
@@ -39,6 +39,11 @@ jobs:
           git checkout -b "${{ env.BRANCH_NAME }}" "${{ env.LAST_REF }}"
           git branch
 
+      - name: Check nothing is lost by promoting to ${{ env.TARGET_BRANCH }}
+        run: |
+          .github/check-promotion-is-safe.sh \
+            "${{ env.LAST_REF }}" "${{ env.TARGET_BRANCH }}"
+
       - name: Rebase ${{ env.BRANCH_NAME }} against ${{ env.TARGET_BRANCH }}
         run: |
           git config --global user.email "creditcoin@gluwa.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,17 @@ jobs:
         id: identify-tag
         shell: bash
         run: |
-          TAG_NAME=$(git describe --tag)
+          # Use the ref that triggered this run, not `git describe`. A release
+          # commit can carry more than one tag (e.g. both -devnet and -mainnet
+          # once a branch is promoted by fast-forward), and `git describe` picks
+          # only one of them, so it can report a tag we are not releasing.
+          if [[ "$GITHUB_REF_TYPE" != "tag" ]]; then
+              echo "FAIL: expected a tag push, got ref type '$GITHUB_REF_TYPE'"
+              exit 1
+          fi
+
+          TAG_NAME="$GITHUB_REF_NAME"
+          echo "INFO: releasing tag '$TAG_NAME'"
           echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
           echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Two things: the CI fixes that a fast-forward promotion needs, and the manual promotion job itself.

### The promotion job

- **`promote-branch.yml` (new)** — `workflow_dispatch`-only job that promotes `usc-dev -> usc-testnet -> main` with `git push origin "${SHA}:refs/heads/${TARGET}"`. No force, no lease: push refusing a non-fast-forward *is* the safety mechanism. `TARGET_BRANCH` is a `choice` input limited to `usc-testnet` and `main`, so `usc-dev` can never be a target, and a `concurrency` group stops two promotions racing the ancestry checks.

  Four gates run before the push, ordered so the most actionable error wins:

  1. the source commit is contained in `origin/usc-dev` (every change enters at usc-dev and is promoted upward)
  2. `check-promotion-is-safe.sh`, which names any direct-landed commits the promotion would revert
  3. a strict fast-forward assert, separate from (2) because that script tolerates dropping empty commits, which the rebase path legitimately does and a push cannot
  4. `DRY_RUN`, on by default, reports what would move without moving it

  A `pull_request` trigger runs the same gates as a report-only self-test; see **Testing it before merge**.

  The existing `propose-testnet-pr.yml` / `propose-mainnet-pr.yml` rebase workflows are left in place as a fallback until FF promotion has been through a real release.

### The CI fixes

- **`check-promotion-is-safe.sh` (new)**, wired into `rebase-branch-and-propose-pr.yml` before the rebase step. Fails a promotion when the target branch has real commits unreachable from the ref being promoted, which the rebase would otherwise drop silently. Empty merge commits from GitHub's promotion PRs are recognized, counted and allowed through.
- **`check-tag-suffix-vs-origin-branch.sh`** now asks "is the tagged commit an ancestor of the branch its suffix names" instead of "which branch is this commit nearest to". The old question has no single answer once a commit is reachable from many branches, which is exactly what fast-forward promotion causes.
- **`check-version-vs-git-tag.sh`** — real bug: the unanchored `=~` let tag `3.131.0-mainnet` match a `Cargo.toml` version of `3.13.0`. Replaced with an anchored literal-prefix glob.
- **`release.yml`** takes `TAG_NAME` from `GITHUB_REF_NAME` (the ref that triggered the run) instead of `git describe --tag`, and asserts the trigger was a tag push. A promoted commit can carry more than one release tag and `git describe` reports only one, which would have published devnet-labelled artifacts from a mainnet tag.

## Verification

Run in throwaway clones against real `origin` refs.

| # | Case | Expect | Result |
|---|------|--------|--------|
| 1 | `usc-dev -> usc-testnet`, state today | FF fail | safe-check PASS (1 empty), FF FAIL naming `bdb4ef872` |
| 2 | Real hotfix landed directly on `main` | fail | FAIL exit 1, commit listed |
| 3 | Source not contained in `usc-dev` | fail | FAIL with the release-branch hotfix guidance |
| 4 | Both targets after the reconcile merges | pass | PASS, clean fast-forward |
| 5 | `DRY_RUN=true` push | no move | remote tip unchanged |
| 6 | Real push | moves | tip advances to source SHA |
| 7 | Non-fast-forward push | refused | `! [rejected] (non-fast-forward)` |
| 8 | Tag suffix, 23 branches + 2 tags on the commit | pass | PASS (old script: FAIL) |
| 9 | `Cargo.toml` 3.13.0 vs tag 3.131.0-mainnet | fail | FAIL (old script: PASS) |

`bash -n` clean on all three scripts and on the workflow's `run` blocks; both edited workflows and the new one parse as valid YAML. Nothing outside `.github/` is touched, so no Rust build is affected.

## Before the first real dispatch

Neither of these is something this PR can do.

**1. The reconcile merges.** `usc-dev` currently contains the tip of neither `main` nor `usc-testnet`, so gate 3 will fail until:

```
git checkout usc-dev
git merge --no-ff origin/main
git merge --no-ff origin/usc-testnet
git push origin usc-dev
```

Merging `main` alone is *not* enough. `main`'s tip is a merge of `04b745c85` and `c89842971`, not of `bdb4ef872` — the testnet-into-main promotion went through the rebase path, which dropped that empty merge and replayed nothing:

```
$ git merge-base --is-ancestor bdb4ef872 origin/main ; echo $?
1
```

All three tips already share tree `9cc51227c705aa510ec5269f064191606cb7bf54`, so the reconcile changes no content: `git diff` across it is empty.

**2. Branch protection.** Block force-push and restrict direct push on `usc-testnet` and `main` to the promotion bot. Without it, fast-forward-only is a convention rather than a guarantee.

## Testing it before merge

`workflow_dispatch` only registers from the default branch (`usc-dev`), so this file
could not be exercised until it had already been merged. It therefore carries a
`pull_request` trigger scoped to its own paths: every push to this PR runs all four
gates on a real runner with the real `GLUWA_BOT_TOKEN` and a real LFS checkout,
with `DRY_RUN` forced on. The gates are `continue-on-error` there and report into
the job summary, because gate 3 legitimately fails until the reconcile merges are
run and a permanently red check would tell us nothing.

First self-test run: https://github.com/gluwa/creditcoin3/actions/runs/32139875281

```
PASS: 06657e990 is contained in origin/usc-dev              <- gate 1
INFO: 1 empty commit(s) on usc-testnet will be dropped
PASS: nothing with real content would be lost               <- gate 2
FAIL: origin/usc-testnet is not an ancestor of usc-dev      <- gate 3, as expected today
INFO: DRY_RUN is set, reporting only
 ! [rejected]  06657e990 -> usc-testnet (non-fast-forward)  <- gate 4
```

Gate 4 went to the real `origin`: the token authenticated and has push rights, the
refspec is correct, LFS pre-push handled the chainspecs, and the non-fast-forward
refusal is real rather than sandbox-only. `usc-testnet` was unmoved afterwards.

Note when reading the run: `continue-on-error` masks step failures, so the API
reports every step as `success`. The real verdicts are in the log and the job
summary.

## Test plan

- [x] CI passes on this PR
- [x] Self-test proves gates 1-2 pass, gate 3 fails as expected, and the dry-run push is refused
- [x] Run the reconcile merges on `usc-dev` (both of them, see above)
- [ ] Re-run the self-test, confirm gate 3 and the dry-run push now pass
- [ ] Merge, then dispatch `promote-branch.yml` with `DRY_RUN=true`, `usc-dev -> usc-testnet`
- [ ] Dispatch again with `DRY_RUN` unchecked, confirm `usc-testnet` fast-forwards
- [ ] Confirm GitHub auto-closes the promotion PR as merged
- [ ] Apply branch protection to `usc-testnet` and `main`
