### PR TITLE
fix(write-ability): recover a rotation that resumed past its Outbox; add factory_scan_genesis_block

### DIFF
--- a/attestor/attestor/src/main.rs
+++ b/attestor/attestor/src/main.rs
@@ -124,8 +124,8 @@ struct ConfigFileWriteAbility {
     /// de-registration, and the genesis fallback. Defaults to 0 (a true genesis scan). A floor
     /// only: it never rewinds a cursor that is already further along. Set it above a factory's
     /// `OutboxCreated` and that Outbox becomes undiscoverable (see
-    /// `write_ability::config::Config::writability_genesis_block`'s docs).
-    writability_genesis_block: Option<u64>,
+    /// `write_ability::config::Config::factory_scan_genesis_block`'s docs).
+    factory_scan_genesis_block: Option<u64>,
 }
 
 impl Config {
@@ -518,9 +518,9 @@ impl Config {
             resume_rotation_from_checkpoint: file
                 .resume_rotation_from_checkpoint
                 .unwrap_or(config::DEFAULT_RESUME_ROTATION_FROM_CHECKPOINT),
-            writability_genesis_block: file
-                .writability_genesis_block
-                .unwrap_or(config::DEFAULT_WRITABILITY_GENESIS_BLOCK),
+            factory_scan_genesis_block: file
+                .factory_scan_genesis_block
+                .unwrap_or(config::DEFAULT_FACTORY_SCAN_GENESIS_BLOCK),
         };
 
         // Fail the boot on a config that would silently weaken safety or prevent quorum, rather

--- a/attestor/attestor/src/main.rs
+++ b/attestor/attestor/src/main.rs
@@ -119,6 +119,13 @@ struct ConfigFileWriteAbility {
     /// `false` only if a deployment ever re-points a chain key at a pre-existing factory (see
     /// `write_ability::config::Config::resume_rotation_from_checkpoint`'s docs).
     resume_rotation_from_checkpoint: Option<bool>,
+    /// First Creditcoin L1 block any from-scratch `OutboxCreated` discovery scan starts at —
+    /// initial activation, a rotation with `resume_rotation_from_checkpoint: false`, a factory
+    /// de-registration, and the genesis fallback. Defaults to 0 (a true genesis scan). A floor
+    /// only: it never rewinds a cursor that is already further along. Set it above a factory's
+    /// `OutboxCreated` and that Outbox becomes undiscoverable (see
+    /// `write_ability::config::Config::writability_genesis_block`'s docs).
+    writability_genesis_block: Option<u64>,
 }
 
 impl Config {
@@ -511,6 +518,9 @@ impl Config {
             resume_rotation_from_checkpoint: file
                 .resume_rotation_from_checkpoint
                 .unwrap_or(config::DEFAULT_RESUME_ROTATION_FROM_CHECKPOINT),
+            writability_genesis_block: file
+                .writability_genesis_block
+                .unwrap_or(config::DEFAULT_WRITABILITY_GENESIS_BLOCK),
         };
 
         // Fail the boot on a config that would silently weaken safety or prevent quorum, rather

--- a/attestor/attestor/src/tasks/write_ability/config.rs
+++ b/attestor/attestor/src/tasks/write_ability/config.rs
@@ -91,7 +91,7 @@ pub struct Config {
     /// restores the old unconditional genesis rescan, which has no such assumption.
     ///
     /// That skip is no longer terminal: a resumed scan that reaches the confirmed tip having found
-    /// nothing retries once from [`writability_genesis_block`](Self::writability_genesis_block)
+    /// nothing retries once from [`factory_scan_genesis_block`](Self::factory_scan_genesis_block)
     /// before reporting "no Outbox" (see [`super::resolver`]). Leaving this on therefore costs one
     /// extra full scan in the pre-existing-factory case rather than stranding the chain key.
     pub resume_rotation_from_checkpoint: bool,
@@ -101,7 +101,7 @@ pub struct Config {
     /// rotation with [`resume_rotation_from_checkpoint`](Self::resume_rotation_from_checkpoint)
     /// off, a factory de-registration, and the genesis fallback above.
     ///
-    /// Defaults to [`DEFAULT_WRITABILITY_GENESIS_BLOCK`] (0), i.e. a true genesis scan. Raising it
+    /// Defaults to [`DEFAULT_FACTORY_SCAN_GENESIS_BLOCK`] (0), i.e. a true genesis scan. Raising it
     /// to a height known to precede this chain key's Outbox factory deployment cuts every one of
     /// those scans down to the blocks that could actually contain the event — on a long-lived chain
     /// that is the difference between a multi-minute fleet-wide quorum outage and a brief one.
@@ -116,7 +116,7 @@ pub struct Config {
     /// becomes undiscoverable — including via the genesis fallback, which floors here too. The safe
     /// value is a height known to precede every factory this chain key will ever be pointed at,
     /// e.g. the block the chain's first Outbox factory was deployed in, minus a margin.
-    pub writability_genesis_block: u64,
+    pub factory_scan_genesis_block: u64,
 }
 
 impl Config {
@@ -136,7 +136,7 @@ impl Config {
             vote_ttl: DEFAULT_VOTE_TTL,
             attestor_set: AttestorSet::default(),
             resume_rotation_from_checkpoint: DEFAULT_RESUME_ROTATION_FROM_CHECKPOINT,
-            writability_genesis_block: DEFAULT_WRITABILITY_GENESIS_BLOCK,
+            factory_scan_genesis_block: DEFAULT_FACTORY_SCAN_GENESIS_BLOCK,
         }
     }
 }
@@ -266,11 +266,11 @@ pub const DEFAULT_VOTE_TTL: Duration = Duration::from_secs(3600);
 /// §10.9). Set to `false` if a deployment ever re-points a chain key at a pre-existing factory.
 pub const DEFAULT_RESUME_ROTATION_FROM_CHECKPOINT: bool = true;
 
-/// Default for [`Config::writability_genesis_block`]: block 0, i.e. a discovery scan that starts
+/// Default for [`Config::factory_scan_genesis_block`]: block 0, i.e. a discovery scan that starts
 /// from scratch really does start at genesis. Preserves the historical behaviour for every
 /// deployment that does not set it, so raising it is always an explicit decision about a specific
 /// chain whose factory deployment height the operator knows.
-pub const DEFAULT_WRITABILITY_GENESIS_BLOCK: u64 = 0;
+pub const DEFAULT_FACTORY_SCAN_GENESIS_BLOCK: u64 = 0;
 
 #[cfg(test)]
 mod tests {
@@ -292,7 +292,7 @@ mod tests {
                 "000000000000000000000000000000000000000a"
             )]),
             resume_rotation_from_checkpoint: DEFAULT_RESUME_ROTATION_FROM_CHECKPOINT,
-            writability_genesis_block: DEFAULT_WRITABILITY_GENESIS_BLOCK,
+            factory_scan_genesis_block: DEFAULT_FACTORY_SCAN_GENESIS_BLOCK,
         }
     }
 

--- a/attestor/attestor/src/tasks/write_ability/config.rs
+++ b/attestor/attestor/src/tasks/write_ability/config.rs
@@ -89,7 +89,34 @@ pub struct Config {
     /// deployment). Re-pointing to a *pre-existing* factory whose `OutboxCreated` predates the
     /// checkpoint would make discovery skip it and never find that chain key's Outbox — `false`
     /// restores the old unconditional genesis rescan, which has no such assumption.
+    ///
+    /// That skip is no longer terminal: a resumed scan that reaches the confirmed tip having found
+    /// nothing retries once from [`writability_genesis_block`](Self::writability_genesis_block)
+    /// before reporting "no Outbox" (see [`super::resolver`]). Leaving this on therefore costs one
+    /// extra full scan in the pre-existing-factory case rather than stranding the chain key.
     pub resume_rotation_from_checkpoint: bool,
+
+    /// First Creditcoin L1 block any *from-scratch* `OutboxCreated` discovery scan starts at — the
+    /// floor that replaces a literal block 0 everywhere discovery restarts: initial activation, a
+    /// rotation with [`resume_rotation_from_checkpoint`](Self::resume_rotation_from_checkpoint)
+    /// off, a factory de-registration, and the genesis fallback above.
+    ///
+    /// Defaults to [`DEFAULT_WRITABILITY_GENESIS_BLOCK`] (0), i.e. a true genesis scan. Raising it
+    /// to a height known to precede this chain key's Outbox factory deployment cuts every one of
+    /// those scans down to the blocks that could actually contain the event — on a long-lived chain
+    /// that is the difference between a multi-minute fleet-wide quorum outage and a brief one.
+    ///
+    /// **It answers one question: where does a scan with no usable position start?** It never
+    /// moves a cursor that has one — a persisted scan resumes from where it left off, and a
+    /// rotation that resumes from a checkpoint keeps that checkpoint, in both cases even when the
+    /// position sits *below* this value. The single deliberate exception is the genesis fallback,
+    /// whose whole job is to rewind to this floor once a resumed scan has proven inconclusive.
+    ///
+    /// ⚠️ Set it **above** the block a factory emitted its `OutboxCreated` in and that Outbox
+    /// becomes undiscoverable — including via the genesis fallback, which floors here too. The safe
+    /// value is a height known to precede every factory this chain key will ever be pointed at,
+    /// e.g. the block the chain's first Outbox factory was deployed in, minus a margin.
+    pub writability_genesis_block: u64,
 }
 
 impl Config {
@@ -109,6 +136,7 @@ impl Config {
             vote_ttl: DEFAULT_VOTE_TTL,
             attestor_set: AttestorSet::default(),
             resume_rotation_from_checkpoint: DEFAULT_RESUME_ROTATION_FROM_CHECKPOINT,
+            writability_genesis_block: DEFAULT_WRITABILITY_GENESIS_BLOCK,
         }
     }
 }
@@ -238,6 +266,12 @@ pub const DEFAULT_VOTE_TTL: Duration = Duration::from_secs(3600);
 /// §10.9). Set to `false` if a deployment ever re-points a chain key at a pre-existing factory.
 pub const DEFAULT_RESUME_ROTATION_FROM_CHECKPOINT: bool = true;
 
+/// Default for [`Config::writability_genesis_block`]: block 0, i.e. a discovery scan that starts
+/// from scratch really does start at genesis. Preserves the historical behaviour for every
+/// deployment that does not set it, so raising it is always an explicit decision about a specific
+/// chain whose factory deployment height the operator knows.
+pub const DEFAULT_WRITABILITY_GENESIS_BLOCK: u64 = 0;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -258,6 +292,7 @@ mod tests {
                 "000000000000000000000000000000000000000a"
             )]),
             resume_rotation_from_checkpoint: DEFAULT_RESUME_ROTATION_FROM_CHECKPOINT,
