### PR TITLE
fix(usc-messaging): wire a real FeeRegistry, and stop defaulting to a personal path

### DIFF
--- a/usc-messaging/scripts/add-quoter.mts
+++ b/usc-messaging/scripts/add-quoter.mts
@@ -5,7 +5,21 @@
 import { ethers } from "ethers";
 import { readFileSync } from "node:fs";
 
-const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/asc-contracts";
+function ascContractsDir(): string {
+  // ASC_CONTRACTS_DIR since the repo was renamed usc-contracts -> asc-contracts; the old name is
+  // still accepted so existing setups keep working. Deliberately no default: this used to fall
+  // back to one developer's home directory, so anyone else got a confusing "cannot read artifact"
+  // three calls later instead of being told what to set.
+  const dir = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR;
+  if (!dir) {
+    throw new Error(
+      "set ASC_CONTRACTS_DIR to a compiled asc-contracts checkout (run `npx hardhat compile` there first)",
+    );
+  }
+  return dir;
+}
+
+const UC = ascContractsDir();
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 

--- a/usc-messaging/scripts/deploy-dest-devnet.mts
+++ b/usc-messaging/scripts/deploy-dest-devnet.mts
@@ -4,7 +4,21 @@
 import { ethers } from "ethers";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 
-const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/asc-contracts";
+function ascContractsDir(): string {
+  // ASC_CONTRACTS_DIR since the repo was renamed usc-contracts -> asc-contracts; the old name is
+  // still accepted so existing setups keep working. Deliberately no default: this used to fall
+  // back to one developer's home directory, so anyone else got a confusing "cannot read artifact"
+  // three calls later instead of being told what to set.
+  const dir = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR;
+  if (!dir) {
+    throw new Error(
+      "set ASC_CONTRACTS_DIR to a compiled asc-contracts checkout (run `npx hardhat compile` there first)",
+    );
+  }
+  return dir;
+}
+
+const UC = ascContractsDir();
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 

