### PR TITLE
feat(runtime): run the EVM at the Osaka hard fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4605,7 +4605,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4617,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "fc-cli"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "clap",
  "ethereum-types 0.15.1",
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4651,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4704,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4774,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4976,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4994,7 +4994,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -5005,7 +5005,7 @@ dependencies = [
 [[package]]
 name = "fp-dynamic-fee"
 version = "1.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "async-trait",
  "sp-core",
@@ -5015,7 +5015,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -5027,7 +5027,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "environmental",
  "evm",
@@ -5043,7 +5043,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -5059,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5071,7 +5071,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9106,7 +9106,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9138,7 +9138,7 @@ dependencies = [
 [[package]]
 name = "pallet-dynamic-fee"
 version = "4.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "fp-dynamic-fee",
  "fp-evm",
@@ -9153,7 +9153,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -9176,7 +9176,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "environmental",
  "ethereum",
@@ -9200,7 +9200,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "fp-evm",
  "num",
@@ -9353,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9457,7 +9457,7 @@ dependencies = [
 [[package]]
 name = "pallet-hotfix-sufficients"
 version = "1.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10638,7 +10638,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "derive_more 1.0.0",
  "environmental",
@@ -10667,7 +10667,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
 dependencies = [
  "case",
  "num_enum 0.7.6",

--- a/cli/src/test/blockchain-tests/precompiles/ed25519-verifier.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/ed25519-verifier.test.ts
@@ -316,12 +316,16 @@ describe('Precompile: Ed25519Verifier.verify()', (): void => {
             }
         });
 
-        test('should revert for message exceeding 3MB limit', async () => {
+        test('should revert for message exceeding the 1.7MB limit', async () => {
             // Generate a keypair
             const pair = keyring.addFromMnemonic(mnemonicGenerate());
 
-            // Create a message larger than 3MB (3MB + 1 byte)
-            const largeMessage = 'A'.repeat(3145729);
+            // One byte over the precompile's MaxMessageSize bound (1_700_000).
+            // Kept under EIP-7623's calldata floor on purpose: an all-non-zero message costs
+            // ~40 gas/byte, so this call needs ~68M of the 75M block gas limit and still
+            // reaches the precompile's own size check. A 3MB message would need 125.8M and
+            // would die on the floor check with no revert data to assert against.
+            const largeMessage = 'A'.repeat(1_700_001);
             const messageBytes = new TextEncoder().encode(largeMessage);
 
             // Sign the message (this will work in substrate)

--- a/cli/src/test/blockchain-tests/precompiles/sr25519-verifier.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/sr25519-verifier.test.ts
@@ -285,12 +285,16 @@ describe('Precompile: Sr25519Verifier.verify()', (): void => {
             ).rejects.toThrow(/Value is too large for length/);
         });
 
-        test('should revert for message exceeding 3MB limit', async () => {
+        test('should revert for message exceeding the 1.7MB limit', async () => {
             // Generate a keypair
             const pair = keyring.addFromMnemonic(mnemonicGenerate());
 
-            // Create a message larger than 3MB (3MB + 1 byte)
-            const largeMessage = 'A'.repeat(3145729);
+            // One byte over the precompile's MaxMessageSize bound (1_700_000).
+            // Kept under EIP-7623's calldata floor on purpose: an all-non-zero message costs
+            // ~40 gas/byte, so this call needs ~68M of the 75M block gas limit and still
+            // reaches the precompile's own size check. A 3MB message would need 125.8M and
+            // would die on the floor check with no revert data to assert against.
+            const largeMessage = 'A'.repeat(1_700_001);
             const messageBytes = new TextEncoder().encode(largeMessage);
 
             // Sign the message (this will work in substrate)

--- a/precompiles/ed25519-verifier/src/lib.rs
+++ b/precompiles/ed25519-verifier/src/lib.rs
@@ -15,8 +15,16 @@ mod tests;
 /// Precompile for verifying ed25519 signatures.
 pub struct Ed25519VerifierPrecompile<Runtime>(PhantomData<Runtime>);
 
-// 3MB limit for message size
-type ConstU3MB = ConstU32<3145728>;
+// Maximum message size, 1.7MB.
+//
+// This bound has to stay reachable under EIP-7623's calldata floor, which prices a
+// transaction at `21000 + 10*zero + 40*non_zero` calldata bytes and hard-rejects one whose
+// gas limit falls below that. An all-non-zero message therefore costs ~40 gas per byte, so
+// BLOCK_GAS_LIMIT (75_000_000) admits at most (75_000_000 - 21000) / 40 = 1_874_475 bytes.
+// The previous 3MB bound sat above that ceiling and was unreachable: a 3MB message needed
+// 125_850_120 gas, so the transaction died on the floor check before this precompile ran,
+// and callers saw an out-of-gas with no revert data instead of a size error.
+type MaxMessageSize = ConstU32<1_700_000>;
 
 // 64 bytes for ed25519 signature
 type ED25519SignatureBytes = ConstU32<64>;
@@ -48,7 +56,7 @@ where
     #[precompile::view]
     fn verify(
         handle: &mut impl PrecompileHandle,
-        message: BoundedBytes<ConstU3MB>,
+        message: BoundedBytes<MaxMessageSize>,
         signature: BoundedBytes<ED25519SignatureBytes>,
         public_key: H256,
     ) -> EvmResult<bool> {

--- a/precompiles/ed25519-verifier/src/tests.rs
+++ b/precompiles/ed25519-verifier/src/tests.rs
@@ -20,7 +20,8 @@ const SMALL_ORDER_POINTS: [[u8; 32]; 8] = [
     hex_literal::hex!("c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac037a"),
 ];
 
-const THREE_MB: usize = 3 * 1024 * 1024; // 3,145,728 bytes
+// Mirrors `MaxMessageSize` in lib.rs.
+const MAX_MESSAGE_SIZE: usize = 1_700_000;
 
 fn precompiles() -> Precompiles<Runtime> {
     PrecompilesValue::get()
@@ -269,13 +270,13 @@ fn verify_signature_too_long_should_revert() {
 }
 
 #[test]
-fn verify_message_exceeding_3mb_should_revert() {
+fn verify_message_exceeding_max_size_should_revert() {
     ExtBuilder::default().build().execute_with(|| {
         let (pair, _seed) = ed25519::Pair::generate();
         let public = pair.public();
 
-        // 3MB + 1 byte exceeds the BoundedBytes<ConstU3MB> limit
-        let message = vec![0x42u8; THREE_MB + 1];
+        // One byte over the bound exceeds the BoundedBytes<MaxMessageSize> limit
+        let message = vec![0x42u8; MAX_MESSAGE_SIZE + 1];
         let signature = pair.sign(&message);
 
         let caller: H160 = Account::Alice.into();

--- a/precompiles/sr25519-verifier/src/lib.rs
+++ b/precompiles/sr25519-verifier/src/lib.rs
@@ -15,8 +15,16 @@ mod tests;
 /// Precompile for verifying Substrate sr25519 signatures.
 pub struct Sr25519VerifierPrecompile<Runtime>(PhantomData<Runtime>);
 
-// 3MB limit for message size
-type ConstU3MB = ConstU32<3145728>;
+// Maximum message size, 1.7MB.
+//
+// This bound has to stay reachable under EIP-7623's calldata floor, which prices a
+// transaction at `21000 + 10*zero + 40*non_zero` calldata bytes and hard-rejects one whose
+// gas limit falls below that. An all-non-zero message therefore costs ~40 gas per byte, so
+// BLOCK_GAS_LIMIT (75_000_000) admits at most (75_000_000 - 21000) / 40 = 1_874_475 bytes.
+// The previous 3MB bound sat above that ceiling and was unreachable: a 3MB message needed
+// 125_850_120 gas, so the transaction died on the floor check before this precompile ran,
+// and callers saw an out-of-gas with no revert data instead of a size error.
+type MaxMessageSize = ConstU32<1_700_000>;
 
 // 64 bytes for sr25519 signature
 type SR25519SignatureBytes = ConstU32<64>;
@@ -45,7 +53,7 @@ where
     #[precompile::view]
     fn verify(
         handle: &mut impl PrecompileHandle,
-        message: BoundedBytes<ConstU3MB>,
+        message: BoundedBytes<MaxMessageSize>,
         signature: BoundedBytes<SR25519SignatureBytes>,
         public_key: H256,
     ) -> EvmResult<bool> {

--- a/precompiles/sr25519-verifier/src/tests.rs
+++ b/precompiles/sr25519-verifier/src/tests.rs
@@ -2,7 +2,8 @@ use crate::mock::*;
 use precompile_utils::testing::*;
 use sp_core::{sr25519, Pair, H160, H256};
 
-const THREE_MB: usize = 3 * 1024 * 1024; // 3,145,728 bytes
+// Mirrors `MaxMessageSize` in lib.rs.
+const MAX_MESSAGE_SIZE: usize = 1_700_000;
 
 fn precompiles() -> Precompiles<Runtime> {
     PrecompilesValue::get()
@@ -251,13 +252,13 @@ fn verify_signature_too_long_should_revert() {
 }
 
 #[test]
-fn verify_message_exceeding_3mb_should_revert() {
+fn verify_message_exceeding_max_size_should_revert() {
     ExtBuilder::default().build().execute_with(|| {
         let (pair, _seed) = sr25519::Pair::generate();
         let public = pair.public();
 
-        // 3MB + 1 byte exceeds the BoundedBytes<ConstU3MB> limit
-        let message = vec![0x42u8; THREE_MB + 1];
+        // One byte over the bound exceeds the BoundedBytes<MaxMessageSize> limit
+        let message = vec![0x42u8; MAX_MESSAGE_SIZE + 1];
         let signature = pair.sign(&message);
 
         let caller: H160 = Account::Alice.into();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -452,13 +452,28 @@ const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 /// The maximum storage growth per block in bytes.
 const MAX_STORAGE_GROWTH: u64 = 400 * 1024;
 
-/// Pin the EVM hard fork to Cancun explicitly. `pallet_evm::Config::config()` defaults to
-/// whatever hard fork our Frontier fork ships (currently Osaka), which silently pulled in
-/// EIP-7623's calldata-floor gas pricing (40 gas per non-zero calldata byte) on the stable2512
-/// upgrade. That floor charges every call up front for raw calldata length before any contract
-/// or precompile logic runs, making our 3MB precompile message limits effectively unaffordable
-/// within BLOCK_GAS_LIMIT. Pin to Cancun to keep the gas economics this chain was tuned for.
-static CANCUN_EVM_CONFIG: fp_evm::Config = fp_evm::Config::cancun();
+/// Run the EVM at the Osaka hard fork, matching Ethereum mainnet's opcode and gas semantics.
+///
+/// `pallet_evm::Config::config()` would default to whatever hard fork our Frontier fork ships,
+/// which is Osaka today; naming it here makes the choice explicit rather than incidental, so a
+/// future Frontier bump cannot move consensus gas pricing under us without a deliberate edit.
+///
+/// Relative to the Cancun pin this replaces, Osaka turns on three EIPs:
+///
+/// - EIP-7702 (`has_eip_7702`): type-4 SetCode transactions. Under Cancun these were accepted
+///   and mined but their authorization lists were silently dropped, because the stack executor
+///   only applies them behind this flag.
+/// - EIP-7623 (`has_eip_7623`): the calldata floor, `21000 + 10*zero + 40*non_zero`, charged as
+///   `max(actual, floor)` and hard-rejected when a transaction's gas *limit* falls below it.
+///   Ordinary traffic is unaffected (the floor only binds when execution is cheaper than
+///   `6*zero + 24*non_zero`), but it roughly doubles the cost of the calldata-heavy,
+///   compute-light precompile paths and caps a single all-non-zero verifier message at ~1.79MB
+///   within BLOCK_GAS_LIMIT, down from ~3.76MB.
+/// - EIP-7939 (`has_eip_7939`): the CLZ opcode. Purely additive.
+///
+/// This is consensus-affecting: it must ship as a runtime upgrade under a new `spec_version`,
+/// never inside a rebuild that reuses the current one.
+static EVM_CONFIG: fp_evm::Config = fp_evm::Config::osaka();
 
 parameter_types! {
     pub BlockGasLimit: U256 = U256::from(BLOCK_GAS_LIMIT);
@@ -494,7 +509,7 @@ impl pallet_evm::Config for Runtime {
     type CreateInnerOriginFilter = ();
 
     fn config() -> &'static fp_evm::Config {
-        &CANCUN_EVM_CONFIG
+        &EVM_CONFIG
     }
 }
 


### PR DESCRIPTION
## What

Stop pinning `pallet_evm::Config::config()` to Cancun and run Osaka, matching Ethereum mainnet's EVM execution semantics.

Frontier's own default is already `Config::osaka()` (`primitives/evm/src/lib.rs:43`), so the Cancun pin was a deliberate divergence, taken during the stable2512 upgrade to dodge EIP-7623's calldata floor. Naming Osaka explicitly rather than relying on the default also means a future Frontier bump can't move consensus gas pricing without a deliberate edit here.

**This is consensus-affecting.** It must ship as a runtime upgrade under a new `spec_version`. `spec_version` is left at 132 in this PR since releases own that bump.

## Why

The motivating bug: **EIP-7702 type-4 transactions were silently broken.** Cancun leaves `has_eip_7702` false, and the stack executor only applies a transaction's authorization list behind that flag (`evm/src/executor/stack/executor.rs:493,564,715`). Nothing in `pallet_ethereum`'s validation gates on the hard fork — `with_eip7702_authorization_list` only checks the list is non-empty and <= 255 entries. So a type-4 transaction was accepted, mined, reported as `type: 0x4` with its `authorizationList` echoed back over RPC, charged a plain 21000 gas, and **no delegation was installed**. A wallet relying on 7702 batching or sponsorship would read that as success and silently do nothing. That's a worse failure than rejecting the transaction.

## What changes

Three EIPs turn on relative to Cancun. The full config delta is exactly these; everything else, `max_initcode_size` included, is identical.

| EIP | Effect |
| --- | --- |
| **7702** | Type-4 SetCode delegations now actually install and execute |
| **7623** | Calldata floor: `21000 + 10*zero + 40*non_zero`, charged as `max(actual, floor)`, and a hard `OutOfGas` when a transaction's gas *limit* falls below it |
| **7939** | CLZ opcode. Purely additive |

### EIP-7623 impact is narrow

The floor only binds when a transaction's execution work is cheaper than `6*zero + 24*non_zero`. Replaying real traffic and recomputing the floor per transaction against actual `gasUsed`:

| Chain | Blocks | Txs | Floor-bound | Extra gas | Would fail |
| --- | --- | --- | --- | --- | --- |
| mainnet | 400 | 38 | 0 | +0.0% | 0 |
| devnet | 300 | 70 | 0 | +0.0% | 0 |

Small samples (both chains are quiet), but the arithmetic agrees: an ERC20 transfer has a floor near 22,600 against ~51,000 used, and deployments pay 200 gas per byte of deployed code against a 40/byte floor. Ordinary EVM traffic is untouched, which is what the EIP was designed for.

Where it does bite is the calldata-heavy, compute-light precompile paths — the signature verifiers charge 3 gas per message byte (`precompiles/ed25519-verifier/src/lib.rs:28`) and the block prover charges base 10 plus 18 per merkle-path iteration. Those roughly double in cost. The attestor's proof submission is a substrate extrinsic (`pallet_attestation::attest`), not an EVM transaction, so it is unaffected entirely.

### The 3MB verifier bound became unreachable

EIP-7623 exposed that the `3MB` message bound on the ed25519/sr25519 verifiers was never enforceable at that price. A 3MB all-non-zero message needs `21000 + 40 * 3145728 = 125,850,120` gas against a `BLOCK_GAS_LIMIT` of 75,000,000, so the transaction died on the floor check *before* the precompile ran. Callers got an out-of-gas with no revert data instead of a size error, which is what the integration tests caught.

Lowered to **1,700,000 bytes**, under the `(75,000,000 - 21000) / 40 = 1,874,475` byte ceiling, so the declared limit is the enforceable one. A one-byte-over message now costs ~68M gas, fits in a block, and reaches the precompile's own check.

## Verification

All against a `--release` build on a dev node.

- **EIP-7702 works**: delegation installs (`code` becomes `0xef0100||address`), delegated code executes against the delegator's storage, implementation storage untouched. Cost depends on whether the authority already exists on chain, both measured: **46,000** gas delegating to a fresh account (21,000 intrinsic + 25,000, i.e. the full `PER_EMPTY_ACCOUNT_COST`) and **36,800** when the authority already exists, against 21,000 under Cancun where the authorization list was inert.
- `gas-estimation.test.ts` **5/5** — `eth_estimateGas` correctly returns the floor, so the binary search converges and the just-below-estimate rejection still holds.
- ed25519 + sr25519 integration suites **21/21**.
- Verifier unit tests **12/12** each.
- **Cancun control**: the same six precompile suites pass 57/57 on the released 3.132.0 binary. On Osaka before the bound fix, the only delta was the two 3MB tests.

Note that unit tests give no signal on this change: no mock overrides `config()`, so every precompile and pallet unit test in the repo has been running at Osaka all along. Only the runtime pinned Cancun.

## Not in scope

Full EVM execution compliance needs more than the hard-fork config, and none of it is here:

- `0x09` BLAKE2F (EIP-152, **Istanbul**) — absent; Frontier ships `Blake2F`, so this is nearly pure wiring
- `0x0b`-`0x11` BLS12-381 (EIP-2537) — Frontier ships the primitives, but the address and gas mapping needs checking against the final spec
- `0x0a` KZG point evaluation and type-3 blob transactions (EIP-4844) — not in the stack at all; `ethereum` 0.18.2's `TransactionV3` is Legacy / 2930 / 1559 / 7702
- `0x100` P256VERIFY (EIP-7951) — would need a new precompile crate

Consensus-layer EIPs (4895 withdrawals, 4788 beacon root, 7002/7251) don't map onto BABE/GRANDPA at all.

## Validation on a live network

The change was applied to an internal network as a staged runtime upgrade and every measurement below was taken against it, not against a local dev chain. A Cancun baseline was captured first, then the identical scripts were re-run after the hard-fork switch, so each pair differs only by the EVM configuration.

**Ordinary traffic is unaffected.** This is the important half:

| | Cancun | Osaka |
| --- | --- | --- |
| plain value transfer | 21,000 | 21,000 |
| 68-byte call | 22,366 | 22,446 |
| contract deployment | 55,604 | 55,604 |

Deployments are untouched because 200 gas per byte of deployed code dominates the 40/byte floor.

**Signature-verification precompiles**, measured with a real keypair on the success path. The ratio asymptotes at ~2.1x and small messages are barely affected, since the 21,000 intrinsic dominates below about 1KB:

| message | Cancun | Osaka | ratio |
| --- | --- | --- | --- |
| 256 B | 32,726 | 36,993 | 1.13x |
| 1 KB | 46,984 | 71,928 | 1.53x |
| 8 KB | 183,730 | 378,895 | 2.06x |
| 64 KB | 1,325,877 | 2,744,396 | 2.07x |
| 256 KB | 5,178,165 | 10,854,476 | 2.10x |

**Calldata decoded inside a contract**, measured with a minimal `CALLDATACOPY` reader, so a real decoder is strictly worse. The linear floor compounds with quadratic memory expansion:

| calldata | Cancun | Osaka | Osaka share of a 75M block |
| --- | --- | --- | --- |
| 0.48 MB | 8,873,866 | 20,660,437 | 27.5% |
| 0.95 MB | 18,695,760 | 41,285,437 | 55.0% |
| 1.43 MB | 29,501,132 | 61,910,437 | 82.5% |
| 1.81 MB | 38,853,531 | 78,410,437 | exceeds a block |
| 3.00 MB | 72,012,408 | 128,923,640 | exceeds a block |

Two consequences worth knowing for anything that passes large payloads into the EVM:

- A transaction whose gas *limit* falls below the floor is rejected outright rather than simply costing more, and that applies to read-only `eth_call` as well as to state-changing transactions. A 20KB call that succeeded at a 400,000 gas cap under Cancun needs 900,000 under Osaka.
- The verifier precompiles' previous 3MB message bound was never enforceable at Osaka pricing (a 3MB all-non-zero message needs 125,850,120 gas against a 75,000,000 block limit), which is why this PR lowers it to 1,700,000 — under the `(75,000,000 - 21,000) / 40 = 1,874,475` byte ceiling, so the declared limit is the enforceable one.

Tracing was confirmed working on type-4 transactions at every stage (`debug_traceTransaction` raw and `callTracer`, `debug_traceBlockByNumber`, `trace_filter`), and no pallet storage migrations were involved in the switch.


🤖 Generated with [Claude Code](https://claude.com/claude-code)