### PR TITLE
fix(attestor): distinguish unregistered from already-registered in startup log

### DIFF
--- a/attestor/attestor/src/startup.rs
+++ b/attestor/attestor/src/startup.rs
@@ -55,9 +55,25 @@ pub async fn register_bls(
     bls_key: &bls_signatures::PrivateKey,
 ) -> Result<(), Error> {
     let status = cc3.get_attestor_status(chain_key).await?;
-    if status != Some(AttestorStatus::Idle) {
-        tracing::info!(?status, %account_id, "ℹ️ skipping attest() — already registered");
-        return Ok(());
+    match status {
+        Some(AttestorStatus::Idle) => {}
+        // Not in the attestor pool at all. `attest()` cannot be self-served from
+        // here — a stash has to call `register_attestor` first — so skipping is
+        // correct, but say why rather than reporting the opposite.
+        None => {
+            tracing::warn!(
+                %account_id,
+                chain_key,
+                "⚠️ not registered as an attestor for this chain — skipping attest(). \
+                 A stash account must call register_attestor(chain_key, attestor_id) first, \
+                 using an account other than the attestor itself."
+            );
+            return Ok(());
+        }
+        Some(other) => {
+            tracing::info!(status = ?other, %account_id, "ℹ️ skipping attest() — already registered");
+            return Ok(());
+        }
     }
 
     // bls_signatures uses BLS12-381 minimal-pubkey-size: public key is 48 bytes (G1),


### PR DESCRIPTION
`register_bls` logs "skipping attest() — already registered" for **any** status
other than `Idle`, including `None`. `None` means the account is not in the
attestor pool at all — the opposite of what the message says.

The behaviour is correct (`attest()` is only valid from `Idle`, and only a stash
can put an account there via `register_attestor`), so this changes diagnostics only.

When bringing up an attestor for a new source chain the log currently reads as
healthy — balance ok, "already registered", waiting on election — while the
attestor is in fact unregistered and will wait forever. The `status=None` field
contradicts the message next to it, so it reads as noise. This cost us several
hours before we read the source.

The patch splits the three cases and, for `None`, points at the actual fix: a
stash must call `register_attestor(chain_key, attestor_id)` with an account other
than the attestor itself.

No behaviour change, so no new tests.