### PR TITLE
Add retry on provision vm step

### DIFF
--- a/.github/provision-github-runner.sh
+++ b/.github/provision-github-runner.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 mkdir actions-runner
 pushd actions-runner || exit 1
 
-curl -L https://github.com/actions/runner/releases/download/v2.335.1/actions-runner-linux-x64-2.335.1.tar.gz > runner.tar.gz
+curl -L https://github.com/actions/runner/releases/download/v2.335.1/actions-runner-linux-x64-2.335.1.tar.gz >runner.tar.gz
 
 tar xzf ./runner.tar.gz
 sudo ./bin/installdependencies.sh
@@ -18,8 +18,8 @@ sudo chmod a+r /etc/apt/keyrings/yarn.gpg
 echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 sudo apt-get update
 sudo apt install -y build-essential clang curl gcc git-lfs jq \
-    libclang-dev llvm-dev libpq-dev libssl-dev pipx pkg-config protobuf-compiler \
-    unzip yarn
+  libclang-dev llvm-dev libpq-dev libssl-dev pipx pkg-config protobuf-compiler \
+  unzip yarn
 
 OWNER_REPO_SLUG="${LC_OWNER_REPO_SLUG}"
 REPOSITORY_URL="https://github.com/$OWNER_REPO_SLUG"
@@ -27,24 +27,24 @@ EPHEMERAL=${LC_RUNNER_EPHEMERAL:-true}
 
 # we need a temporary registration token first
 REGISTRATION_TOKEN=$(curl --silent -X POST \
-    -H "Accept: application/vnd.github+json" \
-    -H "Authorization: Bearer $LC_GITHUB_REPO_ADMIN_TOKEN" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    "https://api.github.com/repos/$OWNER_REPO_SLUG/actions/runners/registration-token" | jq -r '.token')
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $LC_GITHUB_REPO_ADMIN_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/$OWNER_REPO_SLUG/actions/runners/registration-token" | jq -r '.token')
 
 if [ "$REGISTRATION_TOKEN" == "null" ]; then
-    echo "ERROR: REGISTRATION_TOKEN is null"
-    exit 1
+  echo "ERROR: REGISTRATION_TOKEN is null"
+  exit 1
 fi
 
 if [ -z "$REGISTRATION_TOKEN" ]; then
-    echo "ERROR: REGISTRATION_TOKEN is empty"
-    exit 2
+  echo "ERROR: REGISTRATION_TOKEN is empty"
+  exit 2
 fi
 
 # Important: ephemeral runners are removed after a single job is executed on them
 # which is inline with the VM lifecycle
-./config.sh --unattended --ephemeral "$EPHEMERAL" --url "$REPOSITORY_URL" --token "$REGISTRATION_TOKEN" \
-    --name "$LC_RUNNER_VM_NAME" \
-    --labels "$LC_RUNNER_VM_NAME,workflow-$LC_WORKFLOW_ID,proxy-$LC_PROXY_ENABLED,secret-$LC_PROXY_SECRET_VARIANT,type-$LC_PROXY_TYPE"
+./config.sh --unattended --replace --ephemeral "$EPHEMERAL" --url "$REPOSITORY_URL" --token "$REGISTRATION_TOKEN" \
+  --name "$LC_RUNNER_VM_NAME" \
+  --labels "$LC_RUNNER_VM_NAME,workflow-$LC_WORKFLOW_ID,proxy-$LC_PROXY_ENABLED,secret-$LC_PROXY_SECRET_VARIANT,type-$LC_PROXY_TYPE"
 nohup ./run.sh >/dev/null 2>&1 </dev/null &