+            writability_genesis_block: DEFAULT_WRITABILITY_GENESIS_BLOCK,
         }
     }
 

--- a/attestor/attestor/src/tasks/write_ability/cursor.rs
+++ b/attestor/attestor/src/tasks/write_ability/cursor.rs
@@ -22,7 +22,9 @@
 //! at all; a factory change (governance rotation) instead resumes from the checkpoint already on
 //! disk unless `Config::resume_rotation_from_checkpoint` is turned off — the same at-least-once
 //! safety applies either way, since re-scanning already-covered blocks only wastes time, never
-//! correctness.
+//! correctness. The record also carries the *floor* each scan began at, which is what lets the
+//! resolver's genesis fallback recover a scan that resumed above the event it was looking for
+//! (see [`super::resolver`]) even across a restart.
 
 use std::path::{Path, PathBuf};
 
@@ -205,6 +207,17 @@ struct FactoryScanRecord {
     found_outbox: Option<Address>,
     #[serde(skip_serializing_if = "Option::is_none")]
     found_created_at_block: Option<u64>,
+    /// Block this factory's scan *started* from — the floor below which it has never looked. Read
+    /// back by the resolver's genesis fallback to tell "scanned everything and this factory has no
+    /// Outbox" from "resumed above the event and would never have seen it".
+    ///
+    /// `Option` purely for backward compatibility with records written before this field existed:
+    /// [`FactoryScanCursorStore::load`] maps `None` to `scanned_to`, the conservative reading
+    /// ("assume the scan began where it currently sits"), which grants such a record exactly one
+    /// genesis fallback. Reading it as 0 instead would silently deny the fallback to precisely the
+    /// cursors most likely to need it — one written by a rotation on an older build.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    scan_floor: Option<u64>,
 }
 
 /// In-memory shape of a [`FactoryScanCursorStore`] record.
@@ -213,6 +226,8 @@ pub struct PersistedFactoryScan {
     pub factory: Address,
     pub scanned_to: u64,
     pub found: Option<(Address, Option<u64>)>,
+    /// Block this factory's scan started from; see [`FactoryScanRecord::scan_floor`].
+    pub scan_floor: u64,
 }
 
 /// Persists an [`super::resolver::OutboxDiscoveryCursor`]'s `OutboxCreated` discovery progress to a
@@ -277,6 +292,9 @@ impl FactoryScanCursorStore {
             found: record
                 .found_outbox
                 .map(|outbox| (outbox, record.found_created_at_block)),
+            // Pre-`scan_floor` record: assume the scan began where it now sits, so the resolver
+            // grants it one genesis fallback rather than trusting a floor it never recorded.
+            scan_floor: record.scan_floor.unwrap_or(record.scanned_to),
         })
     }
 
@@ -295,6 +313,7 @@ impl FactoryScanCursorStore {
             chain_key: self.chain_key,
             found_outbox,
             found_created_at_block,
+            scan_floor: Some(scan.scan_floor),
         };
         let json = serde_json::to_vec_pretty(&record).context("serialize factory-scan cursor")?;
 
@@ -433,6 +452,7 @@ mod tests {
             factory: factory(),
             scanned_to: 12_345,
             found: Some((outbox(), Some(100))),
+            scan_floor: 0,
         };
         store.save(&scan).unwrap();
         assert_eq!(store.load(), Some(scan));
@@ -442,6 +462,7 @@ mod tests {
             factory: factory(),
             scanned_to: 20_000,
             found: Some((outbox(), Some(100))),
+            scan_floor: 0,
         };
         store.save(&advanced).unwrap();
         assert_eq!(store.load(), Some(advanced));
@@ -457,9 +478,46 @@ mod tests {
             factory: factory(),
             scanned_to: 2_000,
             found: None,
+            scan_floor: 0,
         };
         store.save(&scan).unwrap();
         assert_eq!(store.load(), Some(scan));
+    }
+
+    /// `scan_floor` round-trips, so the resolver can tell "scanned everything below" from
+    /// "resumed above the event" across a restart — the distinction its genesis fallback turns on.
+    #[test]
+    fn factory_scan_round_trips_the_scan_floor() {
+        let dir = TmpDir::new("factory-floor");
+        let store = FactoryScanCursorStore::new(dir.path(), 2);
+        let scan = PersistedFactoryScan {
+            factory: factory(),
+            scanned_to: 705_600,
+            found: None,
+            scan_floor: 705_530,
+        };
+        store.save(&scan).unwrap();
+        assert_eq!(store.load(), Some(scan));
+    }
+
+    /// A record written before `scan_floor` existed loads with the floor set to `scanned_to`, not
+    /// to 0. That is the conservative reading — "assume the scan began where it now sits" — and it
+    /// grants such a record exactly one genesis fallback. Defaulting to 0 would instead claim the
+    /// range below was already covered, denying the recovery to precisely the cursors most likely
+    /// to need it: one written by a rotation on a build that predates this field.
+    #[test]
+    fn factory_scan_record_without_a_floor_defaults_to_its_position() {
+        let dir = TmpDir::new("factory-legacy");
+        let store = FactoryScanCursorStore::new(dir.path(), 2);
+        let legacy = format!(
+            r#"{{"scanned_to":705600,"factory":"{}","chain_key":2}}"#,
+            factory()
+        );
+        std::fs::write(store.path(), legacy).unwrap();
+        let loaded = store.load().expect("legacy record must still load");
+        assert_eq!(loaded.scanned_to, 705_600);
+        assert_eq!(loaded.scan_floor, 705_600);
+        assert_eq!(loaded.found, None);
     }
 
     #[test]
@@ -482,6 +540,7 @@ mod tests {
             factory: old_factory,
             scanned_to: 500,
             found: None,
+            scan_floor: 0,
         };
         store.save(&scan).unwrap();
         assert_eq!(store.load(), Some(scan));
@@ -496,6 +555,7 @@ mod tests {
             factory: factory(),
             scanned_to: 42,
             found: None,
+            scan_floor: 0,
         };
         store.save(&scan).unwrap();
         assert_eq!(store.load(), Some(scan));

--- a/attestor/attestor/src/tasks/write_ability/cursor.rs
+++ b/attestor/attestor/src/tasks/write_ability/cursor.rs
@@ -271,7 +271,7 @@ impl FactoryScanCursorStore {
             Err(e) => {
                 tracing::warn!(
                     path = %self.path.display(), %e,
-                    "could not read factory-scan cursor file; starting OutboxCreated discovery from genesis"
+                    "could not read factory-scan cursor file; starting OutboxCreated discovery from the configured factory-scan genesis block"
                 );
                 return None;
             }

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -471,10 +471,10 @@ pub async fn run(
             );
             resolver::OutboxDiscoveryCursor::from_persisted(persisted)
         }
-        // Nothing persisted: start at the configured write-ability genesis block rather than block
+        // Nothing persisted: start at the configured factory-scan genesis block rather than block
         // 0, so a chain whose factory was deployed far above genesis does not scan the dead range
