### PR TITLE
Exclude execa from dependabot auto-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -136,6 +136,10 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+      # execa >=6 is ESM-only, but cli/ is compiled to CommonJS and requires it
+      # from CJS test helpers, so major bumps break the TypeScript build
+      - dependency-name: "execa"
+        update-types: ["version-update:semver-major"]
 
   # Python dependencies for Linode
   - package-ecosystem: "pip"


### PR DESCRIPTION
This is only used in our /cli directory. And there it causes failures at any version >= 6.0.0

So excluding it from dependabot updates