### PR TITLE
fix(ci): repoint bridge example workflow calls at the renamed repo (unblocks all CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1798,7 +1798,7 @@ jobs:
     uses: gluwa/usc-testnet-bridge-examples/.github/workflows/hello-bridge.yml@main
     with:
       source_chain_kind: "anvil"
-      usc_kind: "local"
+      asc_kind: "local"
       checkout_repo: "gluwa/usc-testnet-bridge-examples"
       checkout_ref: "main"
 
@@ -1810,7 +1810,7 @@ jobs:
     uses: gluwa/usc-testnet-bridge-examples/.github/workflows/custom-contracts-bridging.yml@main
     with:
       source_chain_kind: "anvil"
-      usc_kind: "local"
+      asc_kind: "local"
       checkout_repo: "gluwa/usc-testnet-bridge-examples"
       checkout_ref: "main"
 
@@ -1822,7 +1822,7 @@ jobs:
     uses: gluwa/usc-testnet-bridge-examples/.github/workflows/bridge-offchain-worker.yml@main
     with:
       source_chain_kind: "anvil"
-      usc_kind: "local"
+      asc_kind: "local"
       checkout_repo: "gluwa/usc-testnet-bridge-examples"
       checkout_ref: "main"
 
@@ -1835,7 +1835,7 @@ jobs:
     with:
       runs-on: "['ubuntu-26.04']"
       source_chain_kind: "anvil"
-      usc_kind: "local"
+      asc_kind: "local"
       checkout_repo: "gluwa/usc-testnet-bridge-examples"
       checkout_ref: "main"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1795,11 +1795,11 @@ jobs:
       - build-creditcoin-node-for-testing-ci
       - should-run
     if: ${{ needs.should-run.outputs.integration_test_blockchain == 'true' }}
-    uses: gluwa/usc-testnet-bridge-examples/.github/workflows/hello-bridge.yml@main
+    uses: gluwa/attestcoin-protocol-examples/.github/workflows/hello-bridge.yml@main
     with:
       source_chain_kind: "anvil"
       asc_kind: "local"
-      checkout_repo: "gluwa/usc-testnet-bridge-examples"
+      checkout_repo: "gluwa/attestcoin-protocol-examples"
       checkout_ref: "main"
 
   custom-contracts-bridging:
@@ -1807,11 +1807,11 @@ jobs:
       - build-creditcoin-node-for-testing-ci
       - should-run
     if: ${{ needs.should-run.outputs.integration_test_blockchain == 'true' }}
-    uses: gluwa/usc-testnet-bridge-examples/.github/workflows/custom-contracts-bridging.yml@main
+    uses: gluwa/attestcoin-protocol-examples/.github/workflows/custom-contracts-bridging.yml@main
     with:
       source_chain_kind: "anvil"
       asc_kind: "local"
-      checkout_repo: "gluwa/usc-testnet-bridge-examples"
+      checkout_repo: "gluwa/attestcoin-protocol-examples"
       checkout_ref: "main"
 
   bridge-offchain-worker:
@@ -1819,11 +1819,11 @@ jobs:
       - build-creditcoin-node-for-testing-ci
       - should-run
     if: ${{ needs.should-run.outputs.integration_test_blockchain == 'true' }}
-    uses: gluwa/usc-testnet-bridge-examples/.github/workflows/bridge-offchain-worker.yml@main
+    uses: gluwa/attestcoin-protocol-examples/.github/workflows/bridge-offchain-worker.yml@main
     with:
       source_chain_kind: "anvil"
       asc_kind: "local"
-      checkout_repo: "gluwa/usc-testnet-bridge-examples"
+      checkout_repo: "gluwa/attestcoin-protocol-examples"
       checkout_ref: "main"
 
   loan-flow:
@@ -1831,12 +1831,12 @@ jobs:
       - build-creditcoin-node-for-testing-ci
       - should-run
     if: ${{ needs.should-run.outputs.integration_test_blockchain == 'true' }}
-    uses: gluwa/usc-testnet-bridge-examples/.github/workflows/loan-flow.yml@main
+    uses: gluwa/attestcoin-protocol-examples/.github/workflows/loan-flow.yml@main
     with:
       runs-on: "['ubuntu-26.04']"
       source_chain_kind: "anvil"
       asc_kind: "local"
-      checkout_repo: "gluwa/usc-testnet-bridge-examples"
+      checkout_repo: "gluwa/attestcoin-protocol-examples"
       checkout_ref: "main"
 
   archiver-testing:


### PR DESCRIPTION
## Problem

Every `CI` workflow run since ~2026-08-24 19:00 UTC has failed at **startup** with zero jobs, on every branch. The run shows up named `.github/workflows/ci.yml` instead of `CI`, GitHub's signature for a workflow it could not load:

```
Invalid workflow file: .github/workflows/ci.yml#L1810
error parsing called workflow ".github/workflows/ci.yml"
  -> "gluwa/usc-testnet-bridge-examples/.github/workflows/custom-contracts-bridging.yml@main"
  : workflow was not found
```

Because no job is ever created, the `should-run` gate never reports. `should-run` is a required status check on `usc-dev`:

```
$ gh api repos/gluwa/creditcoin3/branches/usc-dev/protection --jq .required_status_checks.contexts
["MegaLinter","should-run"]
```

so branch protection renders it as an unreported, unclickable "Expected - waiting for status to be reported" row and every open PR is blocked. #1281 is one example.

## Cause

Two independent breakages, both from the same downstream repo, both reachable because `ci.yml` calls it at a floating `@main`:

1. **The repo was renamed.** `gluwa/usc-testnet-bridge-examples` is now `gluwa/attestcoin-protocol-examples`. GitHub Actions does **not** follow repo renames when resolving a cross-repo `uses:` reference, so all four calls fail to resolve and the run dies at load time. Note the REST API *does* follow the rename redirect, so the old path still looks alive when probed with `gh`: `gh api repos/gluwa/usc-testnet-bridge-examples` quietly answers as `gluwa/attestcoin-protocol-examples`.

2. **A `workflow_call` input was renamed.** Commit `40541b10` ("USC -> ASC renames", #97) renamed `usc_kind` to `asc_kind` in all four workflows. Passing an undeclared input to a reusable workflow is also a load-time error, so this would have been the next startup failure after fixing (1).

No commit in this repo was needed to trigger either.

## Fix

- Repoint the four `uses:` refs (and their `checkout_repo` inputs) at `gluwa/attestcoin-protocol-examples`.
- Rename the input `usc_kind` to `asc_kind` at all four call sites.

## Verification

CI now loads and runs on this PR ([run 32952477492](https://github.com/gluwa/creditcoin3/actions/runs/32952477492)): the run is named `CI`, jobs are created, and `should-run` completed **success**, versus zero jobs on the run immediately before ([32951691020](https://github.com/gluwa/creditcoin3/actions/runs/32951691020)).

Also checked:

- All four cross-repo calls match the contract on `@main`: both required inputs (`asc_kind`, `source_chain_kind`) supplied, nothing undeclared, no `secrets` required.
- Swept all six in-repo `uses: ./...` reusable calls: no undeclared or missing-required inputs, no dangling `needs`, no undeclared `needs.*.outputs.*` references.

## Follow-up (not in this PR)

- These four calls are still pinned to `@main`. A rename or an input change downstream can take out all of creditcoin3 CI again, exactly as it did twice this week. Worth pinning to a SHA or tag.
- `README.md:17` and `.github/CONTRIBUTING.md:353` still link to the old repo name. Those redirect fine in a browser, so I left them out of this CI fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