--- a/.github/provision-linode-vm.sh
+++ b/.github/provision-linode-vm.sh
@@ -25,6 +25,16 @@ EXISTING_VM_ID=$(linode-cli linodes list --json --label "$LC_RUNNER_VM_NAME" | j
 if [ -n "$EXISTING_VM_ID" ]; then
   echo "INFO: deleting leftover VM $EXISTING_VM_ID (label $LC_RUNNER_VM_NAME) from a prior attempt"
   linode-cli linodes delete "$EXISTING_VM_ID"
+
+  # delete is async - creating a VM with the same label before it finishes
+  # fails on a label conflict, since Linode labels must be unique.
+  echo "INFO: waiting for $EXISTING_VM_ID to finish deleting ..."
+  for attempt in $(seq 1 12); do
+    STILL_THERE=$(linode-cli linodes list --json --label "$LC_RUNNER_VM_NAME" | jq -r '.[0].id // empty')
+    [ -z "$STILL_THERE" ] && break
+    echo "DEBUG: $EXISTING_VM_ID still present on attempt $attempt, retrying ..."
+    sleep 5
+  done
 fi
 
 # retry until we get a VM
@@ -121,8 +131,9 @@ set -euo pipefail
 echo "INFO: installing upstream Docker Engine ..."
 run_remote_script .github/install-docker-engine-from-upstream.sh
 
-# NOTE: deliberately NOT retried - a partial run may already have registered the
-# runner with GitHub, and a second attempt would register a duplicate.
+# NOTE: not retried internally (still safe under the step-level retry in
+# deploy-runner.yml - provision-github-runner.sh's config.sh uses --replace,
+# so re-registering under the same name on a retried attempt is not an error).
 echo "INFO: provisioning GitHub runner ..."
 vm_ssh -o SendEnv=LC_GITHUB_REPO_ADMIN_TOKEN,LC_RUNNER_VM_NAME,LC_WORKFLOW_ID,LC_PROXY_ENABLED,LC_PROXY_SECRET_VARIANT,LC_PROXY_TYPE \
   "$SSH_USER_AT_HOSTNAME" <.github/provision-github-runner.sh

--- a/.github/provision-linode-vm.sh
+++ b/.github/provision-linode-vm.sh
@@ -7,6 +7,10 @@ python3 --version
 pip install -r .github/requirements.txt
 linode-cli --version
 
+# retry action re-runs this in the same workspace; reset prior attempt's state
+rm -f ~/.ssh/id_rsa ~/.ssh/id_rsa.pub
+git checkout -- .github/authorized_keys .github/linode-cloud-init.template
+
 # Authorize hosted-runner
 mkdir -p ~/.ssh/
 ssh-keygen -q -t rsa -N '' -f ~/.ssh/id_rsa

--- a/.github/provision-linode-vm.sh
+++ b/.github/provision-linode-vm.sh
@@ -10,47 +10,53 @@ linode-cli --version
 # Authorize hosted-runner
 mkdir -p ~/.ssh/
 ssh-keygen -q -t rsa -N '' -f ~/.ssh/id_rsa
-cat ~/.ssh/id_rsa.pub >> .github/authorized_keys
-
+cat ~/.ssh/id_rsa.pub >>.github/authorized_keys
 
 # Provision VM
 echo "INFO: From ENVs: RUNNER_VM_NAME=$LC_RUNNER_VM_NAME"
 
 # inject authorized keys into cloud-init for the `ubuntu@` user
 while read -r LINE; do
-  echo "      - $LINE" >> .github/linode-cloud-init.template
-done < .github/authorized_keys
+  echo "      - $LINE" >>.github/linode-cloud-init.template
+done <.github/authorized_keys
+
+echo "INFO: checking for a leftover VM from a prior attempt ..."
+EXISTING_VM_ID=$(linode-cli linodes list --json --label "$LC_RUNNER_VM_NAME" | jq -r '.[0].id // empty')
+if [ -n "$EXISTING_VM_ID" ]; then
+  echo "INFO: deleting leftover VM $EXISTING_VM_ID (label $LC_RUNNER_VM_NAME) from a prior attempt"
+  linode-cli linodes delete "$EXISTING_VM_ID"
+fi
 
 # retry until we get a VM
 IP_ADDRESS=""
 COUNTER=0
 while [ -z "$IP_ADDRESS" ]; do
-    # if all jobs retry rate-limited queries at the same time they still hit the limit
-    # and subsequently fail. Max number of retries is hard-coded to 3 in linodecli
-    # use up to 60 sec random delay to avoid everything being scheduled at once!
-    sleep $((RANDOM % 60))
+  # if all jobs retry rate-limited queries at the same time they still hit the limit
+  # and subsequently fail. Max number of retries is hard-coded to 3 in linodecli
+  # use up to 60 sec random delay to avoid everything being scheduled at once!
+  sleep $((RANDOM % 60))
 
-    VM_KIND=${VM_KIND:-github-provisioned-runner}
-    echo "INFO: VM_KIND=$VM_KIND"
+  VM_KIND=${VM_KIND:-github-provisioned-runner}
+  echo "INFO: VM_KIND=$VM_KIND"
 
-    KEEP_UNTIL=${KEEP_UNTIL:-$(date --utc "+%Y-%m-%dT%H:%M:%S" -d "+5 hours")}
-    echo "INFO: KEEP_UNTIL=$KEEP_UNTIL UTC"
+  KEEP_UNTIL=${KEEP_UNTIL:-$(date --utc "+%Y-%m-%dT%H:%M:%S" -d "+5 hours")}
+  echo "INFO: KEEP_UNTIL=$KEEP_UNTIL UTC"
 
-    # WARNING: we do not specify --authorized_keys for root b/c
-    # linode-cli expects each key as a separate argument and iteratively constructing
-    # the argument list hits issues with quoting the jey values b/c of white-space.
-    # All SSH logins should be via the `ubuntu@` user. For more info see:
-    # https://www.linode.com/community/questions/21290/how-to-pass-multiple-ssh-public-keys-with-linode-cli-linodes-create
-    linode-cli linodes create --json \
-        --image 'linode/ubuntu26.04' --region "$LINODE_REGION" \
-        --type "$LINODE_VM_SIZE" --label "$LC_RUNNER_VM_NAME" \
-        --root_pass "$(uuidgen)" --backups_enabled false --booted true --private_ip false \
-        --tags "$VM_KIND" --tags "keep_until_$KEEP_UNTIL" \
-        --metadata.user_data "$(base64 --wrap 0 < .github/linode-cloud-init.template)" > "retry_$COUNTER.json"
+  # WARNING: we do not specify --authorized_keys for root b/c
+  # linode-cli expects each key as a separate argument and iteratively constructing
+  # the argument list hits issues with quoting the jey values b/c of white-space.
+  # All SSH logins should be via the `ubuntu@` user. For more info see:
+  # https://www.linode.com/community/questions/21290/how-to-pass-multiple-ssh-public-keys-with-linode-cli-linodes-create
+  linode-cli linodes create --json \
+    --image 'linode/ubuntu26.04' --region "$LINODE_REGION" \
+    --type "$LINODE_VM_SIZE" --label "$LC_RUNNER_VM_NAME" \
+    --root_pass "$(uuidgen)" --backups_enabled false --booted true --private_ip false \
+    --tags "$VM_KIND" --tags "keep_until_$KEEP_UNTIL" \
+    --metadata.user_data "$(base64 --wrap 0 <.github/linode-cloud-init.template)" >"retry_$COUNTER.json"
 
-    IP_ADDRESS=$(jq -r '.[0].ipv4[0]' < "retry_$COUNTER.json")
+  IP_ADDRESS=$(jq -r '.[0].ipv4[0]' <"retry_$COUNTER.json")
 
-    (( COUNTER=COUNTER+1 ))
+  ((COUNTER = COUNTER + 1))
 done
 
 # provision the GitHub Runner binary on the VM
@@ -62,7 +68,7 @@ echo "INFO: $SSH_USER_AT_HOSTNAME"
 # still-booting VM fails fast enough to be retried instead of hanging.
 vm_ssh() {
   ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no \
-      -o ConnectTimeout=30 -o ServerAliveInterval=15 -o ServerAliveCountMax=4 "$@"
+    -o ConnectTimeout=30 -o ServerAliveInterval=15 -o ServerAliveCountMax=4 "$@"
 }
 
 # make sure we have ssh connectivity first by retrying multiple times
@@ -94,7 +100,7 @@ run_remote_script() {
   local script="$1"
   local attempt
   for attempt in 1 2 3; do
-    if vm_ssh "$SSH_USER_AT_HOSTNAME" < "$script"; then
+    if vm_ssh "$SSH_USER_AT_HOSTNAME" <"$script"; then
       return 0
     fi
     echo "DEBUG: $script failed on attempt $attempt, retrying ..."
@@ -119,4 +125,4 @@ run_remote_script .github/install-docker-engine-from-upstream.sh
 # runner with GitHub, and a second attempt would register a duplicate.
 echo "INFO: provisioning GitHub runner ..."
 vm_ssh -o SendEnv=LC_GITHUB_REPO_ADMIN_TOKEN,LC_RUNNER_VM_NAME,LC_WORKFLOW_ID,LC_PROXY_ENABLED,LC_PROXY_SECRET_VARIANT,LC_PROXY_TYPE \
-  "$SSH_USER_AT_HOSTNAME" < .github/provision-github-runner.sh
+  "$SSH_USER_AT_HOSTNAME" <.github/provision-github-runner.sh

--- a/.github/workflows/deploy-runner.yml
+++ b/.github/workflows/deploy-runner.yml
@@ -38,7 +38,7 @@ permissions: read-all
 
 jobs:
   deploy-runner:
-    timeout-minutes: 15
+    timeout-minutes: 25
     name: proxy=${{ inputs.proxy }} / ${{ inputs.secret }} / type=${{ inputs.proxy_type }}
     runs-on: ubuntu-26.04
     steps:
@@ -59,8 +59,12 @@ jobs:
 
       - name: Provision VM
         if: env.LC_GITHUB_REPO_ADMIN_TOKEN
-        run: |
-          .github/provision-linode-vm.sh
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 2
+          retry_wait_seconds: 15
+          command: .github/provision-linode-vm.sh
         env:
           LC_OWNER_REPO_SLUG: ${{ github.repository }}
           LC_GITHUB_REPO_ADMIN_TOKEN: ${{ secrets.GH_REPO_ADMIN_TOKEN }}


### PR DESCRIPTION
# Description of proposed changes

Add retry on provision vm step to auto retry. This is to deal with observed flakiness on provisioning the linode VMs like here
https://github.com/gluwa/creditcoin3/actions/runs/32716048024/job/97397433527?pr=1276
https://github.com/gluwa/creditcoin3/actions/runs/32713702536/job/97390385314?pr=1274

---

When merging this PR:

- For PRs against `usc-dev` use the "Squash and merge" button
- For PRs against `usc-testnet`/`main` use the "Create a merge commit" button
- Hotfixes against `usc-testnet`/`main` should use the "Squash and merge" button

---

Practical tips for PR review:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