--- a/usc-messaging/scripts/deploy-dest-ethers.mts
+++ b/usc-messaging/scripts/deploy-dest-ethers.mts
@@ -4,7 +4,6 @@
 // construction, and EOAValidator delegates its attestor set to a shared AttestorRegistry.
 import { ethers } from "ethers";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 
 // asc-contracts checkout: $ASC_CONTRACTS_DIR, else the sibling of this repo (…/Projects/asc-contracts).
 function ascContractsDir(): string {

--- a/usc-messaging/scripts/deploy-dest-ethers.mts
+++ b/usc-messaging/scripts/deploy-dest-ethers.mts
@@ -7,7 +7,21 @@ import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 // asc-contracts checkout: $ASC_CONTRACTS_DIR, else the sibling of this repo (…/Projects/asc-contracts).
-const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? fileURLToPath(new URL("../../../asc-contracts", import.meta.url));
+function ascContractsDir(): string {
+  // ASC_CONTRACTS_DIR since the repo was renamed usc-contracts -> asc-contracts; the old name is
+  // still accepted so existing setups keep working. Deliberately no default: this used to fall
+  // back to one developer's home directory, so anyone else got a confusing "cannot read artifact"
+  // three calls later instead of being told what to set.
+  const dir = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR;
+  if (!dir) {
+    throw new Error(
+      "set ASC_CONTRACTS_DIR to a compiled asc-contracts checkout (run `npx hardhat compile` there first)",
+    );
+  }
+  return dir;
+}
+
+const UC = ascContractsDir();
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 

--- a/usc-messaging/scripts/deploy-source-devnet.mts
+++ b/usc-messaging/scripts/deploy-source-devnet.mts
@@ -5,7 +5,21 @@
 import { ethers } from "ethers";
 import { readFileSync, writeFileSync } from "node:fs";
 
-const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/asc-contracts";
+function ascContractsDir(): string {
+  // ASC_CONTRACTS_DIR since the repo was renamed usc-contracts -> asc-contracts; the old name is
+  // still accepted so existing setups keep working. Deliberately no default: this used to fall
+  // back to one developer's home directory, so anyone else got a confusing "cannot read artifact"
+  // three calls later instead of being told what to set.
+  const dir = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR;
+  if (!dir) {
+    throw new Error(
+      "set ASC_CONTRACTS_DIR to a compiled asc-contracts checkout (run `npx hardhat compile` there first)",
+    );
+  }
+  return dir;
+}
+
+const UC = ascContractsDir();
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 
@@ -50,17 +64,26 @@ async function main() {
   const factory = await deploy("OutboxFactory", ART("write-ability/deployer/OutboxFactory.sol", "OutboxFactory"));
   const quoter = await deploy("USCRelayingQuoter", ART("write-ability/USCRelayingQuoter.sol", "USCRelayingQuoter"), [owner, await twap.getAddress(), owner]);
 
+  // Outbox.coreFee() reads through IFeeRegistry, NOT the quoter. This slot used to be handed the
+  // quoter, which is a different interface: coreFee() then reverted, and fix-fee-registry.mts
+  // existed to swap the real registry in after every deploy. FeeRegistry forwards to this chain's
+  // own chain-info precompile (ICoreFeeProvider.get_core_fee(uint32), AddressU64<4051> per
+  // runtime/src/precompiles.rs), so fee policy stays in the runtime rather than in contract state.
+  const CORE_FEE_PRECOMPILE = "0x0000000000000000000000000000000000000FD3";
+  const feeRegistry = await deploy("FeeRegistry", ART("write-ability/FeeRegistry.sol", "FeeRegistry"), [CORE_FEE_PRECOMPILE]);
+
   const attestAddr = await attest.getAddress();
   const quoterAddr = await quoter.getAddress();
   const proofAddr = await proof.getAddress();
   const decoderAddr = await decoder.getAddress();
+  const feeRegistryAddr = await feeRegistry.getAddress();
   const RATE = 0n;
 
   // av (nonce n), fv (n+1), rc (n+2); Outbox via CREATE2 — resolves the ctor circularity.
   const n = await wallet.getNonce();
   const at = (k: number) => ethers.getCreateAddress({ from: owner, nonce: n + k });
   const [avAddr, fvAddr, rcAddr] = [at(0), at(1), at(2)];
-  const obAddr = await (factory as any).computeOutboxAddressFor(owner, CHAIN_KEY, owner, owner, RATE, avAddr, quoterAddr, attestAddr);
+  const obAddr = await (factory as any).computeOutboxAddressFor(owner, CHAIN_KEY, owner, owner, RATE, avAddr, feeRegistryAddr, attestAddr);
 
   const av = await deploy("AttestorVault", ART("write-ability/AttestorVault.sol", "AttestorVault"),
     [owner, attestAddr, obAddr, rcAddr, owner, await registry.getAddress(), DEAD, 0]);
@@ -71,7 +94,7 @@ async function main() {
   if ((await av.getAddress()) !== avAddr || (await rc.getAddress()) !== rcAddr) throw new Error("precompute mismatch");
 
   console.log("  deployOutbox via factory…");
-  const tx = await (factory as any).deployOutbox(CHAIN_KEY, owner, owner, RATE, avAddr, quoterAddr, attestAddr);
+  const tx = await (factory as any).deployOutbox(CHAIN_KEY, owner, owner, RATE, avAddr, feeRegistryAddr, attestAddr);
   const rcpt = await tx.wait();
   const created = rcpt.logs.map((l: any) => { try { return (factory as any).interface.parseLog(l); } catch { return null; } })
     .find((e: any) => e?.name === "OutboxCreated");
@@ -106,7 +129,7 @@ async function main() {
     chainId: CC_CHAIN_ID, rpc, chainKey: CHAIN_KEY,
     attest: attestAddr, proofVerifier: proofAddr, deliveryDecoder: decoderAddr,
     twapReader: await twap.getAddress(), attestorRegistry: await registry.getAddress(),
-    quoter: quoterAddr, factory: await factory.getAddress(),
+    quoter: quoterAddr, feeRegistry: feeRegistryAddr, factory: await factory.getAddress(),
     attestorVault: avAddr, outbox: outboxAddr, relayerFeeVault: fvAddr, relayerContract: rcAddr,
     ackValidator: ackAddr, quoterEOA: QUOTER_EOA, coreFee: ethers.parseEther("1").toString(),
   };

--- a/usc-messaging/scripts/deploy-source-ethers.mts
+++ b/usc-messaging/scripts/deploy-source-ethers.mts
@@ -10,7 +10,21 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 // asc-contracts checkout: $ASC_CONTRACTS_DIR, else the sibling of this repo (…/Projects/asc-contracts).
-const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? fileURLToPath(new URL("../../../asc-contracts", import.meta.url));
+function ascContractsDir(): string {
+  // ASC_CONTRACTS_DIR since the repo was renamed usc-contracts -> asc-contracts; the old name is
+  // still accepted so existing setups keep working. Deliberately no default: this used to fall
+  // back to one developer's home directory, so anyone else got a confusing "cannot read artifact"
+  // three calls later instead of being told what to set.
+  const dir = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR;
+  if (!dir) {
+    throw new Error(
+      "set ASC_CONTRACTS_DIR to a compiled asc-contracts checkout (run `npx hardhat compile` there first)",
+    );
+  }
+  return dir;
+}
+
+const UC = ascContractsDir();
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 

--- a/usc-messaging/scripts/deploy-source-ethers.mts
+++ b/usc-messaging/scripts/deploy-source-ethers.mts
@@ -7,7 +7,6 @@ import { ethers } from "ethers";
 import { ApiPromise, Keyring, WsProvider } from "@polkadot/api";
 import { cryptoWaitReady } from "@polkadot/util-crypto";
 import { readFileSync, writeFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 
 // asc-contracts checkout: $ASC_CONTRACTS_DIR, else the sibling of this repo (…/Projects/asc-contracts).
 function ascContractsDir(): string {

--- a/usc-messaging/scripts/fix-fee-registry.mts
+++ b/usc-messaging/scripts/fix-fee-registry.mts
@@ -1,10 +1,29 @@
-// Fix: the Outbox was deployed with the quoter in the feeRegistry slot (stale e2e arg order).
-// Deploy the real FeeRegistry (backed by the chain-info precompile's get_core_fee) and swap it
-// in via Outbox.setFeeRegistry (owner-only). Env: DEPLOYER_KEY (= Outbox owner).
+// Remediation tool, no longer part of a fresh deploy. deploy-source-devnet.mts used to hand the
+// quoter to the Outbox's feeRegistry slot, so coreFee() reverted and this had to be run after
+// every deploy; that script now wires a real FeeRegistry itself. Kept because it is still the way
+// to re-point an ALREADY-deployed Outbox: usc-devnet's live Outbox was created with the wrong slot
+// and repaired by running this, and FeeRegistry is deliberately swappable (its own doc comment
+// anticipates a storage-based registry replacing the precompile-backed one) via the owner-only
+// Outbox.setFeeRegistry. Deploys a FeeRegistry backed by the chain-info precompile's get_core_fee
+// and swaps it in. Env: DEPLOYER_KEY (= Outbox owner).
 import { ethers } from "ethers";
 import { readFileSync, writeFileSync } from "node:fs";
 
-const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/asc-contracts";
+function ascContractsDir(): string {
+  // ASC_CONTRACTS_DIR since the repo was renamed usc-contracts -> asc-contracts; the old name is
+  // still accepted so existing setups keep working. Deliberately no default: this used to fall
+  // back to one developer's home directory, so anyone else got a confusing "cannot read artifact"
+  // three calls later instead of being told what to set.
+  const dir = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR;
+  if (!dir) {
+    throw new Error(
+      "set ASC_CONTRACTS_DIR to a compiled asc-contracts checkout (run `npx hardhat compile` there first)",
+    );
+  }
+  return dir;
+}
+
+const UC = ascContractsDir();
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 const OUT = process.env.DEPLOY_OUT ?? "/tmp/usc-dev-deploy.json";

--- a/usc-messaging/scripts/fix-validator.mts
+++ b/usc-messaging/scripts/fix-validator.mts
@@ -5,7 +5,21 @@
 import { ethers } from "ethers";
 import { readFileSync, writeFileSync } from "node:fs";
 
-const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/asc-contracts";
+function ascContractsDir(): string {
+  // ASC_CONTRACTS_DIR since the repo was renamed usc-contracts -> asc-contracts; the old name is
+  // still accepted so existing setups keep working. Deliberately no default: this used to fall
+  // back to one developer's home directory, so anyone else got a confusing "cannot read artifact"
+  // three calls later instead of being told what to set.
+  const dir = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR;
+  if (!dir) {
+    throw new Error(
+      "set ASC_CONTRACTS_DIR to a compiled asc-contracts checkout (run `npx hardhat compile` there first)",
+    );
+  }
+  return dir;
+}
+
+const UC = ascContractsDir();
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 const OUT = process.env.DEPLOY_OUT ?? "/tmp/usc-dev-deploy.json";

--- a/usc-messaging/scripts/set-oracle-devnet.mts
+++ b/usc-messaging/scripts/set-oracle-devnet.mts
@@ -8,7 +8,21 @@
 import { ethers } from "ethers";
 import { readFileSync } from "node:fs";
 
-const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR ?? "/Users/dylan/Projects/asc-contracts";
+function ascContractsDir(): string {
+  // ASC_CONTRACTS_DIR since the repo was renamed usc-contracts -> asc-contracts; the old name is
+  // still accepted so existing setups keep working. Deliberately no default: this used to fall
+  // back to one developer's home directory, so anyone else got a confusing "cannot read artifact"
+  // three calls later instead of being told what to set.
+  const dir = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR;
+  if (!dir) {
+    throw new Error(
+      "set ASC_CONTRACTS_DIR to a compiled asc-contracts checkout (run `npx hardhat compile` there first)",
+    );
+  }
+  return dir;
+}
+
+const UC = ascContractsDir();
 const ART = (p: string, n: string) =>
   JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
 


### PR DESCRIPTION
Replaces #1286, which GitHub auto-closed when its base branch (`ci/revive-abi-drift-gate`, now merged as #1284) was deleted. Same two commits, rebased onto the post-merge `writeability-off-usc-dev` so the diff is now only the eight script files rather than duplicating #1284's content. The Bugbot finding on #1286 is fixed and included.

## 1. The Outbox was deployed with the quoter in its feeRegistry slot

`deploy-source-devnet.mts` passed `quoterAddr` where `feeRegistry` belongs. `Outbox.coreFee()` reads through `IFeeRegistry`, which the quoter does not implement, so `coreFee()` reverted on every fresh devnet and `fix-fee-registry.mts` had to be run afterwards to repair it. **This reproduces on every fresh deploy, which makes it directly relevant to cc3-devnet.**

Now deploys a `FeeRegistry` backed by the chain-info precompile, exactly as `deploy-source-ethers.mts` already did, and passes it to **both** `computeOutboxAddressFor` and `deployOutbox`. Those must agree: CREATE2 folds constructor arguments into the initcode hash, so a mismatch silently predicts an address nothing was deployed to.

### Three corrections to the drift audit

Recording these because the audit's version of the finding would lead someone to break things:

- **The argument *order* was never wrong.** It is correct in both scripts. Exactly one *value* was wrong, and only in the devnet variant.
- **Passing the deployer in the `validator` slot is not a bug.** `AcknowledgementValidator` receives the Outbox address through a one-shot `setOutbox` guarded by `OutboxAlreadySet`, so it cannot exist when the Outbox is constructed. Placeholder plus `setValidator` afterwards is the required sequence.
- **`fix-validator.mts` is unrelated to deployment.** It replaces the *Sepolia Inbox's* June-era `EOAValidator`, whose `validateVotes` returns `void` where the post-#23 Inbox expects `bool` — empty returndata reverts every delivery. Deleting it, as "retire both fix-up scripts" implied, would break Sepolia deliveries.

`fix-fee-registry.mts` is also kept rather than deleted, and re-documented as a remediation tool: it is still the way to re-point an already-deployed Outbox (usc-devnet's live one was created with the wrong slot and repaired by running it), and `FeeRegistry` is deliberately swappable, as its own doc comment anticipates.

## 2. Eight scripts defaulted to a path in one developer's home directory

Anyone else running them got "cannot read artifact" several calls later rather than being told what to set. They now share a helper taking `ASC_CONTRACTS_DIR`, falling back to `USC_CONTRACTS_DIR`, throwing and naming the variable when neither is present.

## Verified

Helper tested standalone in all three states: unset throws with the instruction, `ASC_CONTRACTS_DIR` resolves, `USC_CONTRACTS_DIR` still resolves. Structural check confirms one helper and one call site per file, definition before use, in all eight. The four untouched scripts (`publish-devnet`, `publish-fee`, `claim-delivery`, `assert-relay-claimed`) genuinely never read the artifacts directory — they build contracts from inline ABI fragments. Post-rebase: helper present in 8/8, FeeRegistry wired, no dead `fileURLToPath` imports, no personal paths.

The full deploy path now gets exercised by the write-ability e2e, which #1284 made trigger on this branch — it ran and passed there for the first time.
