### PR TITLE
fix(proof-gen): return 400 when the archiver rejects a roots range

### DIFF
--- a/common/continuity/src/archiver.rs
+++ b/common/continuity/src/archiver.rs
@@ -33,6 +33,36 @@ struct LatestResponse {
     latest_block: Option<u64>,
 }
 
+/// A non-2xx response from the archiver's HTTP API.
+///
+/// Kept as a typed error rather than collapsing straight into `anyhow!` so callers can tell an
+/// archiver-side *client* rejection (4xx — a request the archiver will never serve, such as a
+/// block range wider than its `MAX_API_RANGE`) apart from a genuine archiver fault (5xx or a
+/// transport failure). The former is a caller mistake and must not surface as a 5xx: doing so
+/// both misleads the client and pages an operator for a request that could never have
+/// succeeded.
+#[derive(Debug, thiserror::Error)]
+#[error("archiver rejected GET /roots for range {from}..{to} with {status}: {body}")]
+pub struct ArchiverStatusError {
+    pub status: reqwest::StatusCode,
+    pub body: String,
+    pub from: u64,
+    pub to: u64,
+}
+
+impl ArchiverStatusError {
+    /// True when the archiver refused the request itself rather than failing to serve it.
+    pub fn is_client_rejection(&self) -> bool {
+        self.status.is_client_error()
+    }
+}
+
+/// Find an [`ArchiverStatusError`] anywhere in an `anyhow` error chain.
+pub fn anyhow_chain_archiver_status(err: &anyhow::Error) -> Option<&ArchiverStatusError> {
+    err.chain()
+        .find_map(|cause| cause.downcast_ref::<ArchiverStatusError>())
+}
+
 impl ArchiverClient {
     /// Create a new archiver client pointing at the given base URL (e.g. `http://localhost:8080`).
     pub fn new(base_url: String) -> Self {
@@ -56,38 +86,46 @@ impl ArchiverClient {
         );
 
         let started = Instant::now();
-        let response = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .with_context(|| {
-                let elapsed_ms = started.elapsed().as_millis();
-                warn!(
-                    archiver_url = %self.base_url,
-                    from,
-                    to,
-                    span,
-                    duration_ms = elapsed_ms,
-                    "📡 ❌ archiver GET /roots transport error"
-                );
-                "archiver request failed"
-            })?
-            .error_for_status()
-            .with_context(|| {
-                let elapsed_ms = started.elapsed().as_millis();
-                warn!(
-                    archiver_url = %self.base_url,
-                    from,
-                    to,
-                    span,
-                    duration_ms = elapsed_ms,
-                    "📡 ❌ archiver GET /roots non-success status"
-                );
-                "archiver returned error status"
-            })?;
+        let response = self.http.get(&url).send().await.with_context(|| {
+            let elapsed_ms = started.elapsed().as_millis();
+            warn!(
+                archiver_url = %self.base_url,
+                from,
+                to,
+                span,
+                duration_ms = elapsed_ms,
+                "📡 ❌ archiver GET /roots transport error"
+            );
+            "archiver request failed"
+        })?;
 
         let status = response.status();
+        if !status.is_success() {
+            let elapsed_ms = started.elapsed().as_millis();
+            // Read the body before discarding the response: the archiver puts the actionable
+            // detail there (e.g. "range too large (max 1000 blocks)"), and `error_for_status`
+            // would throw it away, leaving callers only a bare status to reason about.
+            let body = response.text().await.unwrap_or_default();
+            let body = body.trim().to_string();
+            warn!(
+                archiver_url = %self.base_url,
+                from,
+                to,
+                span,
+                status = %status,
+                duration_ms = elapsed_ms,
+                detail = %body,
+                "📡 ❌ archiver GET /roots non-success status"
+            );
+            return Err(ArchiverStatusError {
+                status,
+                body,
+                from,
+                to,
+            }
+            .into());
+        }
+
         let entries: Vec<RootEntry> = response
             .json()
             .await

--- a/common/continuity/src/archiver.rs
+++ b/common/continuity/src/archiver.rs
@@ -35,12 +35,22 @@ struct LatestResponse {
 
 /// A non-2xx response from the archiver's HTTP API.
 ///
-/// Kept as a typed error rather than collapsing straight into `anyhow!` so callers can tell an
-/// archiver-side *client* rejection (4xx — a request the archiver will never serve, such as a
-/// block range wider than its `MAX_API_RANGE`) apart from a genuine archiver fault (5xx or a
-/// transport failure). The former is a caller mistake and must not surface as a 5xx: doing so
-/// both misleads the client and pages an operator for a request that could never have
-/// succeeded.
+/// Kept as a typed error rather than collapsing straight into `anyhow!` so callers can tell three
+/// cases apart, because they need three different answers:
+///
+/// - **Range rejection** (`400`) — a request the archiver will never serve, such as a block range
+///   wider than its `MAX_API_RANGE`, or `to < from`. A caller mistake; must not surface as a 5xx,
+///   which both misleads the client and pages an operator for a request that could never have
+///   succeeded.
+/// - **Data unavailable** (`404`) — the range is perfectly valid, but the archiver does not hold
+///   every root in it yet (`incomplete data: expected N roots ... found M`). That is a *temporary*
+///   availability gap while it catches up or backfills, so the caller should be told to retry and
+///   an operator should still see it: a persistent 404 means a real archiver gap.
+/// - **Archiver fault** (`5xx`) — a genuine server-side failure, left to the caller's fallback.
+///
+/// The 400/404 split matters: collapsing both into "client rejection" tells a caller its range was
+/// bad when the range was fine, marks a recoverable condition non-retriable, and downgrades the log
+/// out of the range an operator is paged on.
 #[derive(Debug, thiserror::Error)]
 #[error("archiver rejected GET /roots for range {from}..{to} with {status}: {body}")]
 pub struct ArchiverStatusError {
@@ -51,9 +61,19 @@ pub struct ArchiverStatusError {
 }
 
 impl ArchiverStatusError {
-    /// True when the archiver refused the request itself rather than failing to serve it.
-    pub fn is_client_rejection(&self) -> bool {
-        self.status.is_client_error()
+    /// True when the archiver refused the request itself and always will — a 4xx that is not a
+    /// `404`. Retrying an identical request cannot help.
+    ///
+    /// `404` is deliberately excluded: see [`Self::is_data_unavailable`].
+    pub fn is_range_rejection(&self) -> bool {
+        self.status.is_client_error() && self.status != reqwest::StatusCode::NOT_FOUND
+    }
+
+    /// True when the archiver accepted the range but cannot serve it *yet* — a `404`, which its
+    /// `/roots` handler returns when the store holds fewer roots than the range asks for. The same
+    /// request can succeed once the archiver has caught up, so this is retriable.
+    pub fn is_data_unavailable(&self) -> bool {
+        self.status == reqwest::StatusCode::NOT_FOUND
     }
 }
 

--- a/proof-gen-api-server/src/prom/mod.rs
+++ b/proof-gen-api-server/src/prom/mod.rs
@@ -507,6 +507,7 @@ mod labels {
         EmptyTxHashes,
         TooManyTxHashes,
         BatchSpanTooLarge,
+        ArchiverRangeRejected,
         Internal,
     }
 

--- a/proof-gen-api-server/src/prom/mod.rs
+++ b/proof-gen-api-server/src/prom/mod.rs
@@ -508,6 +508,7 @@ mod labels {
         TooManyTxHashes,
         BatchSpanTooLarge,
         ArchiverRangeRejected,
+        ArchiverDataUnavailable,
         Internal,
     }
 

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -26,18 +26,35 @@ fn classify_eth_rpc_anyhow_as_inconsistent(
     Some(ServiceError::UnsupportedBlockFormat { block_number })
 }
 
-/// If the anyhow chain carries a 4xx from the archiver, surface it as a client error rather
-/// than letting it fall through to `Internal`/`RpcUnavailable`.
+/// If the anyhow chain carries a non-2xx status from the archiver, surface the archiver's own
+/// classification rather than letting it flatten into `Internal`/`RpcUnavailable`.
 ///
-/// The archiver already answers these correctly (`400 range too large (max N blocks)`); without
-/// this the status is flattened into an opaque 5xx, which is both wrong for the caller and the
-/// reason a boundary-crossing batch pages an operator. 5xx from the archiver keeps falling
-/// through to the caller-supplied mapping — those are real faults.
+/// The archiver answers precisely, and the three cases need three different responses:
+///
+/// - `400` (`range too large (max N blocks)`, `"to" must be >= "from"`) → `ArchiverRangeRejected`,
+///   a non-retriable 400. Without this the status becomes an opaque 5xx, which is both wrong for
+///   the caller and the reason a boundary-crossing batch pages an operator.
+/// - `404` (`incomplete data: expected N roots ... found M`) → `ArchiverDataUnavailable`, a
+///   retriable 503. The range is valid; the archiver is behind or has a gap. Folding this in with
+///   the 400 case would tell the caller its range was bad, mark a recoverable state non-retriable,
+///   and drop the log below the level an operator is paged on.
+/// - `5xx` and transport failures → `None`, falling through to the caller-supplied mapping. Those
+///   are real faults and keep their existing behaviour.
 fn classify_archiver_client_rejection(err: &AnyhowError) -> Option<ServiceError> {
     let status_err = archiver::anyhow_chain_archiver_status(err)?;
-    if !status_err.is_client_rejection() {
+
+    if status_err.is_data_unavailable() {
+        return Some(ServiceError::ArchiverDataUnavailable {
+            from: status_err.from,
+            to: status_err.to,
+            detail: status_err.body.clone(),
+        });
+    }
+
+    if !status_err.is_range_rejection() {
         return None;
     }
+
     Some(ServiceError::ArchiverRangeRejected {
         from: status_err.from,
         to: status_err.to,
@@ -384,6 +401,7 @@ mod tests {
     use anyhow::Result;
     use async_trait::async_trait;
     use attestor_primitives::block::Block;
+    use axum::http::StatusCode;
     use continuity::rpc::EthRpcProvider;
     use continuity::{mocks::make_mock_providers, ContinuityBuilder, ContinuityConfig};
     use std::sync::Arc;
@@ -1285,5 +1303,97 @@ mod tests {
 
         assert_eq!(att_before, att_after, "attestation cache must be untouched");
         assert_eq!(cp_before, cp_after, "checkpoint cache must be untouched");
+    }
+
+    // ---------------------------------------------------------------------
+    // Archiver status classification.
+    //
+    // The archiver's `/roots` handler (archiver/src/api.rs) answers with three distinct
+    // meanings, and they must not be collapsed: `400` for a range it will never serve,
+    // `404` for a valid range it does not hold *yet*, and `5xx` for its own faults.
+    // ---------------------------------------------------------------------
+
+    /// Build an anyhow chain shaped like the one `ArchiverClient::get_roots` produces, so the
+    /// classifier is exercised through `anyhow_chain_archiver_status` rather than a bare value.
+    fn archiver_err(status: u16, body: &str, from: u64, to: u64) -> AnyhowError {
+        AnyhowError::new(archiver::ArchiverStatusError {
+            status: reqwest::StatusCode::from_u16(status).expect("valid status"),
+            body: body.to_string(),
+            from,
+            to,
+        })
+        .context("failed to get roots from archiver")
+    }
+
+    #[test]
+    fn archiver_400_range_too_large_is_a_non_retriable_bad_request() {
+        let err = archiver_err(
+            400,
+            "range too large (max 1000 blocks)",
+            24_996_001,
+            24_998_000,
+        );
+        let mapped = classify_archiver_client_rejection(&err).expect("400 must classify");
+
+        assert!(
+            matches!(
+                mapped,
+                ServiceError::ArchiverRangeRejected {
+                    from: 24_996_001,
+                    to: 24_998_000,
+                    ..
+                }
+            ),
+            "expected ArchiverRangeRejected, got {mapped:?}"
+        );
+        assert_eq!(mapped.status_code(), StatusCode::BAD_REQUEST);
+        assert!(
+            !mapped.retriable(),
+            "a range the archiver will never serve is not retriable"
+        );
+        assert_eq!(mapped.code(), "ArchiverRangeRejected");
+    }
+
+    #[test]
+    fn archiver_404_incomplete_data_is_a_retriable_service_unavailable() {
+        // Regression: this used to fall into `is_client_rejection` (any 4xx) and surface as a
+        // non-retriable 400, telling the caller its range was bad when the range was fine and
+        // demoting a real archiver gap out of the operator-visible log range.
+        let err = archiver_err(
+            404,
+            "incomplete data: expected 2000 roots for range 24996001..=24998000, found 1200",
+            24_996_001,
+            24_998_000,
+        );
+        let mapped = classify_archiver_client_rejection(&err).expect("404 must classify");
+
+        assert!(
+            matches!(mapped, ServiceError::ArchiverDataUnavailable { .. }),
+            "expected ArchiverDataUnavailable, got {mapped:?}"
+        );
+        assert_eq!(mapped.status_code(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            mapped.retriable(),
+            "the archiver catching up makes this retriable"
+        );
+        assert_eq!(mapped.code(), "ArchiverDataUnavailable");
+        // 503 is a server error, so `into_response` logs it at ERROR and a persistent gap
+        // still reaches an operator.
+        assert!(mapped.status_code().is_server_error());
+    }
+
+    #[test]
+    fn archiver_5xx_falls_through_to_the_caller_supplied_mapping() {
+        let err = archiver_err(500, "database is on fire", 1, 100);
+        assert!(
+            classify_archiver_client_rejection(&err).is_none(),
+            "archiver faults must keep their existing handling"
+        );
+    }
+
+    #[test]
+    fn non_archiver_errors_are_not_classified() {
+        let err = AnyhowError::msg("something else entirely");
+        assert!(classify_archiver_client_rejection(&err).is_none());
     }
 }

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 use super::*;
 use anyhow::Error as AnyhowError;
 use attestor_primitives::block::ContinuityProof;
+use continuity::archiver;
 use eth;
 
 /// If the anyhow chain wraps an [`eth::Error`] that the eth client classifies as a
@@ -23,6 +24,25 @@ fn classify_eth_rpc_anyhow_as_inconsistent(
     let block_number =
         eth::anyhow_chain_inconsistent_block_number_hint(err).unwrap_or(fallback_block_number);
     Some(ServiceError::UnsupportedBlockFormat { block_number })
+}
+
+/// If the anyhow chain carries a 4xx from the archiver, surface it as a client error rather
+/// than letting it fall through to `Internal`/`RpcUnavailable`.
+///
+/// The archiver already answers these correctly (`400 range too large (max N blocks)`); without
+/// this the status is flattened into an opaque 5xx, which is both wrong for the caller and the
+/// reason a boundary-crossing batch pages an operator. 5xx from the archiver keeps falling
+/// through to the caller-supplied mapping — those are real faults.
+fn classify_archiver_client_rejection(err: &AnyhowError) -> Option<ServiceError> {
+    let status_err = archiver::anyhow_chain_archiver_status(err)?;
+    if !status_err.is_client_rejection() {
+        return None;
+    }
+    Some(ServiceError::ArchiverRangeRejected {
+        from: status_err.from,
+        to: status_err.to,
+        detail: status_err.body.clone(),
+    })
 }
 
 /// Map an `anyhow::Error` returned by the eth provider into a `ServiceError`,
@@ -55,6 +75,9 @@ where
     F: FnOnce(AnyhowError) -> ServiceError,
 {
     if let Some(svc_err) = classify_eth_rpc_anyhow_as_inconsistent(&err, fallback_block_number) {
+        return svc_err;
+    }
+    if let Some(svc_err) = classify_archiver_client_rejection(&err) {
         return svc_err;
     }
     on_other(err)

--- a/proof-gen-api-server/src/services/errors.rs
+++ b/proof-gen-api-server/src/services/errors.rs
@@ -161,6 +161,17 @@ pub enum ServiceError {
     /// satisfy the former and still exceed the latter.
     #[error("archiver cannot serve roots for range {from}..{to}: {detail}")]
     ArchiverRangeRejected { from: u64, to: u64, detail: String },
+
+    /// The archiver accepted the roots range but does not hold every root in it yet — its `/roots`
+    /// handler answers `404 incomplete data: expected N roots ... found M`.
+    ///
+    /// Distinct from [`Self::ArchiverRangeRejected`] in every respect that matters: the range is
+    /// valid, the condition is temporary, and the same request succeeds once the archiver catches
+    /// up. So this is a retriable 503 rather than a 400, which also keeps it in the server-error
+    /// range that `into_response` logs at `ERROR` — a persistent gap here is a real archiver
+    /// problem an operator needs to see, not a caller mistake to be filed away at `WARN`.
+    #[error("archiver has not yet indexed every root for range {from}..{to}: {detail}")]
+    ArchiverDataUnavailable { from: u64, to: u64, detail: String },
 }
 
 impl ServiceError {
@@ -170,6 +181,9 @@ impl ServiceError {
             ServiceError::RpcUnavailable { .. }
                 | ServiceError::BlockNotReady { .. }
                 | ServiceError::BlockNotOnSourceChain { .. }
+                // The range is valid and the archiver will hold it once it catches up, so the
+                // identical request is worth retrying — unlike ArchiverRangeRejected.
+                | ServiceError::ArchiverDataUnavailable { .. }
         )
     }
     pub fn code(&self) -> &'static str {
@@ -196,6 +210,7 @@ impl ServiceError {
             ServiceError::EmptyTxHashes => "EmptyTxHashes",
             ServiceError::BatchSpanTooLarge { .. } => "BatchSpanTooLarge",
             ServiceError::ArchiverRangeRejected { .. } => "ArchiverRangeRejected",
+            ServiceError::ArchiverDataUnavailable { .. } => "ArchiverDataUnavailable",
         }
     }
 
@@ -214,7 +229,9 @@ impl ServiceError {
             | Self::TooManyTxHashes
             | Self::BatchSpanTooLarge { .. }
             | Self::ArchiverRangeRejected { .. } => StatusCode::BAD_REQUEST,
-            Self::RpcUnavailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
+            Self::RpcUnavailable { .. } | Self::ArchiverDataUnavailable { .. } => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
             Self::TxHashLookupUnavailable { .. } => StatusCode::NOT_IMPLEMENTED,
             Self::TxHashNotFound { .. } | Self::BlockNotOnSourceChain { .. } => {
                 StatusCode::NOT_FOUND
@@ -354,6 +371,7 @@ impl GetErrorType for ServiceError {
             ServiceError::TooManyTxHashes => ErrorType::TooManyTxHashes,
             ServiceError::BatchSpanTooLarge { .. } => ErrorType::BatchSpanTooLarge,
             ServiceError::ArchiverRangeRejected { .. } => ErrorType::ArchiverRangeRejected,
+            ServiceError::ArchiverDataUnavailable { .. } => ErrorType::ArchiverDataUnavailable,
         }
     }
 }

--- a/proof-gen-api-server/src/services/errors.rs
+++ b/proof-gen-api-server/src/services/errors.rs
@@ -150,6 +150,17 @@ pub enum ServiceError {
         span: u64,
         max_span: u64,
     },
+    /// The archiver refused the roots request itself with a 4xx — in practice a checkpoint-aligned
+    /// range wider than its `MAX_API_RANGE`.
+    ///
+    /// This is deliberately *not* `Internal`. The request cannot be served as submitted no matter
+    /// how many times it is retried, so reporting it as 5xx tells the caller the server is broken
+    /// (and that retrying is pointless for the wrong reason) while paging an operator for a request
+    /// that was never going to succeed. `max_batch_span` bounds the *transaction* spread, whereas
+    /// the archiver bounds the *checkpoint-aligned* range the proof actually needs, so a batch can
+    /// satisfy the former and still exceed the latter.
+    #[error("archiver cannot serve roots for range {from}..{to}: {detail}")]
+    ArchiverRangeRejected { from: u64, to: u64, detail: String },
 }
 
 impl ServiceError {
@@ -184,6 +195,7 @@ impl ServiceError {
             ServiceError::TooManyTxHashes => "TooManyTxHashes",
             ServiceError::EmptyTxHashes => "EmptyTxHashes",
             ServiceError::BatchSpanTooLarge { .. } => "BatchSpanTooLarge",
+            ServiceError::ArchiverRangeRejected { .. } => "ArchiverRangeRejected",
         }
     }
 
@@ -200,7 +212,8 @@ impl ServiceError {
             | Self::TooManyTxQueriesInProofQuery
             | Self::EmptyTxHashes
             | Self::TooManyTxHashes
-            | Self::BatchSpanTooLarge { .. } => StatusCode::BAD_REQUEST,
+            | Self::BatchSpanTooLarge { .. }
+            | Self::ArchiverRangeRejected { .. } => StatusCode::BAD_REQUEST,
             Self::RpcUnavailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
             Self::TxHashLookupUnavailable { .. } => StatusCode::NOT_IMPLEMENTED,
             Self::TxHashNotFound { .. } | Self::BlockNotOnSourceChain { .. } => {
@@ -340,6 +353,7 @@ impl GetErrorType for ServiceError {
             ServiceError::EmptyTxHashes => ErrorType::EmptyTxHashes,
             ServiceError::TooManyTxHashes => ErrorType::TooManyTxHashes,
             ServiceError::BatchSpanTooLarge { .. } => ErrorType::BatchSpanTooLarge,
+            ServiceError::ArchiverRangeRejected { .. } => ErrorType::ArchiverRangeRejected,
         }
     }
 }


### PR DESCRIPTION
## Problem

A `proof-batch-by-tx` request whose transactions straddle a checkpoint boundary returns **500 Internal Server Error** and logs at `ERROR`, which pages an operator. Nothing is actually broken.

Observed on cc3-testnet (`request_id=b7a4f35d-be92-4b8f-809a-c3514d8a4f62`):

```
min_query=24996801  lower_checkpoint=24996000  upper_checkpoint=24998000
archiver GET /roots from=24996001 to=24998000 span=2000
500 Internal error: failed to build continuity blocks:
    failed to get roots from archiver for range 24996001..24998000
```

The two limits involved measure **different windows**:

| Limit | Measures | Default |
|---|---|---|
| `max_batch_span` (proof-gen) | tx spread — `max_query - min_query` | 1000 |
| `MAX_API_RANGE` (archiver) | checkpoint-**aligned** roots range | 1000 |

The aligned range is always wider, because bounds are expanded outward to enclosing checkpoints. On eth-mainnet, where the checkpoint interval is also 1000, *any* batch crossing a boundary produces a 2000-block range — so it passes `max_batch_span` and is then refused by the archiver.

The archiver already answers this correctly with `400 range too large (max 1000 blocks)`. Two things then discard that:

1. `error_for_status()` in `ArchiverClient::get_roots` drops the response body, keeping only the status.
2. The error is flattened into `ServiceError::Internal`, which maps to 500 and logs via `tracing::error!`.

Result: a caller-side problem is reported as a server fault, with `retriable: false` and no indication of what to change.

## Change

Preserve the archiver's classification and honour it.

- **`common/continuity/src/archiver.rs`** — add `ArchiverStatusError { status, body, from, to }`. `get_roots` now checks the status itself, reads the body before discarding the response, and returns the typed error. Adds `anyhow_chain_archiver_status()` to find it in an error chain. The existing `warn!` gains `status` and `detail` fields.
- **`proof-gen-api-server/src/services/errors.rs`** — add `ServiceError::ArchiverRangeRejected { from, to, detail }`, mapped to **400**, code `ArchiverRangeRejected`, `retriable: false`.
- **`proof-gen-api-server/.../helpers.rs`** — `classify_archiver_client_rejection()` maps an archiver **4xx** to that variant, wired into `map_eth_rpc_anyhow_to_service_error_with` alongside the existing inconsistency classifier. Archiver **5xx** and transport failures are untouched and still surface as before.
- **`proof-gen-api-server/src/prom/mod.rs`** — matching `ErrorType::ArchiverRangeRejected` so the new variant gets its own metrics label instead of being folded into `Internal`.

## Effect

Before:
```json
HTTP 500  {"code":"Internal","message":"internal error: failed to build continuity blocks: failed to get roots from archiver for range 24996001..24998000","retriable":false}
```

After:
```json
HTTP 400  {"code":"ArchiverRangeRejected","message":"archiver cannot serve roots for range 24996001..24998000: range too large (max 1000 blocks)","retriable":false}
```

Because `ServiceError::into_response` branches on `status.is_server_error()`, this moves the log line from `tracing::error!` to `tracing::warn!` automatically — no log suppression, and a genuine archiver fault still logs at `ERROR`.

This is what softens `[CC3-TESTNET] ProofGen error logs`, which fired 3× this morning on these requests.

## Note: this reclassifies, it does not raise the limit

Boundary-crossing batches still fail — the caller now just gets a truthful 400 instead of a 500. If those batches should succeed, `MAX_API_RANGE` needs to be **≥ 2000** on eth-mainnet (worst case is two full checkpoint intervals when `max_batch_span` is 1000). That is a config change, deliberately not in this PR.

Longer term the two limits should be derived from one another (`MAX_API_RANGE ≥ max_batch_span + 2 × checkpoint_interval`) rather than both hardcoded to 1000, since the checkpoint interval differs per chain — 100 on Sepolia, 1000 on eth-mainnet.

## Scope

`get_roots` only. `get_latest` still uses `error_for_status()`; it takes no range and cannot hit this path.

## Testing

`cargo check -p continuity -p proof-gen-api-server`. No behaviour change for successful requests or for archiver 5xx/transport errors.
