### PR TITLE
ci: revive the ABI drift gate and point it at asc-contracts

### DIFF
--- a/.github/workflows/write-ability-e2e.yml
+++ b/.github/workflows/write-ability-e2e.yml
@@ -19,7 +19,7 @@ name: write-ability-e2e
 "on":
   workflow_dispatch:
   pull_request:
-    branches: [main, usc-dev, usc-testnet, attestor_v2]
+    branches: [main, usc-dev, usc-testnet, attestor_v2, writeability-off-usc-dev]
     paths:
       - "attestor/**"
       - "common/**"
@@ -108,18 +108,18 @@ jobs:
           # the *same* relayer code — `ref: main` made the e2e non-reproducible (the same commit
           # could pass or fail as the relayer's default branch moved). Bump this deliberately when
           # a relayer change needs to be exercised here.
-          ref: 62f17fdcbc5a2e917e6ce1199c21d5d9440e9177 # main @ 2026-08-20 (#39) — resynced to usc-contracts #23 (AckAndClaim); bump deliberately
+          ref: ea6a0b2802f878b51f8943a74baec9eb60931d92 # v0.5.0 (#43) — cursor persistence, settlement metrics, genesis fallback; bump deliberately
           path: usc-message-relayer
 
       # Fee-integrated write-ability contracts. The plain-ethers deploy scripts read their compiled
-      # artifacts from here (via $USC_CONTRACTS_DIR); pinned to a full SHA so the e2e is reproducible.
-      - name: Check out usc-contracts (fee-integrated contracts)
+      # artifacts from here (via $ASC_CONTRACTS_DIR); pinned to a full SHA so the e2e is reproducible.
+      - name: Check out asc-contracts (fee-integrated contracts)
         uses: actions/checkout@v6
         with:
-          repository: gluwa/usc-contracts
+          repository: gluwa/asc-contracts
           ref: e300c16676efc850a5b382033d666bc9c3a0ce23 # main @ 2026-08-17 (post-#23/#28 v3 RelayerQuote struct) — bump deliberately
-          path: usc-contracts
-          # usc-contracts is private; the default GITHUB_TOKEN is scoped to creditcoin3 only and
+          path: asc-contracts
+          # asc-contracts is private; the default GITHUB_TOKEN is scoped to creditcoin3 only and
           # gets "Repository not found". Use the org bot PAT (same one build-native uses cross-repo).
           token: ${{ secrets.GLUWA_BOT_TOKEN }}
 
@@ -156,22 +156,25 @@ jobs:
         # tsx and need ethers / @polkadot/api / express from usc-messaging's own package.
         run: npm install
 
-      - name: Build usc-contracts artifacts (fee stack)
-        working-directory: ./usc-contracts
-        # `npm install` (not `npm ci`): usc-contracts' committed lockfile can lag its package.json
+      - name: Build asc-contracts artifacts (fee stack)
+        working-directory: ./asc-contracts
+        # `npm install` (not `npm ci`): asc-contracts' committed lockfile can lag its package.json
         # at the pinned SHA (e.g. a missing @openzeppelin/contracts entry), which `npm ci` rejects.
         # We only need the compiled artifacts, so tolerate the drift and resolve on the fly.
         run: |
           npm install
           npx hardhat compile
-          echo "USC_CONTRACTS_DIR=$GITHUB_WORKSPACE/usc-contracts" >> "$GITHUB_ENV"
+          echo "ASC_CONTRACTS_DIR=$GITHUB_WORKSPACE/asc-contracts" >> "$GITHUB_ENV"
+          # Fail the gate rather than skip it if the dir ever goes missing (see ABI_GATE_STRICT).
+          echo "ABI_GATE_STRICT=1" >> "$GITHUB_ENV"
 
       # Solidity↔Rust drift gate: every function/event the attestor's sol! mirror binds must have a
       # byte-identical selector/topic0 in the artifacts compiled above. This is the only CI job with