-        // below it on every fresh volume (`Config::writability_genesis_block`).
-        None => resolver::OutboxDiscoveryCursor::starting_at(cfg.writability_genesis_block),
+        // below it on every fresh volume (`Config::factory_scan_genesis_block`).
+        None => resolver::OutboxDiscoveryCursor::starting_at(cfg.factory_scan_genesis_block),
     };
     let resolved = loop {
         // Progress-aware failure budget, mirroring the listener's `next_failure_count`. Outbox
@@ -673,7 +673,7 @@ pub async fn run(
     // One live resolved-Outbox view feeds both the supervision loop below and the reobservation
     // worker. The monitor inherits the discovery cursor from initial activation, so it scans only
     // new finalized factory events — and resumes from the last factory-scan checkpoint (or, with
-    // `resume_rotation_from_checkpoint` off, restarts from `writability_genesis_block`) when
+    // `resume_rotation_from_checkpoint` off, restarts from `factory_scan_genesis_block`) when
     // governance re-points the chain key at a different factory. A resumed scan that turns out to
     // have started above the new factory's own `OutboxCreated` rewinds to that floor once on its
     // own (`resolver::genesis_fallback_target`), so a rotation onto a pre-existing factory

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -465,12 +465,16 @@ pub async fn run(
                 path = %factory_scan_store.path().display(),
                 factory = %persisted.factory,
                 scanned_to = persisted.scanned_to,
+                scan_floor = persisted.scan_floor,
                 found = ?persisted.found,
                 "🗂️ resuming OutboxCreated discovery from persisted factory-scan cursor"
             );
             resolver::OutboxDiscoveryCursor::from_persisted(persisted)
         }
-        None => resolver::OutboxDiscoveryCursor::default(),
+        // Nothing persisted: start at the configured write-ability genesis block rather than block
+        // 0, so a chain whose factory was deployed far above genesis does not scan the dead range
+        // below it on every fresh volume (`Config::writability_genesis_block`).
+        None => resolver::OutboxDiscoveryCursor::starting_at(cfg.writability_genesis_block),
     };
     let resolved = loop {
         // Progress-aware failure budget, mirroring the listener's `next_failure_count`. Outbox
@@ -669,8 +673,11 @@ pub async fn run(
     // One live resolved-Outbox view feeds both the supervision loop below and the reobservation
     // worker. The monitor inherits the discovery cursor from initial activation, so it scans only
     // new finalized factory events — and resumes from the last factory-scan checkpoint (or, with
-    // `resume_rotation_from_checkpoint` off, restarts from genesis) when governance re-points the
-    // chain key at a different factory.
+    // `resume_rotation_from_checkpoint` off, restarts from `writability_genesis_block`) when
+    // governance re-points the chain key at a different factory. A resumed scan that turns out to
+    // have started above the new factory's own `OutboxCreated` rewinds to that floor once on its
+    // own (`resolver::genesis_fallback_target`), so a rotation onto a pre-existing factory
+    // recovers here instead of leaving the chain key paused indefinitely.
     let (resolved_tx, mut resolved_rx) = watch::channel(Some(resolved));
     let mut outbox_monitor = {
         let provider = provider.clone();

--- a/attestor/attestor/src/tasks/write_ability/resolver.rs
+++ b/attestor/attestor/src/tasks/write_ability/resolver.rs
@@ -32,6 +32,13 @@
 //! factory and reads back as valid on the next boot. [`genesis_fallback_target`] closes that: a
 //! scan that completes with no match, having started above [`Config::factory_scan_genesis_block`],
 //! rewinds to that floor and tries once more before the chain key is declared Outbox-less.
+//!
+//! That fallback would otherwise fire on the *common*, healthy rotation too: a factory that was
+//! itself just deployed looks identical, for one tick, to a pre-existing one — both complete a
+//! scan above the floor and find nothing, because the fresh factory's own event has not finalized
+//! yet. [`OutboxDiscoveryCursor::grace_until_tip`] holds the fallback off until the finalized head
+//! has caught up to the tip observed when the floor was (re)armed, so a same-tick emission gets a
+//! chance to finalize before its absence is trusted as evidence.
 
 use alloy::primitives::{Address, B256};
 use alloy::providers::Provider;
@@ -84,21 +91,32 @@ pub struct ResolvedOutbox {
 /// cursor file on every pod by hand, and the recovery costs one extra scan of a range that was
 /// going to be scanned anyway had the checkpoint not been trusted.
 ///
-/// Three conditions, all necessary:
+/// Two conditions, both necessary:
 /// - `found_something` is false — a match makes the scan conclusive whatever floor it began at;
 /// - `scan_floor > genesis_block` — the scan started above the floor, so there is unlooked-at range
 ///   below it. A scan that already began at the floor has covered everything and its "no Outbox"
-///   verdict is the truth;
-/// - `already_used` is false — one rewind per factory per process, so a factory that genuinely has
-///   no `OutboxCreated` settles into the cheap tip-following steady state instead of rescanning the
-///   whole chain on every retry.
+///   verdict is the truth.
+///
+/// `grace_satisfied` guards against a race, not against re-firing: a rotation onto a factory that
+/// was itself *just* deployed looks identical, for one tick, to a rotation onto a pre-existing one
+/// whose event will never be found above the checkpoint — both complete a scan above the floor and
+/// find nothing, because the fresh factory's own event has not finalized yet. Trusting that first
+/// empty result would burn the one-shot recovery on the common, healthy rotation path this fallback
+/// is not meant to touch. The caller only passes `true` once the finalized tip has caught up to the
+/// height observed when the current floor was set, so a same-tick emission has had a chance to
+/// finalize — see [`OutboxDiscoveryCursor::grace_until_tip`].
+///
+/// Nothing here bounds this to *one* rewind per factory: once it fires, the caller lowers
+/// `scan_floor` to `genesis_block`, and every later call with the same (constant, per-process)
+/// `genesis_block` finds `scan_floor > genesis_block` already false — the floor itself carries the
+/// termination invariant.
 fn genesis_fallback_target(
     found_something: bool,
     scan_floor: u64,
     genesis_block: u64,
-    already_used: bool,
+    grace_satisfied: bool,
 ) -> Option<u64> {
-    (!found_something && !already_used && scan_floor > genesis_block).then_some(genesis_block)
+    (!found_something && scan_floor > genesis_block && grace_satisfied).then_some(genesis_block)
 }
 
 /// The scan-shaping knobs [`resolve_outbox_address`] reads out of [`Config`], grouped so the
@@ -119,7 +137,6 @@ struct DiscoveryPolicy {
 /// how far we have scanned and against which factory, so each retry only scans new *confirmed*
 /// blocks (no full-history log storm) while staying reorg-safe, and a factory re-registration
 /// restarts the scan from the configured floor.
-#[derive(Default)]
 pub struct OutboxDiscoveryCursor {
     /// Next block to scan from.
     from: u64,
@@ -146,10 +163,25 @@ pub struct OutboxDiscoveryCursor {
     /// Moves with `from` whenever a scan (re)starts — initial seed, rotation, de-registration,
     /// fallback — and is persisted so the distinction survives a restart.
     scan_floor: u64,
-    /// Whether the genesis fallback has already been spent on the current factory. Reset alongside
-    /// `from`/`found` on every factory change, so each factory gets exactly one — bounding the
-    /// recovery to a single extra full scan instead of one per retry.
-    genesis_fallback_done: bool,
+    /// Finalized tip that must be reached before a completed empty scan above `scan_floor` is
+    /// trusted enough to trigger the genesis fallback, or `None` when no such wait is pending.
+    ///
+    /// Set to the *unfinalized* tip observed at the moment a rotation (re)armed the floor: any
+    /// transaction at or before that height — including the new factory's own `OutboxCreated`, had
+    /// it been emitted around rotation time — is already included in it, so once the finalized head
+    /// reaches this value the absence of a match is evidence, not a race against finality. Without
+    /// this, a rotation onto a factory that was itself *just* deployed looks identical, for one
+    /// tick, to a rotation onto a pre-existing one whose event will never be found above the
+    /// checkpoint — both complete a scan and find nothing, and only one of them should burn the
+    /// one-shot recovery.
+    grace_until_tip: Option<u64>,
+    /// Set by [`Self::from_persisted`]: a reloaded cursor's floor may be a rotation that happened
+    /// moments before the restart, but no tip is available yet to arm `grace_until_tip` against
+    /// (that needs a live read). The next call converts this into `grace_until_tip` using the tip
+    /// it reads, instead of trusting the reload's first scan immediately — the same race
+    /// `grace_until_tip` guards against, just deferred one call because construction has no
+    /// provider to ask.
+    arm_grace_on_next_call: bool,
 }
 
 impl OutboxDiscoveryCursor {
@@ -168,14 +200,16 @@ impl OutboxDiscoveryCursor {
             found: persisted.found,
             advanced_last_call: false,
             scan_floor: persisted.scan_floor,
-            genesis_fallback_done: false,
+            grace_until_tip: None,
+            // A restart cannot rule out that the persisted floor is a rotation from moments before
+            // the process went down — arm the same grace the live rotation path would have, once a
+            // tip is available to arm it against.
+            arm_grace_on_next_call: true,
         }
     }
 
     /// A fresh cursor for a chain key with nothing persisted, starting at `genesis_block` (see
-    /// [`Config::factory_scan_genesis_block`]). Prefer this over `default()` anywhere a real
-    /// configuration is in hand — `default()` starts at block 0 regardless, which is only correct
-    /// when the floor is 0.
+    /// [`Config::factory_scan_genesis_block`]).
     pub(super) fn starting_at(genesis_block: u64) -> Self {
         Self {
             from: genesis_block,
@@ -183,8 +217,27 @@ impl OutboxDiscoveryCursor {
             found: None,
             advanced_last_call: false,
             scan_floor: genesis_block,
-            genesis_fallback_done: false,
+            grace_until_tip: None,
+            arm_grace_on_next_call: false,
         }
+    }
+
+    /// Reset the cursor for a factory rotation: `resume_from` is the new scan position (the old
+    /// checkpoint when [`Config::resume_rotation_from_checkpoint`] is on, else the configured
+    /// floor — see the call site), and `tip` is the *unfinalized* tip read in the same call, which
+    /// arms [`Self::grace_until_tip`] against the exact race documented there.
+    ///
+    /// The one place this matters and testing can't otherwise reach: `resolve_outbox_address` needs
+    /// a live `Provider`, so this method is what lets a unit test drive the real rotation reset
+    /// instead of hand-copying its field assignments — the drift that copy is prone to is exactly
+    /// what let this line go untested before (see the tests below).
+    pub(super) fn rotate_to(&mut self, factory: Address, resume_from: u64, tip: u64) {
+        self.factory = Some(factory);
+        self.from = resume_from;
+        self.scan_floor = resume_from;
+        self.found = None;
+        self.grace_until_tip = Some(tip);
+        self.arm_grace_on_next_call = false;
     }
 
     /// Block the scan has reached.
@@ -296,7 +349,8 @@ async fn resolve_outbox_address<P: Provider>(
         cursor.from = policy.genesis_block;
         cursor.scan_floor = policy.genesis_block;
         cursor.found = None;
-        cursor.genesis_fallback_done = false;
+        cursor.grace_until_tip = None;
+        cursor.arm_grace_on_next_call = false;
         tracing::warn!(
             chain_key,
             "no Outbox factory registered on-chain for chain_key"
@@ -304,6 +358,39 @@ async fn resolve_outbox_address<P: Provider>(
         return Ok(None);
     }
     let factory = factory.factoryAddr;
+
+    // Read the tip early, before the rotation check below: a rotation needs the *unfinalized* tip
+    // observed at the moment it is detected to arm `OutboxDiscoveryCursor::grace_until_tip` against
+    // (see its docs) — reading it after would race the very thing it is meant to bound against.
+    //
+    // Bound the scan (and thus the cursor) at the FINALIZED head, mirroring the listener's
+    // `FinalityPolicy::Finalized`: Creditcoin L1 has deterministic GRANDPA finality, so a
+    // finalized block cannot reorg. Only fall back to `tip - confirmation_depth` when the
+    // `finalized` tag is unavailable (node up but tag unsupported/errored), matching the
+    // listener's depth fallback. The cursor advances permanently, so resolving OutboxCreated
+    // from a still-reorgable block would let a reorg re-mine it below the cursor and hide the
+    // Outbox for the whole process lifetime — the listener signs only up to the finalized head,
+    // so discovery must not run ahead of it.
+    let tip = provider
+        .get_block_number()
+        .await
+        .context("read EVM tip for Outbox discovery scan")?;
+    let safe_tip = match provider
+        .get_block_by_number(BlockNumberOrTag::Finalized, BlockTransactionsKind::Hashes)
+        .await
+    {
+        Ok(Some(block)) => block.header.number,
+        // `finalized` tag unsupported/errored → depth fallback (same as the listener). The tip
+        // read above already covers a dead RPC, so a finalized-read failure is not fatal here.
+        Ok(None) | Err(_) => tip.saturating_sub(policy.confirmation_depth),
+    };
+
+    // A cursor reloaded from disk cannot rule out that its floor is a rotation from moments before
+    // the restart — arm the grace window it would have gotten live, now that a tip is in hand.
+    if cursor.arm_grace_on_next_call {
+        cursor.grace_until_tip = Some(tip);
+        cursor.arm_grace_on_next_call = false;
+    }
 
     // If the resolved factory changed (governance re-registered a different one for this chain key),
     // the cursor reflects the *old* factory's scanned history and could skip the new factory's
@@ -324,8 +411,8 @@ async fn resolve_outbox_address<P: Provider>(
         };
         if previous_factory.is_some() {
             // Not fired on the very first resolve (no `previous_factory` yet) — that is initial
-            // discovery, not a rotation, and `resume_from` is 0 either way since a fresh cursor
-            // never scanned anything.
+            // discovery, not a rotation, and `resume_from` equals the configured genesis block
+            // either way, since a fresh cursor starts there and has never scanned anything below it.
             tracing::info!(
                 chain_key,
                 %factory,
@@ -336,12 +423,9 @@ async fn resolve_outbox_address<P: Provider>(
                 "🔁 Outbox factory rotated; restarting OutboxCreated discovery"
             );
         }
-        cursor.factory = Some(factory);
-        cursor.from = resume_from;
-        cursor.scan_floor = resume_from;
-        cursor.found = None;
-        // A fresh factory earns a fresh fallback: this is the transition that can overshoot.
-        cursor.genesis_fallback_done = false;
+        // A fresh factory earns a fresh fallback (armed with this call's tip — see
+        // `OutboxDiscoveryCursor::grace_until_tip`): this is the transition that can overshoot.
+        cursor.rotate_to(factory, resume_from, tip);
     }
 
     // 2. Discover the factory's Outbox for this chain key. The synced CREATE2 factory has no
@@ -354,31 +438,29 @@ async fn resolve_outbox_address<P: Provider>(
     //    `cursor.from` rather than genesis: the factory emits OutboxCreated exactly once, so once a
     //    retry has scanned the confirmed range and found nothing, the next retry only needs the new
     //    blocks — otherwise every 12s retry re-issues a full-history log storm across all attestors.
-    //
-    //    Bound the scan (and thus the cursor) at the FINALIZED head, mirroring the listener's
-    //    `FinalityPolicy::Finalized`: Creditcoin L1 has deterministic GRANDPA finality, so a
-    //    finalized block cannot reorg. Only fall back to `tip - confirmation_depth` when the
-    //    `finalized` tag is unavailable (node up but tag unsupported/errored), matching the
-    //    listener's depth fallback. The cursor advances permanently, so resolving OutboxCreated
-    //    from a still-reorgable block would let a reorg re-mine it below the cursor and hide the
-    //    Outbox for the whole process lifetime — the listener signs only up to the finalized head,
-    //    so discovery must not run ahead of it.
-    let tip = provider
-        .get_block_number()
-        .await
-        .context("read EVM tip for Outbox discovery scan")?;
-    let safe_tip = match provider
-        .get_block_by_number(BlockNumberOrTag::Finalized, BlockTransactionsKind::Hashes)
-        .await
-    {
-        Ok(Some(block)) => block.header.number,
-        // `finalized` tag unsupported/errored → depth fallback (same as the listener). The tip
-        // read above already covers a dead RPC, so a finalized-read failure is not fatal here.
-        Ok(None) | Err(_) => tip.saturating_sub(policy.confirmation_depth),
-    };
     let sig = IOutboxFactory::OutboxCreated::SIGNATURE_HASH;
     let topic_chain_key = alloy::primitives::U256::from(chain_key);
     let mut from = cursor.from;
+    // Persists whatever progress `cursor` currently reflects — called both per-chunk below and
+    // after the loop (and any fallback rewind). A scan spanning many chunks in one call (the
+    // initial backlog, or a genesis-fallback rescan) would otherwise checkpoint only at the very
+    // end: a process restart partway through discards every chunk scanned since the last full-loop
+    // completion, even though `cursor.from` itself advanced past them in memory. Best-effort — a
+    // write failure only costs a re-scan on the next restart, never correctness, so it must not
+    // fail resolution.
+    let persist_progress = |c: &OutboxDiscoveryCursor| {
+        if let Some(store) = factory_scan_store {
+            let to_persist = PersistedFactoryScan {
+                factory,
+                scanned_to: c.from,
+                found: c.found,
+                scan_floor: c.scan_floor,
+            };
+            if let Err(err) = store.save(&to_persist) {
+                tracing::warn!(chain_key, %err, "failed to persist factory-scan cursor");
+            }
+        }
+    };
     // Bind the *latest* OutboxCreated for this chain_key, not the first. The factory is
     // permissionless, so it can emit more than one OutboxCreated for a chain_key (a redeploy, or a
     // different `msg.sender`'s CREATE2 salt); returning the oldest could bind a superseded or
@@ -419,6 +501,7 @@ async fn resolve_outbox_address<P: Provider>(
         // below resumes from here and re-reads nothing already covered.
         cursor.from = from;
         cursor.advanced_last_call = true;
+        persist_progress(cursor);
         if from <= safe_tip {
             // More chunks remain after this one — a multi-chunk backlog (post-rotation or initial
             // activation), the same condition the relayer's own "N of M blocks" line fires under.
@@ -441,12 +524,19 @@ async fn resolve_outbox_address<P: Provider>(
     // RPC_ATTEMPT_TIMEOUT is aborted mid-`await`, and a failing chunk returns via `?`. So a `found`
     // of `None` at this point is a *complete* scan of [`scan_floor`, `safe_tip`] that matched
     // nothing — which is only the same thing as "this factory has no Outbox" when the scan began at
-    // the configured floor. Otherwise rewind once and let the next retry cover the rest.
+    // the configured floor *and* the finalized tip has caught up to the height observed when that
+    // floor was set (see `OutboxDiscoveryCursor::grace_until_tip`). Otherwise rewind once (or wait
+    // for the grace to clear) and let the next retry cover the rest.
+    let grace_satisfied = cursor.grace_until_tip.is_none_or(|until| safe_tip >= until);
+    // Captured before a rewind (below) can overwrite it — the diagnostic check further down needs
+    // to know what floor *this* call's scan actually ran from, not what the cursor's floor becomes
+    // once a rewind reassigns it for the *next* call's scan.
+    let scanned_from_this_call = cursor.scan_floor;
     if let Some(rewind_to) = genesis_fallback_target(
         cursor.found.is_some(),
         cursor.scan_floor,
         policy.genesis_block,
-        cursor.genesis_fallback_done,
+        grace_satisfied,
     ) {
         tracing::warn!(
             chain_key,
@@ -458,28 +548,18 @@ async fn resolve_outbox_address<P: Provider>(
              may predate it (a rotation onto a pre-existing factory). Rescanning once from \
              the configured factory-scan genesis block before reporting no Outbox"
         );
-        cursor.genesis_fallback_done = true;
         cursor.from = rewind_to;
         cursor.scan_floor = rewind_to;
     }
 
-    // Persist whatever progress this call made, win or not — best-effort: a write failure only
-    // costs a re-scan on the next restart, never correctness, so it must not fail resolution.
+    // Persist whatever progress this call made, win or not (redundant with the per-chunk
+    // checkpoints above whenever the loop ran, but this is also the only persist for a call that
+    // found the range already scanned and skipped the loop entirely).
     //
     // Deliberately *after* the rewind above, so a fallback that has been decided is durable: a
     // restart mid-recovery resumes the rescan instead of reloading the very cursor that stranded
     // this chain key in the first place.
-    if let Some(store) = factory_scan_store {
-        let to_persist = PersistedFactoryScan {
-            factory,
-            scanned_to: cursor.from,
-            found: cursor.found,
-            scan_floor: cursor.scan_floor,
-        };
-        if let Err(err) = store.save(&to_persist) {
-            tracing::warn!(chain_key, %err, "failed to persist factory-scan cursor");
-        }
-    }
+    persist_progress(cursor);
 
     if let Some((outbox, created_at_block)) = cursor.found {
         tracing::info!(
@@ -488,13 +568,31 @@ async fn resolve_outbox_address<P: Provider>(
         );
         return Ok(Some((outbox, created_at_block)));
     }
-    tracing::warn!(
-        %factory,
-        chain_key,
-        scanned_from = cursor.scan_floor,
-        scanned_to = cursor.from,
-        "factory has emitted no OutboxCreated for chain_key yet"
-    );
+    if policy.genesis_block > 0 && scanned_from_this_call <= policy.genesis_block {
+        // This call's own scan already started at the configured floor (so no rewind fired, or
+        // could have — see `scanned_from_this_call`) and still found nothing. That is the one
+        // observable moment a `factory_scan_genesis_block` set above this factory's real
+        // `OutboxCreated` height would produce exactly this symptom, indistinguishable otherwise
+        // from "not created yet".
+        tracing::warn!(
+            %factory,
+            chain_key,
+            scanned_from = scanned_from_this_call,
+            scanned_to = cursor.from,
+            factory_scan_genesis_block = policy.genesis_block,
+            "factory has emitted no OutboxCreated for chain_key yet, and the scan has already \
+             covered everything down to factory_scan_genesis_block — if this persists, check \
+             whether that floor is set above this factory's real OutboxCreated height"
+        );
+    } else {
+        tracing::warn!(
+            %factory,
+            chain_key,
+            scanned_from = cursor.scan_floor,
+            scanned_to = cursor.from,
+            "factory has emitted no OutboxCreated for chain_key yet"
+        );
+    }
     Ok(None)
 }
 
@@ -522,7 +620,8 @@ mod tests {
             found: Some((outbox, Some(950))),
             advanced_last_call: false,
             scan_floor: 0,
-            genesis_fallback_done: false,
+            grace_until_tip: None,
+            arm_grace_on_next_call: false,
         };
 
         // Attempt 2 resumes from 1_000 and finds nothing new; the earlier discovery must survive.
@@ -532,20 +631,21 @@ mod tests {
         // A factory re-registration invalidates the match: the new factory's Outbox may live
         // anywhere, and the old address must not be reported for it. This exercises
         // `resume_rotation_from_checkpoint: false` — the legacy unconditional genesis reset;
-        // see `factory_rotation_resumes_from_checkpoint_when_enabled` for the default path.
+        // see `factory_rotation_resumes_from_checkpoint_when_enabled` for the default path. Goes
+        // through `rotate_to`, the same method production code calls, rather than hand-copying its
+        // assignments (see `the_load_bearing_rotation_reset_is_exercised_through_rotate_to`).
         let new_factory = address!("00000000000000000000000000000000000000ee");
         let resume_rotation_from_checkpoint = false;
-        if cursor.factory != Some(new_factory) {
-            cursor.from = if resume_rotation_from_checkpoint {
-                cursor.from
-            } else {
-                0
-            };
-            cursor.factory = Some(new_factory);
-            cursor.found = None;
-        }
+        let resume_from = if resume_rotation_from_checkpoint {
+            cursor.from
+        } else {
+            0
+        };
+        cursor.rotate_to(new_factory, resume_from, 2_000);
         assert_eq!(cursor.scanned_to(), 0);
         assert_eq!(cursor.found, None);
+        assert_eq!(cursor.scan_floor, 0);
+        assert_eq!(cursor.grace_until_tip, Some(2_000));
     }
 
     /// With `resume_rotation_from_checkpoint` (the default), a factory rotation keeps the cursor's
@@ -565,23 +665,59 @@ mod tests {
             found: Some((outbox, Some(499_000))),
             advanced_last_call: false,
             scan_floor: 0,
-            genesis_fallback_done: false,
+            grace_until_tip: None,
+            arm_grace_on_next_call: false,
         };
 
         let resume_rotation_from_checkpoint = true;
-        if cursor.factory != Some(new_factory) {
-            cursor.from = if resume_rotation_from_checkpoint {
-                cursor.from
-            } else {
-                0
-            };
-            cursor.factory = Some(new_factory);
-            cursor.found = None;
-        }
+        let resume_from = if resume_rotation_from_checkpoint {
+            cursor.from
+        } else {
+            0
+        };
+        cursor.rotate_to(new_factory, resume_from, 500_010);
 
         assert_eq!(cursor.scanned_to(), 500_000);
         assert_eq!(cursor.factory(), Some(new_factory));
         assert_eq!(cursor.found, None);
+        assert_eq!(
+            cursor.scan_floor, 500_000,
+            "the resumed checkpoint becomes the new floor — this is what arms the genesis fallback"
+        );
+        assert_eq!(
+            cursor.grace_until_tip,
+            Some(500_010),
+            "armed with this call's tip, so the fallback cannot fire until the finalized head \
+             catches up to it"
+        );
+    }
+
+    /// Pins down that the load-bearing rotation reset (`scan_floor`/`grace_until_tip`, alongside
+    /// `from`/`factory`/`found`) lives in one method both production code and tests call, instead
+    /// of being hand-copied at each rotation test — a hand-copy is exactly how earlier tests here
+    /// drifted and stopped covering the fix this fallback exists for.
+    #[test]
+    fn the_load_bearing_rotation_reset_is_exercised_through_rotate_to() {
+        let mut cursor = OutboxDiscoveryCursor::starting_at(0);
+        cursor.factory = Some(address!("00000000000000000000000000000000000000ff"));
+        cursor.from = 500_000;
+        cursor.scan_floor = 0;
+
+        cursor.rotate_to(
+            address!("00000000000000000000000000000000000000ee"),
+            500_000,
+            500_005,
+        );
+
+        assert_eq!(
+            cursor.factory(),
+            Some(address!("00000000000000000000000000000000000000ee"))
+        );
+        assert_eq!(cursor.scanned_to(), 500_000);
+        assert_eq!(cursor.scan_floor, 500_000);
+        assert_eq!(cursor.found, None);
+        assert_eq!(cursor.grace_until_tip, Some(500_005));
+        assert!(!cursor.arm_grace_on_next_call);
     }
 
     /// The T4-shaped failure this fallback exists for, in cursor terms: a rotation onto a
@@ -590,31 +726,40 @@ mod tests {
     /// scan is complete but not conclusive, so it rewinds to the configured floor.
     #[test]
     fn fallback_rewinds_a_resumed_scan_that_found_nothing() {
-        // Resumed at 705_530, factory B's OutboxCreated is at 608_120 — never looked at.
+        // Resumed at 705_530, factory B's OutboxCreated is at 608_120 — never looked at. Grace is
+        // satisfied (either nothing was pending, or the finalized tip has already caught up).
         assert_eq!(
-            genesis_fallback_target(false, 705_530, 0, false),
+            genesis_fallback_target(false, 705_530, 0, true),
             Some(0),
-            "a resumed scan with no match must rewind to the floor"
+            "a resumed scan with no match must rewind to the floor once grace is satisfied"
         );
     }
 
-    /// The three ways the fallback correctly declines, each for a different reason.
+    /// The race this fallback must not lose: a rotation onto a factory that was itself *just*
+    /// deployed looks identical, for one tick, to a rotation onto a pre-existing one whose event
+    /// will never be found above the checkpoint — both complete a scan and find nothing. Grace is
+    /// what keeps the common, healthy rotation from burning the one-shot recovery.
+    #[test]
+    fn fallback_declines_while_grace_is_unsatisfied() {
+        assert_eq!(
+            genesis_fallback_target(false, 705_530, 0, false),
+            None,
+            "grace not yet satisfied — the fresh factory's own event may simply not have finalized"
+        );
+    }
+
+    /// The two ways the fallback correctly declines when grace isn't the blocker.
     #[test]
     fn fallback_declines_when_the_scan_is_already_conclusive() {
         assert_eq!(
-            genesis_fallback_target(true, 705_530, 0, false),
+            genesis_fallback_target(true, 705_530, 0, true),
             None,
             "a match makes the scan conclusive whatever floor it began at"
         );
         assert_eq!(
-            genesis_fallback_target(false, 0, 0, false),
+            genesis_fallback_target(false, 0, 0, true),
             None,
             "a scan that began at the floor has covered everything; no Outbox is the truth"
-        );
-        assert_eq!(
-            genesis_fallback_target(false, 705_530, 0, true),
-            None,
-            "one rewind per factory — otherwise an Outbox-less factory rescans on every retry"
         );
     }
 
@@ -623,23 +768,26 @@ mod tests {
     #[test]
     fn fallback_targets_the_configured_genesis_block() {
         assert_eq!(
-            genesis_fallback_target(false, 705_530, 300_000, false),
+            genesis_fallback_target(false, 705_530, 300_000, true),
             Some(300_000)
         );
         assert_eq!(
-            genesis_fallback_target(false, 300_000, 300_000, false),
+            genesis_fallback_target(false, 300_000, 300_000, true),
             None,
             "starting at the configured floor is as complete as a scan can be"
         );
         assert_eq!(
-            genesis_fallback_target(false, 250_000, 300_000, false),
+            genesis_fallback_target(false, 250_000, 300_000, true),
             None,
             "already below the floor: nothing above it went unscanned"
         );
     }
 
-    /// The fallback terminates. Walking the cursor through the full recovery — rotate, scan, no
-    /// match, rewind, rescan, still no match — must end in a settled state, not a rescan loop.
+    /// The fallback terminates without a separate "already used" flag: once it fires, the caller
+    /// lowers `scan_floor` to `genesis_block`, and — `genesis_block` being constant per process —
+    /// every later call finds `scan_floor > genesis_block` already false. The floor alone carries
+    /// the termination invariant, walked here through the full recovery: rotate, scan, no match,
+    /// rewind, rescan, still no match, must end in a settled state rather than a rescan loop.
     #[test]
     fn fallback_terminates_after_one_rewind() {
         let mut cursor = OutboxDiscoveryCursor::starting_at(0);
@@ -647,43 +795,73 @@ mod tests {
         cursor.from = 705_530;
         cursor.scan_floor = 705_530;
 
-        // First completion: nothing found above the resumed floor → rewind.
-        let first = genesis_fallback_target(
-            cursor.found.is_some(),
-            cursor.scan_floor,
-            0,
-            cursor.genesis_fallback_done,
-        );
+        // First completion: nothing found above the resumed floor, grace satisfied → rewind.
+        let first = genesis_fallback_target(cursor.found.is_some(), cursor.scan_floor, 0, true);
         assert_eq!(first, Some(0));
-        cursor.genesis_fallback_done = true;
         cursor.from = 0;
         cursor.scan_floor = 0;
 
-        // Second completion after the full rescan: still nothing. Both the spent-fallback guard and
-        // the floor check now say stop, so the verdict stands.
+        // Second completion after the full rescan: still nothing. The floor alone now says stop.
         cursor.from = 705_600;
         assert_eq!(
-            genesis_fallback_target(
-                cursor.found.is_some(),
-                cursor.scan_floor,
-                0,
-                cursor.genesis_fallback_done
-            ),
+            genesis_fallback_target(cursor.found.is_some(), cursor.scan_floor, 0, true),
             None
         );
     }
 
+    /// The spurious-fire race this fallback must not lose to, worked through with the actual tip
+    /// arithmetic `resolve_outbox_address` uses: a rotation observes tip 500_005, and the very same
+    /// tick's scan is bounded by a *finalized* `safe_tip` that lags behind it — so an empty result
+    /// on that tick must not be trusted, only once the finalized head has caught up to 500_005.
+    #[test]
+    fn grace_declines_immediately_after_rotation_and_clears_once_finality_catches_up() {
+        let mut cursor = OutboxDiscoveryCursor::starting_at(0);
+        cursor.rotate_to(
+            address!("00000000000000000000000000000000000000ee"),
+            500_000, // old checkpoint, resumed
+            500_005, // unfinalized tip observed at the moment the rotation was detected
+        );
+
+        // Same tick: the scan completes [500_000, 500_003] and finds nothing — the new factory's
+        // own event, even if emitted around rotation time, may simply not have finalized yet.
+        let safe_tip_same_tick = 500_003;
+        let grace_satisfied = cursor
+            .grace_until_tip
+            .is_none_or(|until| safe_tip_same_tick >= until);
+        assert!(!grace_satisfied);
+        assert_eq!(
+            genesis_fallback_target(false, cursor.scan_floor, 0, grace_satisfied),
+            None,
+            "must not burn the one-shot recovery on a rotation that is merely awaiting finality"
+        );
+
+        // Later tick: the finalized head has now passed the rotation-observed tip, so anything at
+        // or before it — including a same-tick `OutboxCreated` — has had its chance to finalize.
+        let safe_tip_later = 500_006;
+        let grace_satisfied = cursor
+            .grace_until_tip
+            .is_none_or(|until| safe_tip_later >= until);
+        assert!(grace_satisfied);
+        assert_eq!(
+            genesis_fallback_target(false, cursor.scan_floor, 0, grace_satisfied),
+            Some(0),
+            "still no match once finality has caught up — now it is evidence, not a race"
+        );
+    }
+
     /// `starting_at` is what a fresh cursor uses when nothing is persisted: the configured floor is
-    /// both the scan position and the floor, so a first scan is immediately conclusive.
+    /// both the scan position and the floor, so a first scan is immediately conclusive, and there
+    /// is no pending grace to wait on.
     #[test]
     fn starting_at_seeds_position_and_floor_together() {
         let cursor = OutboxDiscoveryCursor::starting_at(300_000);
         assert_eq!(cursor.scanned_to(), 300_000);
         assert_eq!(cursor.scan_floor, 300_000);
         assert_eq!(cursor.factory(), None);
-        assert!(!cursor.genesis_fallback_done);
+        assert_eq!(cursor.grace_until_tip, None);
+        assert!(!cursor.arm_grace_on_next_call);
         assert_eq!(
-            genesis_fallback_target(false, cursor.scan_floor, 300_000, false),
+            genesis_fallback_target(false, cursor.scan_floor, 300_000, true),
             None
         );
     }
@@ -704,12 +882,15 @@ mod tests {
         assert_eq!(cursor.scanned_to(), 705_600);
         assert_eq!(cursor.scan_floor, 705_530);
         assert!(
-            !cursor.genesis_fallback_done,
-            "a reload re-arms the fallback"
+            cursor.arm_grace_on_next_call,
+            "a reload can't rule out the floor being a rotation from moments before the restart, \
+             so it defers arming the grace window to the first live call instead of trusting an \
+             empty scan blind"
         );
         assert_eq!(
-            genesis_fallback_target(false, cursor.scan_floor, 0, cursor.genesis_fallback_done),
-            Some(0)
+            genesis_fallback_target(false, cursor.scan_floor, 0, true),
+            Some(0),
+            "the decision itself is unaffected by the reload — only the caller's grace check is"
         );
     }
 
@@ -726,7 +907,8 @@ mod tests {
             found: None,
             advanced_last_call: false,
             scan_floor: 0,
-            genesis_fallback_done: false,
+            grace_until_tip: None,
+            arm_grace_on_next_call: false,
         };
         let scanned_before = cursor.scanned_to();
 

--- a/attestor/attestor/src/tasks/write_ability/resolver.rs
+++ b/attestor/attestor/src/tasks/write_ability/resolver.rs
@@ -30,7 +30,7 @@
 //! sits *below* the checkpoint and the resumed scan runs to the tip, matches nothing, and reports
 //! "no Outbox" — permanently, since the cursor is then persisted at the tip against that very
 //! factory and reads back as valid on the next boot. [`genesis_fallback_target`] closes that: a
-//! scan that completes with no match, having started above [`Config::writability_genesis_block`],
+//! scan that completes with no match, having started above [`Config::factory_scan_genesis_block`],
 //! rewinds to that floor and tries once more before the chain key is declared Outbox-less.
 
 use alloy::primitives::{Address, B256};
@@ -111,7 +111,7 @@ struct DiscoveryPolicy {
     confirmation_depth: u64,
     /// See [`Config::resume_rotation_from_checkpoint`].
     resume_rotation_from_checkpoint: bool,
-    /// See [`Config::writability_genesis_block`] — the floor every from-scratch scan starts at.
+    /// See [`Config::factory_scan_genesis_block`] — the floor every from-scratch scan starts at.
     genesis_block: u64,
 }
 
@@ -173,7 +173,7 @@ impl OutboxDiscoveryCursor {
     }
 
     /// A fresh cursor for a chain key with nothing persisted, starting at `genesis_block` (see
-    /// [`Config::writability_genesis_block`]). Prefer this over `default()` anywhere a real
+    /// [`Config::factory_scan_genesis_block`]). Prefer this over `default()` anywhere a real
     /// configuration is in hand — `default()` starts at block 0 regardless, which is only correct
     /// when the floor is 0.
     pub(super) fn starting_at(genesis_block: u64) -> Self {
@@ -238,7 +238,7 @@ pub async fn resolve<P: Provider>(
         DiscoveryPolicy {
             confirmation_depth: cfg.block_confirmation_depth,
             resume_rotation_from_checkpoint: cfg.resume_rotation_from_checkpoint,
-            genesis_block: cfg.writability_genesis_block,
+            genesis_block: cfg.factory_scan_genesis_block,
         },
         cursor,
         factory_scan_store,
@@ -456,7 +456,7 @@ async fn resolve_outbox_address<P: Provider>(
             rewind_to,
             "🪃 no OutboxCreated found above the resumed checkpoint; the factory's own event \
              may predate it (a rotation onto a pre-existing factory). Rescanning once from \
-             the configured write-ability genesis block before reporting no Outbox"
+             the configured factory-scan genesis block before reporting no Outbox"
         );
         cursor.genesis_fallback_done = true;
         cursor.from = rewind_to;
@@ -618,7 +618,7 @@ mod tests {
         );
     }
 
-    /// The floor is honoured, not hardcoded to 0: with `writability_genesis_block` set, the rewind
+    /// The floor is honoured, not hardcoded to 0: with `factory_scan_genesis_block` set, the rewind
     /// targets it, and a scan that already started there is conclusive rather than looping.
     #[test]
     fn fallback_targets_the_configured_genesis_block() {

--- a/attestor/attestor/src/tasks/write_ability/resolver.rs
+++ b/attestor/attestor/src/tasks/write_ability/resolver.rs
@@ -24,6 +24,14 @@
 //! history from genesis. A factory change (rotation) used to force that same genesis rescan even
 //! within one run; with [`Config::resume_rotation_from_checkpoint`] (on by default) it instead
 //! resumes from the last checkpoint, same as a restart does.
+//!
+//! Resuming can overshoot: the checkpoint is a valid floor only when the rotated-to factory was
+//! itself deployed at rotation time. Point a chain key at a factory whose `OutboxCreated` already
+//! sits *below* the checkpoint and the resumed scan runs to the tip, matches nothing, and reports
+//! "no Outbox" — permanently, since the cursor is then persisted at the tip against that very
+//! factory and reads back as valid on the next boot. [`genesis_fallback_target`] closes that: a
+//! scan that completes with no match, having started above [`Config::writability_genesis_block`],
+//! rewinds to that floor and tries once more before the chain key is declared Outbox-less.
 
 use alloy::primitives::{Address, B256};
 use alloy::providers::Provider;
@@ -67,15 +75,55 @@ pub struct ResolvedOutbox {
     pub created_at_block: Option<u64>,
 }
 
+/// Where a completed-but-empty `OutboxCreated` scan should restart, or `None` to accept "this
+/// factory has no Outbox" as final. Pure so the decision is unit-testable without a live provider,
+/// mirroring how the rest of this module's cursor arithmetic is tested.
+///
+/// The fallback is deliberately **not** configurable. The state it recovers from — a scan resumed
+/// above the event it was looking for — is otherwise unrecoverable without an operator deleting the
+/// cursor file on every pod by hand, and the recovery costs one extra scan of a range that was
+/// going to be scanned anyway had the checkpoint not been trusted.
+///
+/// Three conditions, all necessary:
+/// - `found_something` is false — a match makes the scan conclusive whatever floor it began at;
+/// - `scan_floor > genesis_block` — the scan started above the floor, so there is unlooked-at range
+///   below it. A scan that already began at the floor has covered everything and its "no Outbox"
+///   verdict is the truth;
+/// - `already_used` is false — one rewind per factory per process, so a factory that genuinely has
+///   no `OutboxCreated` settles into the cheap tip-following steady state instead of rescanning the
+///   whole chain on every retry.
+fn genesis_fallback_target(
+    found_something: bool,
+    scan_floor: u64,
+    genesis_block: u64,
+    already_used: bool,
+) -> Option<u64> {
+    (!found_something && !already_used && scan_floor > genesis_block).then_some(genesis_block)
+}
+
+/// The scan-shaping knobs [`resolve_outbox_address`] reads out of [`Config`], grouped so the
+/// function keeps a legible signature as they accumulate (and stays under clippy's argument-count
+/// limit). Copied per call — all three are plain scalars read from a config that only changes on
+/// restart.
+#[derive(Clone, Copy, Debug)]
+struct DiscoveryPolicy {
+    /// Depth below the tip to treat as safe when the `finalized` tag is unavailable.
+    confirmation_depth: u64,
+    /// See [`Config::resume_rotation_from_checkpoint`].
+    resume_rotation_from_checkpoint: bool,
+    /// See [`Config::writability_genesis_block`] — the floor every from-scratch scan starts at.
+    genesis_block: u64,
+}
+
 /// Caller-owned state for the incremental Outbox-discovery scan across activation retries. Tracks
 /// how far we have scanned and against which factory, so each retry only scans new *confirmed*
 /// blocks (no full-history log storm) while staying reorg-safe, and a factory re-registration
-/// restarts the scan from genesis.
+/// restarts the scan from the configured floor.
 #[derive(Default)]
 pub struct OutboxDiscoveryCursor {
     /// Next block to scan from.
     from: u64,
-    /// Factory the cursor was advanced against; a change resets `from` to 0.
+    /// Factory the cursor was advanced against; a change resets `from` to the scan floor.
     factory: Option<Address>,
     /// Newest `OutboxCreated` (address, emitting block) seen so far, carried across attempts.
     /// Progress and discovery must advance together: `from` moves past each completed chunk, so
@@ -87,9 +135,21 @@ pub struct OutboxDiscoveryCursor {
     /// `false` at the start of every call. Callers use this — not a before/after diff of
     /// `scanned_to()` — to tell a resolve attempt that *failed after advancing* from one that made
     /// no headway at all: with `resume_rotation_from_checkpoint: false`, a rotation resets `from`
-    /// back to `0` inside the same call, so a before/after diff would see a *lower* value after a
-    /// call that did make progress and misreport it as a stall (bugbot).
+    /// back to the scan floor inside the same call — as does the genesis fallback — so a
+    /// before/after diff would see a *lower* value after a call that did make progress and
+    /// misreport it as a stall (bugbot).
     advanced_last_call: bool,
+    /// Block the *current* factory's scan started from. Everything below it has never been looked
+    /// at for this factory, which is exactly what the genesis fallback needs to know: a completed
+    /// scan that found nothing is only conclusive when this equals the configured floor.
+    ///
+    /// Moves with `from` whenever a scan (re)starts — initial seed, rotation, de-registration,
+    /// fallback — and is persisted so the distinction survives a restart.
+    scan_floor: u64,
+    /// Whether the genesis fallback has already been spent on the current factory. Reset alongside
+    /// `from`/`found` on every factory change, so each factory gets exactly one — bounding the
+    /// recovery to a single extra full scan instead of one per retry.
+    genesis_fallback_done: bool,
 }
 
 impl OutboxDiscoveryCursor {
@@ -107,6 +167,23 @@ impl OutboxDiscoveryCursor {
             factory: Some(persisted.factory),
             found: persisted.found,
             advanced_last_call: false,
+            scan_floor: persisted.scan_floor,
+            genesis_fallback_done: false,
+        }
+    }
+
+    /// A fresh cursor for a chain key with nothing persisted, starting at `genesis_block` (see
+    /// [`Config::writability_genesis_block`]). Prefer this over `default()` anywhere a real
+    /// configuration is in hand — `default()` starts at block 0 regardless, which is only correct
+    /// when the floor is 0.
+    pub(super) fn starting_at(genesis_block: u64) -> Self {
+        Self {
+            from: genesis_block,
+            factory: None,
+            found: None,
+            advanced_last_call: false,
+            scan_floor: genesis_block,
+            genesis_fallback_done: false,
         }
     }
 
@@ -158,8 +235,11 @@ pub async fn resolve<P: Provider>(
         provider,
         chain_key,
         destination_chain_key,
-        cfg.block_confirmation_depth,
-        cfg.resume_rotation_from_checkpoint,
+        DiscoveryPolicy {
+            confirmation_depth: cfg.block_confirmation_depth,
+            resume_rotation_from_checkpoint: cfg.resume_rotation_from_checkpoint,
+            genesis_block: cfg.writability_genesis_block,
+        },
         cursor,
         factory_scan_store,
     )
@@ -194,8 +274,7 @@ async fn resolve_outbox_address<P: Provider>(
     provider: &P,
     chain_key: ChainKey,
     _destination_chain_key: B256,
-    confirmation_depth: u64,
-    resume_rotation_from_checkpoint: bool,
+    policy: DiscoveryPolicy,
     cursor: &mut OutboxDiscoveryCursor,
     factory_scan_store: Option<&FactoryScanCursorStore>,
 ) -> Result<Option<(Address, Option<u64>)>> {
@@ -214,8 +293,10 @@ async fn resolve_outbox_address<P: Provider>(
         // make the monitor interpret `Ok(None)` as merely "no new events" and continue signing the
         // de-registered Outbox until another factory eventually appeared.
         cursor.factory = None;
-        cursor.from = 0;
+        cursor.from = policy.genesis_block;
+        cursor.scan_floor = policy.genesis_block;
         cursor.found = None;
+        cursor.genesis_fallback_done = false;
         tracing::warn!(
             chain_key,
             "no Outbox factory registered on-chain for chain_key"
@@ -232,10 +313,14 @@ async fn resolve_outbox_address<P: Provider>(
     // `Config::resume_rotation_from_checkpoint`'s docs for the assumption and its failure mode).
     if cursor.factory != Some(factory) {
         let previous_factory = cursor.factory;
-        let resume_from = if resume_rotation_from_checkpoint {
+        // Note the asymmetry: the resume branch keeps the checkpoint verbatim even if it sits
+        // *below* `genesis_block`. The floor answers "where does a scan with no usable position
+        // start?", and a checkpoint is a position; raising it here would skip range the previous
+        // scan had already proven worth covering. Only the from-scratch branch takes the floor.
+        let resume_from = if policy.resume_rotation_from_checkpoint {
             cursor.from
         } else {
-            0
+            policy.genesis_block
         };
         if previous_factory.is_some() {
             // Not fired on the very first resolve (no `previous_factory` yet) — that is initial
@@ -246,13 +331,17 @@ async fn resolve_outbox_address<P: Provider>(
                 %factory,
                 ?previous_factory,
                 resume_from,
-                resume_rotation_from_checkpoint,
+                resume_rotation_from_checkpoint = policy.resume_rotation_from_checkpoint,
+                genesis_block = policy.genesis_block,
                 "🔁 Outbox factory rotated; restarting OutboxCreated discovery"
             );
         }
         cursor.factory = Some(factory);
         cursor.from = resume_from;
+        cursor.scan_floor = resume_from;
         cursor.found = None;
+        // A fresh factory earns a fresh fallback: this is the transition that can overshoot.
+        cursor.genesis_fallback_done = false;
     }
 
     // 2. Discover the factory's Outbox for this chain key. The synced CREATE2 factory has no
@@ -285,7 +374,7 @@ async fn resolve_outbox_address<P: Provider>(
         Ok(Some(block)) => block.header.number,
         // `finalized` tag unsupported/errored → depth fallback (same as the listener). The tip
         // read above already covers a dead RPC, so a finalized-read failure is not fatal here.
-        Ok(None) | Err(_) => tip.saturating_sub(confirmation_depth),
+        Ok(None) | Err(_) => tip.saturating_sub(policy.confirmation_depth),
     };
     let sig = IOutboxFactory::OutboxCreated::SIGNATURE_HASH;
     let topic_chain_key = alloy::primitives::U256::from(chain_key);
@@ -348,13 +437,44 @@ async fn resolve_outbox_address<P: Provider>(
     // `safe_tip < cursor.from` (tip regressed / depth grew) — never regressing the cursor.
     cursor.from = cursor.from.max(from);
 
+    // Reaching here means the chunk loop ran to completion: an attempt cut short by the caller's
+    // RPC_ATTEMPT_TIMEOUT is aborted mid-`await`, and a failing chunk returns via `?`. So a `found`
+    // of `None` at this point is a *complete* scan of [`scan_floor`, `safe_tip`] that matched
+    // nothing — which is only the same thing as "this factory has no Outbox" when the scan began at
+    // the configured floor. Otherwise rewind once and let the next retry cover the rest.
+    if let Some(rewind_to) = genesis_fallback_target(
+        cursor.found.is_some(),
+        cursor.scan_floor,
+        policy.genesis_block,
+        cursor.genesis_fallback_done,
+    ) {
+        tracing::warn!(
+            chain_key,
+            %factory,
+            scanned_from = cursor.scan_floor,
+            scanned_to = cursor.from,
+            rewind_to,
+            "🪃 no OutboxCreated found above the resumed checkpoint; the factory's own event \
+             may predate it (a rotation onto a pre-existing factory). Rescanning once from \
+             the configured write-ability genesis block before reporting no Outbox"
+        );
+        cursor.genesis_fallback_done = true;
+        cursor.from = rewind_to;
+        cursor.scan_floor = rewind_to;
+    }
+
     // Persist whatever progress this call made, win or not — best-effort: a write failure only
     // costs a re-scan on the next restart, never correctness, so it must not fail resolution.
+    //
+    // Deliberately *after* the rewind above, so a fallback that has been decided is durable: a
+    // restart mid-recovery resumes the rescan instead of reloading the very cursor that stranded
+    // this chain key in the first place.
     if let Some(store) = factory_scan_store {
         let to_persist = PersistedFactoryScan {
             factory,
             scanned_to: cursor.from,
             found: cursor.found,
+            scan_floor: cursor.scan_floor,
         };
         if let Err(err) = store.save(&to_persist) {
             tracing::warn!(chain_key, %err, "failed to persist factory-scan cursor");
@@ -368,7 +488,13 @@ async fn resolve_outbox_address<P: Provider>(
         );
         return Ok(Some((outbox, created_at_block)));
     }
-    tracing::warn!(%factory, chain_key, "factory has emitted no OutboxCreated for chain_key yet");
+    tracing::warn!(
+        %factory,
+        chain_key,
+        scanned_from = cursor.scan_floor,
+        scanned_to = cursor.from,
+        "factory has emitted no OutboxCreated for chain_key yet"
+    );
     Ok(None)
 }
 
@@ -395,6 +521,8 @@ mod tests {
             factory: Some(factory),
             found: Some((outbox, Some(950))),
             advanced_last_call: false,
+            scan_floor: 0,
+            genesis_fallback_done: false,
         };
 
         // Attempt 2 resumes from 1_000 and finds nothing new; the earlier discovery must survive.
@@ -436,6 +564,8 @@ mod tests {
             factory: Some(old_factory),
             found: Some((outbox, Some(499_000))),
             advanced_last_call: false,
+            scan_floor: 0,
+            genesis_fallback_done: false,
         };
 
         let resume_rotation_from_checkpoint = true;
@@ -454,6 +584,135 @@ mod tests {
         assert_eq!(cursor.found, None);
     }
 
+    /// The T4-shaped failure this fallback exists for, in cursor terms: a rotation onto a
+    /// **pre-existing** factory resumes at the old factory's checkpoint, scans to the tip, and
+    /// matches nothing — because the new factory's `OutboxCreated` was emitted far below. The
+    /// scan is complete but not conclusive, so it rewinds to the configured floor.
+    #[test]
+    fn fallback_rewinds_a_resumed_scan_that_found_nothing() {
+        // Resumed at 705_530, factory B's OutboxCreated is at 608_120 — never looked at.
+        assert_eq!(
+            genesis_fallback_target(false, 705_530, 0, false),
+            Some(0),
+            "a resumed scan with no match must rewind to the floor"
+        );
+    }
+
+    /// The three ways the fallback correctly declines, each for a different reason.
+    #[test]
+    fn fallback_declines_when_the_scan_is_already_conclusive() {
+        assert_eq!(
+            genesis_fallback_target(true, 705_530, 0, false),
+            None,
+            "a match makes the scan conclusive whatever floor it began at"
+        );
+        assert_eq!(
+            genesis_fallback_target(false, 0, 0, false),
+            None,
+            "a scan that began at the floor has covered everything; no Outbox is the truth"
+        );
+        assert_eq!(
+            genesis_fallback_target(false, 705_530, 0, true),
+            None,
+            "one rewind per factory — otherwise an Outbox-less factory rescans on every retry"
+        );
+    }
+
+    /// The floor is honoured, not hardcoded to 0: with `writability_genesis_block` set, the rewind
+    /// targets it, and a scan that already started there is conclusive rather than looping.
+    #[test]
+    fn fallback_targets_the_configured_genesis_block() {
+        assert_eq!(
+            genesis_fallback_target(false, 705_530, 300_000, false),
+            Some(300_000)
+        );
+        assert_eq!(
+            genesis_fallback_target(false, 300_000, 300_000, false),
+            None,
+            "starting at the configured floor is as complete as a scan can be"
+        );
+        assert_eq!(
+            genesis_fallback_target(false, 250_000, 300_000, false),
+            None,
+            "already below the floor: nothing above it went unscanned"
+        );
+    }
+
+    /// The fallback terminates. Walking the cursor through the full recovery — rotate, scan, no
+    /// match, rewind, rescan, still no match — must end in a settled state, not a rescan loop.
+    #[test]
+    fn fallback_terminates_after_one_rewind() {
+        let mut cursor = OutboxDiscoveryCursor::starting_at(0);
+        cursor.factory = Some(address!("00000000000000000000000000000000000000ff"));
+        cursor.from = 705_530;
+        cursor.scan_floor = 705_530;
+
+        // First completion: nothing found above the resumed floor → rewind.
+        let first = genesis_fallback_target(
+            cursor.found.is_some(),
+            cursor.scan_floor,
+            0,
+            cursor.genesis_fallback_done,
+        );
+        assert_eq!(first, Some(0));
+        cursor.genesis_fallback_done = true;
+        cursor.from = 0;
+        cursor.scan_floor = 0;
+
+        // Second completion after the full rescan: still nothing. Both the spent-fallback guard and
+        // the floor check now say stop, so the verdict stands.
+        cursor.from = 705_600;
+        assert_eq!(
+            genesis_fallback_target(
+                cursor.found.is_some(),
+                cursor.scan_floor,
+                0,
+                cursor.genesis_fallback_done
+            ),
+            None
+        );
+    }
+
+    /// `starting_at` is what a fresh cursor uses when nothing is persisted: the configured floor is
+    /// both the scan position and the floor, so a first scan is immediately conclusive.
+    #[test]
+    fn starting_at_seeds_position_and_floor_together() {
+        let cursor = OutboxDiscoveryCursor::starting_at(300_000);
+        assert_eq!(cursor.scanned_to(), 300_000);
+        assert_eq!(cursor.scan_floor, 300_000);
+        assert_eq!(cursor.factory(), None);
+        assert!(!cursor.genesis_fallback_done);
+        assert_eq!(
+            genesis_fallback_target(false, cursor.scan_floor, 300_000, false),
+            None
+        );
+    }
+
+    /// A cursor reloaded from disk carries the floor its scan actually began at, so a restart in
+    /// the middle of the stranded state still recognises it as unresolved rather than trusting the
+    /// tip-height checkpoint as a completed scan. This is what makes the recovery survive the
+    /// "restart it and see" reflex.
+    #[test]
+    fn from_persisted_carries_the_floor_so_a_restart_can_still_recover() {
+        let persisted = PersistedFactoryScan {
+            factory: address!("00000000000000000000000000000000000000ee"),
+            scanned_to: 705_600,
+            found: None,
+            scan_floor: 705_530,
+        };
+        let cursor = OutboxDiscoveryCursor::from_persisted(persisted);
+        assert_eq!(cursor.scanned_to(), 705_600);
+        assert_eq!(cursor.scan_floor, 705_530);
+        assert!(
+            !cursor.genesis_fallback_done,
+            "a reload re-arms the fallback"
+        );
+        assert_eq!(
+            genesis_fallback_target(false, cursor.scan_floor, 0, cursor.genesis_fallback_done),
+            Some(0)
+        );
+    }
+
     /// Regression (bugbot): a caller that diffs `scanned_to()` before and after a call to tell
     /// "advanced" from "no headway" gets it backwards when `resume_rotation_from_checkpoint: false`
     /// resets `from` to genesis *inside* that same call — the post-call value can land below the
@@ -466,6 +725,8 @@ mod tests {
             factory: Some(address!("00000000000000000000000000000000000000ff")),
             found: None,
             advanced_last_call: false,
+            scan_floor: 0,
+            genesis_fallback_done: false,
         };
         let scanned_before = cursor.scanned_to();
 
@@ -497,6 +758,7 @@ mod tests {
             factory,
             scanned_to: 12_345,
             found: Some((outbox, Some(950))),
+            scan_floor: 0,
         };
         let cursor = OutboxDiscoveryCursor::from_persisted(persisted);
         assert_eq!(cursor.scanned_to(), 12_345);
@@ -515,6 +777,7 @@ mod tests {
             factory: address!("00000000000000000000000000000000000000ff"),
             scanned_to: 12_345,
             found: None,
+            scan_floor: 0,
         };
         let cursor = OutboxDiscoveryCursor::from_persisted(persisted);
         let live_factory = address!("00000000000000000000000000000000000000ee");

--- a/attestor/config.yaml
+++ b/attestor/config.yaml
@@ -115,12 +115,39 @@ write_ability:
 
   # On a governance Outbox-factory rotation, resume OutboxCreated discovery from the
   # last factory-scan checkpoint instead of rescanning the factory's full log history
-  # from genesis. Defaults to true. Only turn this off if a deployment ever re-points
-  # a chain key at a pre-existing factory (one not freshly deployed as part of the
-  # rotation) — resuming from the checkpoint would then risk skipping an OutboxCreated
-  # emitted before it.
+  # from genesis. Defaults to true. Turning it off restores the unconditional rescan
+  # from writability_genesis_block, which makes no assumption about when the rotated-to
+  # factory was deployed.
+  #
+  # Resuming can overshoot — re-point a chain key at a pre-existing factory whose
+  # OutboxCreated already sits below the checkpoint and the resumed scan matches
+  # nothing. That is recovered automatically: a completed scan that found nothing,
+  # having started above writability_genesis_block, rewinds to that floor and tries
+  # once more (logged as "🪃 no OutboxCreated found above the resumed checkpoint")
+  # before the chain key is reported as having no Outbox. The recovery costs one extra
+  # full scan and fires at most once per factory per process.
   #
   # resume_rotation_from_checkpoint: true
+
+  # First Creditcoin L1 block that any *from-scratch* OutboxCreated discovery scan
+  # starts at: initial activation on an empty state volume, a rotation with
+  # resume_rotation_from_checkpoint off, a factory de-registration, and the rewind
+  # described above. Defaults to 0 — a true genesis scan.
+  #
+  # This is a floor, not a rewind. A persisted cursor that is already further along
+  # resumes from where it left off, and a rotation that resumes from a checkpoint keeps
+  # that checkpoint; this value only answers "where does a scan with no position start?".
+  #
+  # Raising it to a height known to precede this chain key's Outbox factory deployment
+  # cuts every one of those scans down to the range that could actually contain the
+  # event — on a long-lived chain that is the difference between a multi-minute
+  # fleet-wide quorum outage during a rotation and a brief one.
+  #
+  # ⚠️ Set it ABOVE a factory's OutboxCreated block and that Outbox becomes
+  # undiscoverable, including via the rewind, which floors here too. Use a height known
+  # to precede every factory this chain key will ever be pointed at.
+  #
+  # writability_genesis_block: 0
 
   # Directory for durable write-ability state — the Outbox scan cursor, so a restart
   # resumes where it left off instead of skipping messages published while down.

--- a/attestor/config.yaml
+++ b/attestor/config.yaml
@@ -116,13 +116,13 @@ write_ability:
   # On a governance Outbox-factory rotation, resume OutboxCreated discovery from the
   # last factory-scan checkpoint instead of rescanning the factory's full log history
   # from genesis. Defaults to true. Turning it off restores the unconditional rescan
-  # from writability_genesis_block, which makes no assumption about when the rotated-to
+  # from factory_scan_genesis_block, which makes no assumption about when the rotated-to
   # factory was deployed.
   #
   # Resuming can overshoot — re-point a chain key at a pre-existing factory whose
   # OutboxCreated already sits below the checkpoint and the resumed scan matches
   # nothing. That is recovered automatically: a completed scan that found nothing,
-  # having started above writability_genesis_block, rewinds to that floor and tries
+  # having started above factory_scan_genesis_block, rewinds to that floor and tries
   # once more (logged as "🪃 no OutboxCreated found above the resumed checkpoint")
   # before the chain key is reported as having no Outbox. The recovery costs one extra
   # full scan and fires at most once per factory per process.
@@ -147,7 +147,7 @@ write_ability:
   # undiscoverable, including via the rewind, which floors here too. Use a height known
   # to precede every factory this chain key will ever be pointed at.
   #
-  # writability_genesis_block: 0
+  # factory_scan_genesis_block: 0
 
   # Directory for durable write-ability state — the Outbox scan cursor, so a restart
   # resumes where it left off instead of skipping messages published while down.


### PR DESCRIPTION
## Why

`ea1cf11da` made a factory rotation resume the new factory's `OutboxCreated` scan from the previous factory's checkpoint instead of rescanning from genesis. That is a valid floor **only when the rotated-to factory was itself deployed at rotation time** — its own doc comment names the assumption and the failure mode.

Re-point a chain key at a **pre-existing** factory whose `OutboxCreated` already sits below the checkpoint and the resumed scan runs to the confirmed tip, matches nothing, and returns `Ok(None)`. The monitor reads that as "no Outbox" and holds the `⏸️` pause.

It does not clear. The cursor is persisted at the tip *against that very factory*, so on the next boot it **matches** and is read back as a valid checkpoint — the "just restart it" reflex entrenches the failure rather than fixing it. Recovery today means deleting `/data/factory-scan-cursor-{chain_key}.json` on every attestor by hand.

This is not hypothetical: the documented T4 rotation drill re-points key 8 between two long-existing factories, and violates the assumption on **both** legs. On usc-dev today the cursor sits at ~705,530 while Outbox B was created at 608,120 and Outbox A at 362,796 — gaps of ~97k and ~343k blocks.

## What

**1. A genesis fallback.** Track `scan_floor` — the block each factory's scan started from — and persist it beside the cursor. That is the missing input: a completed scan that found nothing is only conclusive when it began at the configured floor. Otherwise rewind to the floor and scan once more before reporting no Outbox.

- Bounded by `genesis_fallback_done`, reset on every factory change: **one rewind per factory per process**, so a factory that genuinely has no `OutboxCreated` costs one extra scan and then settles back into the cheap tip-following steady state.
- The rewind is persisted **before** the cursor write, so a restart mid-recovery continues rather than reloading the poisoned checkpoint.
- A record written before `scan_floor` existed loads with the floor set to `scanned_to`, not 0 — the conservative reading, which grants it exactly one fallback. Reading it as 0 would deny the recovery to precisely the cursors most likely to need it: one written by a rotation on an older build.

**2. `factory_scan_genesis_block`.** The block every *from-scratch* discovery scan starts at, replacing the literal 0 at initial activation, at a rotation with `resume_rotation_from_checkpoint` off, at de-registration, and in the rewind. Defaults to `0`, so behaviour is unchanged unless set.

It answers one question — *where does a scan with no usable position start?* It never moves a cursor that has one: a persisted scan, or a rotation resuming from a checkpoint, keeps its position even when that sits below this value. The one deliberate exception is the fallback, whose whole job is to rewind to it.

⚠️ Set it **above** a factory's `OutboxCreated` and that Outbox becomes undiscoverable, the fallback included. Documented in all three places it is configured.

## Notes for review

- **The fallback alone does not make a rotation fast, only recoverable.** The forward leg resumes, finds nothing, rewinds, and pays a full scan. Setting `factory_scan_genesis_block` near the factory deployment height is what makes it cheap.
- Naming: `factory_scan_genesis_block` over `writability_genesis_block` — it names the scan it bounds, matches `FactoryScanCursorStore` / `factory-scan-cursor-{chain_key}.json`, and does not read as a sibling of the unrelated `start_block` already in that section.
- The relayer half is https://github.com/gluwa/usc-message-relayer/pull/43 — same mechanism, same names, same defaults. Both are needed; either alone leaves the other component stranded on a rotation.
- **Not exercised against a live rotation.** Unit tests cover the decision function, the floor asymmetry, the persistence round-trip and the legacy-record path, but the end-to-end claim is still reasoning from source plus the live cursor heights. The falsification test is one rotation: expect `🔁 … resume_from=705…`, then `🪃 no OutboxCreated found above the resumed checkpoint`, then a rescan that resolves.

## Testing

`cargo test -p attestor` 133 pass · `cargo clippy -p attestor --all-targets --all-features -- -D warnings` clean · `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)