### PR TITLE
fix(write-ability): persist the OutboxCreated factory-scan cursor

### DIFF
--- a/attestor/attestor/src/tasks/write_ability/cursor.rs
+++ b/attestor/attestor/src/tasks/write_ability/cursor.rs
@@ -15,6 +15,12 @@
 //! and the relayer dedups votes (see [`super::listener::scan_range`]). We therefore never advance the
 //! persisted cursor *past* work that has not been scanned, but we may repeat a little already-scanned
 //! work; that is the safe direction for a signer.
+//!
+//! [`FactoryScanCursorStore`] persists the *other* scan this task runs: `OutboxCreated` discovery
+//! against the factory contract (see [`super::resolver::OutboxDiscoveryCursor`]). Without it, a
+//! factory change (or just a restart) rescans that factory's full log history from genesis before
+//! write-ability can activate at all — the same at-least-once safety applies, since re-scanning
+//! already-covered blocks only wastes time, never correctness.
 
 use std::path::{Path, PathBuf};
 
@@ -175,6 +181,144 @@ impl CursorStore {
     }
 }
 
+/// On-disk record of an [`super::resolver::OutboxDiscoveryCursor`]'s scan progress.
+///
+/// Unlike [`CursorRecord`], `factory` is not a validity gate enforced by this store — the factory
+/// is exactly what the scan is trying to pin down, so there is nothing to compare it against at
+/// load time. Instead [`FactoryScanCursorStore::load`] returns the record as-is and
+/// `resolver::resolve_outbox_address`'s existing `cursor.factory != factory` comparison against the
+/// freshly-read on-chain registration discards it, the same way it already discards a mid-run
+/// rotation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FactoryScanRecord {
+    /// Highest block scanned so far for `OutboxCreated` on `factory` (inclusive).
+    scanned_to: u64,
+    /// Factory this scan was performed against.
+    factory: Address,
+    /// Write-ability chain key this cursor belongs to.
+    chain_key: u64,
+    /// The latest `OutboxCreated` match found so far, if any: its Outbox address and the block it
+    /// was emitted in (see `resolver::OutboxDiscoveryCursor::found`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    found_outbox: Option<Address>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    found_created_at_block: Option<u64>,
+}
+
+/// In-memory shape of a [`FactoryScanCursorStore`] record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PersistedFactoryScan {
+    pub factory: Address,
+    pub scanned_to: u64,
+    pub found: Option<(Address, Option<u64>)>,
+}
+
+/// Persists an [`super::resolver::OutboxDiscoveryCursor`]'s `OutboxCreated` discovery progress to a
+/// JSON file, atomically.
+///
+/// Scoped only by `chain_key`, not by factory: the resolved factory can change (governance
+/// re-registration), and it is exactly the discovery scan's job to find the Outbox for whichever
+/// factory is currently registered — see [`FactoryScanRecord`]'s docs for how a stale factory is
+/// handled.
+#[derive(Clone, Debug)]
+pub struct FactoryScanCursorStore {
+    path: PathBuf,
+    chain_key: u64,
+}
+
+impl FactoryScanCursorStore {
+    /// Factory-scan cursor file for `chain_key` inside `dir`. See [`CursorStore::new`]'s
+    /// single-owner-of-`dir` invariant — the same one applies here.
+    #[must_use]
+    pub fn new(dir: &Path, chain_key: u64) -> Self {
+        Self {
+            path: dir.join(format!("factory-scan-cursor-{chain_key}.json")),
+            chain_key,
+        }
+    }
+
+    /// The file this store reads and writes (for logging).
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Load the persisted scan progress, or `None` when there is nothing usable yet: file missing
+    /// (first boot), or unreadable/corrupt (logged, then treated as absent so a bad file never
+    /// wedges boot — same reasoning as [`CursorStore::load`]).
+    #[must_use]
+    pub fn load(&self) -> Option<PersistedFactoryScan> {
+        let raw = match std::fs::read(&self.path) {
+            Ok(bytes) => bytes,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) => {
+                tracing::warn!(
+                    path = %self.path.display(), %e,
+                    "could not read factory-scan cursor file; starting OutboxCreated discovery from genesis"
+                );
+                return None;
+            }
+        };
+        let record: FactoryScanRecord = match serde_json::from_slice(&raw) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(
+                    path = %self.path.display(), %e,
+                    "factory-scan cursor file is corrupt; ignoring it"
+                );
+                return None;
+            }
+        };
+        Some(PersistedFactoryScan {
+            factory: record.factory,
+            scanned_to: record.scanned_to,
+            found: record
+                .found_outbox
+                .map(|outbox| (outbox, record.found_created_at_block)),
+        })
+    }
+
+    /// Persist `scan` atomically (temp file + fsync + rename — same scheme as
+    /// [`CursorStore::save`]). Overwrites whatever was previously recorded for this `chain_key`
+    /// outright: every call carries the scan's full current progress, so there is nothing from a
+    /// prior record worth preserving.
+    pub fn save(&self, scan: &PersistedFactoryScan) -> Result<()> {
+        let (found_outbox, found_created_at_block) = match scan.found {
+            Some((outbox, block)) => (Some(outbox), block),
+            None => (None, None),
+        };
+        let record = FactoryScanRecord {
+            scanned_to: scan.scanned_to,
+            factory: scan.factory,
+            chain_key: self.chain_key,
+            found_outbox,
+            found_created_at_block,
+        };
+        let json = serde_json::to_vec_pretty(&record).context("serialize factory-scan cursor")?;
+
+        let dir = self.path.parent().unwrap_or_else(|| Path::new("."));
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("create cursor dir {}", dir.display()))?;
+
+        let tmp = self
+            .path
+            .with_extension(format!("json.tmp.{}", std::process::id()));
+        {
+            use std::io::Write as _;
+            let mut f = std::fs::File::create(&tmp).with_context(|| {
+                format!("create temp factory-scan cursor file {}", tmp.display())
+            })?;
+            f.write_all(&json)
+                .context("write temp factory-scan cursor file")?;
+            f.sync_all()
+                .context("fsync temp factory-scan cursor file")?;
+        }
+        std::fs::rename(&tmp, &self.path)
+            .with_context(|| format!("rename {} -> {}", tmp.display(), self.path.display()))?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -266,5 +410,92 @@ mod tests {
         // No probe file should linger after the check.
         let leftover: Vec<_> = std::fs::read_dir(&nested).unwrap().collect();
         assert!(leftover.is_empty(), "probe file must be cleaned up");
+    }
+
+    fn factory() -> Address {
+        address!("00000000000000000000000000000000000000ff")
+    }
+
+    #[test]
+    fn factory_scan_missing_file_loads_none() {
+        let dir = TmpDir::new("factory-missing");
+        let store = FactoryScanCursorStore::new(dir.path(), 2);
+        assert_eq!(store.load(), None);
+    }
+
+    #[test]
+    fn factory_scan_round_trips_with_a_winner() {
+        let dir = TmpDir::new("factory-roundtrip");
+        let store = FactoryScanCursorStore::new(dir.path(), 2);
+        let scan = PersistedFactoryScan {
+            factory: factory(),
+            scanned_to: 12_345,
+            found: Some((outbox(), Some(100))),
+        };
+        store.save(&scan).unwrap();
+        assert_eq!(store.load(), Some(scan));
+
+        // A later save overwrites in place.
+        let advanced = PersistedFactoryScan {
+            factory: factory(),
+            scanned_to: 20_000,
+            found: Some((outbox(), Some(100))),
+        };
+        store.save(&advanced).unwrap();
+        assert_eq!(store.load(), Some(advanced));
+    }
+
+    /// A scan that has covered some of the range but found no `OutboxCreated` match yet round-trips
+    /// with `found: None` rather than a partially-populated pair.
+    #[test]
+    fn factory_scan_round_trips_with_no_winner_yet() {
+        let dir = TmpDir::new("factory-no-winner");
+        let store = FactoryScanCursorStore::new(dir.path(), 2);
+        let scan = PersistedFactoryScan {
+            factory: factory(),
+            scanned_to: 2_000,
+            found: None,
+        };
+        store.save(&scan).unwrap();
+        assert_eq!(store.load(), Some(scan));
+    }
+
+    #[test]
+    fn factory_scan_corrupt_file_loads_none() {
+        let dir = TmpDir::new("factory-corrupt");
+        let store = FactoryScanCursorStore::new(dir.path(), 2);
+        std::fs::write(store.path(), b"not json {{{").unwrap();
+        assert_eq!(store.load(), None);
+    }
+
+    /// Unlike [`CursorStore`], loading does not itself discard a record for a different factory —
+    /// that discard happens one layer up, in `resolver::resolve_outbox_address`'s comparison
+    /// against the freshly-read on-chain factory. This store just returns whatever was persisted.
+    #[test]
+    fn factory_scan_load_returns_record_regardless_of_which_factory_it_names() {
+        let dir = TmpDir::new("factory-any");
+        let store = FactoryScanCursorStore::new(dir.path(), 2);
+        let old_factory = address!("00000000000000000000000000000000000000ee");
+        let scan = PersistedFactoryScan {
+            factory: old_factory,
+            scanned_to: 500,
+            found: None,
+        };
+        store.save(&scan).unwrap();
+        assert_eq!(store.load(), Some(scan));
+    }
+
+    #[test]
+    fn factory_scan_save_creates_missing_dir() {
+        let dir = TmpDir::new("factory-mkdir");
+        let nested = dir.path().join("a").join("b");
+        let store = FactoryScanCursorStore::new(&nested, 1);
+        let scan = PersistedFactoryScan {
+            factory: factory(),
+            scanned_to: 42,
+            found: None,
+        };
+        store.save(&scan).unwrap();
+        assert_eq!(store.load(), Some(scan));
     }
 }

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -449,9 +449,29 @@ pub async fn run(
     // `run_outbox_monitor`, which detects factory and Outbox rotations with the same polling.
     let mut resolve_attempts: u64 = 0;
     let mut consecutive_resolve_failures: u64 = 0;
+    // Durable factory-scan cursor: persists `OutboxCreated` discovery progress so a restart resumes
+    // the scan instead of rescanning the factory's full log history from genesis. Scoped only by
+    // chain_key — see `cursor::FactoryScanCursorStore`'s docs for how a stale (rotated-away)
+    // persisted factory is handled.
+    let factory_scan_store =
+        cursor::FactoryScanCursorStore::new(&cfg.state_dir, cfg.write_ability_chain_key);
     // Discovery cursor: advances past confirmed blocks already scanned for `OutboxCreated` so each
     // retry only scans new blocks instead of re-scanning the whole chain history every interval.
-    let mut outbox_cursor = resolver::OutboxDiscoveryCursor::default();
+    // Seeded from whatever `factory_scan_store` has on disk; a persisted factory that has since
+    // rotated away is discarded automatically by `resolve`'s on-chain factory comparison.
+    let mut outbox_cursor = match factory_scan_store.load() {
+        Some(persisted) => {
+            tracing::info!(
+                path = %factory_scan_store.path().display(),
+                factory = %persisted.factory,
+                scanned_to = persisted.scanned_to,
+                found = ?persisted.found,
+                "🗂️ resuming OutboxCreated discovery from persisted factory-scan cursor"
+            );
+            resolver::OutboxDiscoveryCursor::from_persisted(persisted)
+        }
+        None => resolver::OutboxDiscoveryCursor::default(),
+    };
     let resolved = loop {
         // Progress-aware failure budget, mirroring the listener's `next_failure_count`. Outbox
         // discovery is a *chunked* log scan, so one attempt legitimately exceeds
@@ -468,6 +488,7 @@ pub async fn run(
                     &cfg,
                     state.destination_chain_key,
                     &mut outbox_cursor,
+                    Some(&factory_scan_store),
                 ),
             ) => attempt.unwrap_or_else(|_| {
                 Err(anyhow!(
@@ -661,6 +682,7 @@ pub async fn run(
             cfg,
             destination_chain_key,
             outbox_cursor,
+            factory_scan_store,
             resolved,
             resolved_tx,
             token,
@@ -959,11 +981,13 @@ fn child_exit_error(
 /// key at another factory or the active factory emits a replacement Outbox. A factory transition
 /// with no finalized replacement Outbox publishes `None` immediately so consumers stop signing the
 /// de-registered Outbox while discovery continues.
+#[allow(clippy::too_many_arguments)]
 async fn run_outbox_monitor<P: Provider>(
     provider: P,
     cfg: Config,
     destination_chain_key: B256,
     mut cursor: resolver::OutboxDiscoveryCursor,
+    factory_scan_store: cursor::FactoryScanCursorStore,
     current: resolver::ResolvedOutbox,
     resolved_tx: watch::Sender<Option<resolver::ResolvedOutbox>>,
     token: tokio_util::sync::CancellationToken,
@@ -987,7 +1011,13 @@ async fn run_outbox_monitor<P: Provider>(
                 // whatever progress the attempt made, so a timeout costs nothing).
                 let attempt = tokio::time::timeout(
                     RPC_ATTEMPT_TIMEOUT,
-                    resolver::resolve(&provider, &cfg, destination_chain_key, &mut cursor),
+                    resolver::resolve(
+                        &provider,
+                        &cfg,
+                        destination_chain_key,
+                        &mut cursor,
+                        Some(&factory_scan_store),
+                    ),
                 )
                 .await
                 .unwrap_or_else(|_| {

--- a/attestor/attestor/src/tasks/write_ability/resolver.rs
+++ b/attestor/attestor/src/tasks/write_ability/resolver.rs
@@ -16,6 +16,12 @@
 //! Resolution continues after activation: [`super::run_outbox_monitor`] polls this resolver with the
 //! same incremental cursor and hot-swaps the listener when governance changes the factory or the
 //! active factory emits a replacement Outbox.
+//!
+//! The `OutboxCreated` scan this module runs is itself durable: when a
+//! [`FactoryScanCursorStore`](super::cursor::FactoryScanCursorStore) is supplied, progress is
+//! persisted after every call and — via [`OutboxDiscoveryCursor::from_persisted`] — reloaded once
+//! at process start, so a restart resumes the scan instead of rescanning the factory's full log
+//! history from genesis (which a factory change already forces even within one run).
 
 use alloy::primitives::{Address, B256};
 use alloy::providers::Provider;
@@ -28,6 +34,7 @@ use attestor_primitives::ChainKey;
 use write_ability::abi::{IChainInfo, IOutboxFactory};
 
 use super::config::Config;
+use super::cursor::{FactoryScanCursorStore, PersistedFactoryScan};
 
 /// `chain-info` precompile address (`0x…0fD3`, 4051) — see `precompiles/metadata/sol/chain_info.sol`.
 /// Exposes `pallet_supported_chains::OutboxFactories` (`chain_key → factory address`) to the EVM.
@@ -77,6 +84,22 @@ pub struct OutboxDiscoveryCursor {
 }
 
 impl OutboxDiscoveryCursor {
+    /// Seed a cursor from previously persisted scan progress (see
+    /// [`FactoryScanCursorStore::load`](super::cursor::FactoryScanCursorStore::load)), so a restart
+    /// resumes `OutboxCreated` discovery instead of starting over from genesis.
+    ///
+    /// The seed is provisional, not validated here: `resolve_outbox_address`'s on-chain factory
+    /// read discards it via the ordinary `cursor.factory != factory` comparison below if the
+    /// persisted factory turns out to differ from what is currently registered (a rotation that
+    /// happened while the process was down) — the same path a mid-run rotation already takes.
+    pub(super) fn from_persisted(persisted: PersistedFactoryScan) -> Self {
+        Self {
+            from: persisted.scanned_to,
+            factory: Some(persisted.factory),
+            found: persisted.found,
+        }
+    }
+
     /// Block the scan has reached. The caller uses this to tell a resolve attempt that *failed after
     /// advancing* from one that made no headway at all, so a chunked scan spanning several attempts
     /// is not mistaken for a dead RPC.
@@ -100,11 +123,16 @@ impl OutboxDiscoveryCursor {
 /// Returns `Ok(None)` when no Outbox factory / Outbox is registered on-chain for this chain key —
 /// the caller treats that as "write-ability not available" and disables it for the run rather than
 /// failing. `Err` is reserved for genuine RPC/contract failures.
+///
+/// `factory_scan_store`, when `Some`, persists `cursor`'s progress after this call so a restart can
+/// resume via [`OutboxDiscoveryCursor::from_persisted`] instead of rescanning from genesis; `None`
+/// keeps discovery in-memory-only (used in tests and wherever persistence is not wired up).
 pub async fn resolve<P: Provider>(
     provider: &P,
     cfg: &Config,
     destination_chain_key: B256,
     cursor: &mut OutboxDiscoveryCursor,
+    factory_scan_store: Option<&FactoryScanCursorStore>,
 ) -> Result<Option<ResolvedOutbox>> {
     let chain_key = cfg.write_ability_chain_key;
 
@@ -117,6 +145,7 @@ pub async fn resolve<P: Provider>(
         destination_chain_key,
         cfg.block_confirmation_depth,
         cursor,
+        factory_scan_store,
     )
     .await?
     else {
@@ -151,6 +180,7 @@ async fn resolve_outbox_address<P: Provider>(
     _destination_chain_key: B256,
     confirmation_depth: u64,
     cursor: &mut OutboxDiscoveryCursor,
+    factory_scan_store: Option<&FactoryScanCursorStore>,
 ) -> Result<Option<(Address, Option<u64>)>> {
     // 1. Outbox factory for this chain, from the chain-info precompile.
     let factory = IChainInfo::new(CHAIN_INFO_PRECOMPILE, provider)
@@ -260,6 +290,20 @@ async fn resolve_outbox_address<P: Provider>(
     // `from` is `safe_tip + 1` when the loop ran, or unchanged (`cursor.from`) if
     // `safe_tip < cursor.from` (tip regressed / depth grew) — never regressing the cursor.
     cursor.from = cursor.from.max(from);
+
+    // Persist whatever progress this call made, win or not — best-effort: a write failure only
+    // costs a re-scan on the next restart, never correctness, so it must not fail resolution.
+    if let Some(store) = factory_scan_store {
+        let to_persist = PersistedFactoryScan {
+            factory,
+            scanned_to: cursor.from,
+            found: cursor.found,
+        };
+        if let Err(err) = store.save(&to_persist) {
+            tracing::warn!(chain_key, %err, "failed to persist factory-scan cursor");
+        }
+    }
+
     if let Some((outbox, created_at_block)) = cursor.found {
         tracing::info!(
             %factory, %outbox, chain_key, ?created_at_block,
@@ -309,5 +353,39 @@ mod tests {
         }
         assert_eq!(cursor.scanned_to(), 0);
         assert_eq!(cursor.found, None);
+    }
+
+    /// A cursor seeded from a persisted scan carries over its cursor position, factory and winner
+    /// verbatim — the whole point of persisting it is to skip re-scanning that range.
+    #[test]
+    fn from_persisted_seeds_cursor_verbatim() {
+        let outbox = address!("00000000000000000000000000000000000000aa");
+        let factory = address!("00000000000000000000000000000000000000ff");
+        let persisted = PersistedFactoryScan {
+            factory,
+            scanned_to: 12_345,
+            found: Some((outbox, Some(950))),
+        };
+        let cursor = OutboxDiscoveryCursor::from_persisted(persisted);
+        assert_eq!(cursor.scanned_to(), 12_345);
+        assert_eq!(cursor.factory(), Some(factory));
+        assert_eq!(cursor.found, Some((outbox, Some(950))));
+    }
+
+    /// A seed recorded against a factory other than the one currently registered on-chain must not
+    /// be reused verbatim — `resolve_outbox_address`'s ordinary `cursor.factory != factory`
+    /// comparison is what actually discards it, but this pins down that `from_persisted` itself
+    /// does no filtering, so that comparison is the only thing standing between a stale seed and a
+    /// wrongly-carried-over cursor.
+    #[test]
+    fn from_persisted_does_not_filter_by_factory_itself() {
+        let persisted = PersistedFactoryScan {
+            factory: address!("00000000000000000000000000000000000000ff"),
+            scanned_to: 12_345,
+            found: None,
+        };
+        let cursor = OutboxDiscoveryCursor::from_persisted(persisted);
+        let live_factory = address!("00000000000000000000000000000000000000ee");
+        assert_ne!(cursor.factory(), Some(live_factory));
     }
 }


### PR DESCRIPTION
## Summary

Handoff doc §9 item 1 ("Persist the Outbox-discovery cursor"): a factory change (or a plain restart) rescans `OutboxCreated` on the factory contract from genesis, in 2,000-block chunks capped at 30s each. Measured on the kc cluster: +463s on 17 Aug → +714s on 19 Aug (54% slower while the chain only grew 5.6%), putting Outbox rotation on a path to becoming impractical. This is the attestor side of that fix; the companion relayer-side PR is gluwa/usc-message-relayer#41.

- Adds `FactoryScanCursorStore` (`attestor/attestor/src/tasks/write_ability/cursor.rs`), persisting `OutboxDiscoveryCursor`'s scan position and current winner to a small atomic JSON file (same write scheme as the existing `MessagePublished` cursor store), keyed only by `chain_key`.
- `OutboxDiscoveryCursor::from_persisted` seeds a fresh cursor from disk at process start; `resolver::resolve_outbox_address` persists progress after every scan attempt (win or not) and threads the store through both call sites (`write_ability::run`'s activation loop and `run_outbox_monitor`'s periodic re-resolution).
- A checkpoint recorded against a factory other than the one currently registered on-chain (a rotation while the process was down) is discarded — not by the store, but by the existing `cursor.factory != factory` comparison against the freshly-read on-chain factory, the same path a mid-run rotation already takes.

## Test plan

- [x] `cargo test -p attestor --lib` — 123 passed, including 9 new tests on `FactoryScanCursorStore` and `OutboxDiscoveryCursor::from_persisted`
- [x] `cargo clippy -p attestor --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p attestor -- --check` — clean
- [x] `cargo check --workspace` — whole project builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)