-      # both a Rust toolchain and compiled usc-contracts, so the check lives here — a pin bump that
+      # both a Rust toolchain and compiled asc-contracts, so the check lives here — a pin bump that
       # moves a mirrored surface fails THIS step naming the drifted item, instead of a revert (or a
-      # silently dead topic filter) somewhere in the e2e below. Without USC_CONTRACTS_DIR the test
-      # no-ops, so plain `cargo test` runs elsewhere are unaffected.
+      # silently dead topic filter) somewhere in the e2e below. ABI_GATE_STRICT is set above so a
+      # missing artifacts dir fails here instead of no-opping; plain `cargo test` runs elsewhere
+      # leave it unset and still skip.
       - name: ABI-surface drift check (Rust mirror vs compiled contracts)
         run: |
           rustup show active-toolchain || rustup toolchain install

--- a/.github/workflows/write-ability-e2e.yml
+++ b/.github/workflows/write-ability-e2e.yml
@@ -165,6 +165,9 @@ jobs:
           npm install
           npx hardhat compile
           echo "ASC_CONTRACTS_DIR=$GITHUB_WORKSPACE/asc-contracts" >> "$GITHUB_ENV"
+          # Also export the pre-rename name: the usc-messaging deploy scripts accept either,
+          # but anything else that still reads only the old one keeps working.
+          echo "USC_CONTRACTS_DIR=$GITHUB_WORKSPACE/asc-contracts" >> "$GITHUB_ENV"
           # Fail the gate rather than skip it if the dir ever goes missing (see ABI_GATE_STRICT).
           echo "ABI_GATE_STRICT=1" >> "$GITHUB_ENV"
 

--- a/common/write-ability/tests/abi_surface.rs
+++ b/common/write-ability/tests/abi_surface.rs
@@ -1,6 +1,6 @@
 //! Solidity ↔ Rust ABI-surface drift detector.
 //!
-//! `src/abi.rs` is a hand-trimmed `sol!` mirror of the usc-contracts surface the attestor calls.
+//! `src/abi.rs` is a hand-trimmed `sol!` mirror of the asc-contracts surface the attestor calls.
 //! Nothing enforces that the mirror stays byte-identical with the contracts: creditcoin3↔relayer
 //! agreement is policed by the shared golden vectors, but Solidity↔Rust drift was only caught
 //! implicitly, three layers deep, when the e2e's delivery reverted (or worse, when a topic filter
@@ -8,11 +8,11 @@
 //!
 //! This test closes that leg: for every mirrored function and event, recompute the selector /
 //! topic0 from the Rust `sol!` types and assert an identical one exists in the compiled hardhat
-//! artifact. It runs wherever `USC_CONTRACTS_DIR` points at a compiled usc-contracts checkout —
+//! artifact. It runs wherever `ASC_CONTRACTS_DIR` points at a compiled asc-contracts checkout —
 //! locally, and in the `write-ability-e2e` workflow, which exports exactly that variable — so a
-//! usc-contracts pin bump that moves a mirrored surface fails HERE, naming the drifted item,
+//! asc-contracts pin bump that moves a mirrored surface fails HERE, naming the drifted item,
 //! instead of somewhere downstream. Without the env var the test is a no-op (unit-test runs and
-//! CI jobs that don't check out usc-contracts stay green).
+//! CI jobs that don't check out asc-contracts stay green).
 //!
 //! `IChainInfo` is deliberately NOT covered: it mirrors this repo's own chain-info precompile
 //! (`precompiles/chain-info`), not a usc-contracts artifact, and drift there is caught by the
@@ -88,17 +88,32 @@ fn assert_function_mirrored(artifact: &std::path::Path, rust_signature: &str, se
 
 #[test]
 fn mirrored_abi_surface_matches_compiled_contracts() {
-    let Ok(dir) = std::env::var("USC_CONTRACTS_DIR") else {
+    // `ASC_CONTRACTS_DIR` since the repository was renamed usc-contracts -> asc-contracts;
+    // `USC_CONTRACTS_DIR` stays accepted so existing local setups keep working.
+    let dir = std::env::var("ASC_CONTRACTS_DIR")
+        .or_else(|_| std::env::var("USC_CONTRACTS_DIR"))
+        .ok();
+    // Set by CI alongside the artifacts dir. Without it an unset dir skips, which is what a plain
+    // `cargo test` on a dev machine wants — but it also silently no-opped this gate in CI for
+    // weeks, so any environment that means to enforce the gate sets this and gets a failure
+    // instead of a pass.
+    let strict = std::env::var("ABI_GATE_STRICT").is_ok();
+    let Some(dir) = dir else {
+        assert!(
+            !strict,
+            "ABI_GATE_STRICT is set but neither ASC_CONTRACTS_DIR nor USC_CONTRACTS_DIR is — the \
+             drift gate would have silently passed without checking anything"
+        );
         eprintln!(
-            "USC_CONTRACTS_DIR not set — skipping ABI-surface check (run against a compiled \
-             usc-contracts checkout to enable; the write-ability-e2e workflow does)"
+            "ASC_CONTRACTS_DIR not set — skipping ABI-surface check (point it at a compiled \
+             asc-contracts checkout to enable; the write-ability-e2e workflow does)"
         );
         return;
     };
     let contracts = std::path::Path::new(&dir).join("artifacts/contracts/write-ability");
     assert!(
         contracts.is_dir(),
-        "USC_CONTRACTS_DIR is set but {} does not exist — run `npx hardhat compile` there first",
+        "contracts dir is set but {} does not exist — run `npx hardhat compile` there first",
         contracts.display()
     );
 

--- a/usc-messaging/scripts/add-quoter.mts
+++ b/usc-messaging/scripts/add-quoter.mts
@@ -5,7 +5,7 @@
 import { ethers } from "ethers";
 import { readFileSync } from "node:fs";
 
-const UC = process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/usc-contracts";
+const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/asc-contracts";
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 

--- a/usc-messaging/scripts/deploy-dest-devnet.mts
+++ b/usc-messaging/scripts/deploy-dest-devnet.mts
@@ -1,10 +1,10 @@
 // usc-dev destination-stack deploy (real Sepolia): SimpleInbox + MockDestination, REUSING the
 // live EOAValidator (attestor _3 + relayer 0.1.1 already speak it; set is synced 10/7).
-// Env: SEPOLIA_RPC, DEPLOYER_KEY. Artifacts from $USC_CONTRACTS_DIR (post-#23 build).
+// Env: SEPOLIA_RPC, DEPLOYER_KEY. Artifacts from $ASC_CONTRACTS_DIR (post-#23 build).
 import { ethers } from "ethers";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 
-const UC = process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/usc-contracts";
+const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/asc-contracts";
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 

--- a/usc-messaging/scripts/deploy-dest-ethers.mts
+++ b/usc-messaging/scripts/deploy-dest-ethers.mts
@@ -6,8 +6,8 @@ import { ethers } from "ethers";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-// usc-contracts checkout: $USC_CONTRACTS_DIR, else the sibling of this repo (…/Projects/usc-contracts).
-const UC = process.env.USC_CONTRACTS_DIR ?? fileURLToPath(new URL("../../../usc-contracts", import.meta.url));
+// asc-contracts checkout: $ASC_CONTRACTS_DIR, else the sibling of this repo (…/Projects/asc-contracts).
+const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? fileURLToPath(new URL("../../../asc-contracts", import.meta.url));
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 

--- a/usc-messaging/scripts/deploy-source-devnet.mts
+++ b/usc-messaging/scripts/deploy-source-devnet.mts
@@ -5,7 +5,7 @@
 import { ethers } from "ethers";
 import { readFileSync, writeFileSync } from "node:fs";
 
-const UC = process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/usc-contracts";
+const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/asc-contracts";
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 

--- a/usc-messaging/scripts/deploy-source-ethers.mts
+++ b/usc-messaging/scripts/deploy-source-ethers.mts
@@ -9,8 +9,8 @@ import { cryptoWaitReady } from "@polkadot/util-crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-// usc-contracts checkout: $USC_CONTRACTS_DIR, else the sibling of this repo (…/Projects/usc-contracts).
-const UC = process.env.USC_CONTRACTS_DIR ?? fileURLToPath(new URL("../../../usc-contracts", import.meta.url));
+// asc-contracts checkout: $ASC_CONTRACTS_DIR, else the sibling of this repo (…/Projects/asc-contracts).
+const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? fileURLToPath(new URL("../../../asc-contracts", import.meta.url));
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 

--- a/usc-messaging/scripts/fix-fee-registry.mts
+++ b/usc-messaging/scripts/fix-fee-registry.mts
@@ -4,7 +4,7 @@
 import { ethers } from "ethers";
 import { readFileSync, writeFileSync } from "node:fs";
 
-const UC = process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/usc-contracts";
+const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/asc-contracts";
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 const OUT = process.env.DEPLOY_OUT ?? "/tmp/usc-dev-deploy.json";

--- a/usc-messaging/scripts/fix-validator.mts
+++ b/usc-messaging/scripts/fix-validator.mts
@@ -5,7 +5,7 @@
 import { ethers } from "ethers";
 import { readFileSync, writeFileSync } from "node:fs";
 
-const UC = process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/usc-contracts";
+const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/asc-contracts";
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 const OUT = process.env.DEPLOY_OUT ?? "/tmp/usc-dev-deploy.json";

--- a/usc-messaging/scripts/set-oracle-devnet.mts
+++ b/usc-messaging/scripts/set-oracle-devnet.mts
@@ -8,7 +8,7 @@
 import { ethers } from "ethers";
 import { readFileSync } from "node:fs";
 
-const UC = process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/usc-contracts";
+const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/asc-contracts";
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 


### PR DESCRIPTION
## Why

The write-ability e2e is the only CI job with both a Rust toolchain and compiled contracts, so it is where the Solidity↔Rust ABI drift gate runs. It triggers on `[main, usc-dev, usc-testnet, attestor_v2]` — and **not** on `writeability-off-usc-dev`, which is where every single write-ability PR targets.

So the gate has never run on any of them. `gh pr checks 1278 | grep -c write-ability-e2e` returns `0`. The mirrors are currently correct by luck rather than by enforcement.

Two related staleness problems in the same file: the pinned relayer is `62f17fdc` = **v0.2.0**, three releases behind, so the e2e exercises none of the cursor persistence, settlement metrics, rotation-resume or genesis-fallback code the fleet actually runs. And the contracts checkout still names `gluwa/usc-contracts`, which only resolves via GitHub's redirect after the rename to `asc-contracts`.

## What

- Add `writeability-off-usc-dev` to the e2e trigger branches.
- Bump the relayer pin to `ea6a0b28` (v0.5.0, #43).
- Follow the rename: `gluwa/asc-contracts`, checkout path `asc-contracts`, env var `ASC_CONTRACTS_DIR`.
- **The gate no longer fails open.** CI additionally exports `ABI_GATE_STRICT=1`, and the test now asserts rather than skips when no contracts dir is set. `USC_CONTRACTS_DIR` is still honoured so existing local setups keep working, and a plain `cargo test` with neither variable set still skips — which is what a dev machine wants.

## Verified

`cargo test -p write-ability --test abi_surface` skips as before; the same test with `ABI_GATE_STRICT=1` and no dir fails with the explanatory message. `cargo fmt --check` clean, clippy clean, workflow YAML parses.

## Note

This makes the e2e run on write-ability PRs for the first time, so expect the first few runs to surface real problems rather than green ticks. That is the point, but it is worth knowing before merging into a release week.
