### PR TITLE
chore(review): osaka runtime against EIP-7702 type-4 CREATE fix (frontier_2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4605,7 +4605,6 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4617,7 +4616,6 @@ dependencies = [
 [[package]]
 name = "fc-cli"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "clap",
  "ethereum-types 0.15.1",
@@ -4635,7 +4633,6 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4651,7 +4648,6 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4681,7 +4677,6 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4704,7 +4699,6 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4758,7 +4752,6 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4774,7 +4767,6 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4976,7 +4968,6 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4994,7 +4985,6 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -5005,7 +4995,6 @@ dependencies = [
 [[package]]
 name = "fp-dynamic-fee"
 version = "1.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "async-trait",
  "sp-core",
@@ -5015,7 +5004,6 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -5027,7 +5015,6 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "environmental",
  "evm",
@@ -5043,7 +5030,6 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -5059,7 +5045,6 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5071,7 +5056,6 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9106,7 +9090,6 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9138,7 +9121,6 @@ dependencies = [
 [[package]]
 name = "pallet-dynamic-fee"
 version = "4.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "fp-dynamic-fee",
  "fp-evm",
@@ -9153,7 +9135,6 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -9176,7 +9157,6 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "environmental",
  "ethereum",
@@ -9200,7 +9180,6 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9279,7 +9258,6 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9344,7 +9322,6 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "fp-evm",
  "num",
@@ -9353,7 +9330,6 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9364,7 +9340,6 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9457,7 +9432,6 @@ dependencies = [
 [[package]]
 name = "pallet-hotfix-sufficients"
 version = "1.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10638,7 +10612,6 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "derive_more 1.0.0",
  "environmental",
@@ -10667,7 +10640,6 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#89b8cc6610ee528909b0919b76897cc9213d2560"
 dependencies = [
  "case",
  "num_enum 0.7.6",
@@ -18537,3 +18509,7 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "pallet-evm-test-vector-support"
+version = "1.0.0-dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,3 +367,37 @@ inherits = "release"
 # https://doc.rust-lang.org/rustc/linker-plugin-lto.html
 codegen-units = 1
 lto = "fat"
+
+# --- REVIEW-ONLY: local override to consume the EIP-7702 type-4 CREATE fix ---
+# All gluwa/frontier_2 crates repointed to the local review branch
+# (fix/eip7702-reject-type4-create) so there is a single consistent crate source.
+# Do NOT merge/push; for core-team review only.
+[patch."https://github.com/gluwa/frontier_2"]
+fc-api = { path = "../frontier_2/client/api" }
+fc-cli = { path = "../frontier_2/client/cli" }
+fc-consensus = { path = "../frontier_2/client/consensus" }
+fc-db = { path = "../frontier_2/client/db" }
+fc-mapping-sync = { path = "../frontier_2/client/mapping-sync" }
+fc-rpc = { path = "../frontier_2/client/rpc" }
+fc-rpc-core = { path = "../frontier_2/client/rpc-core" }
+fc-storage = { path = "../frontier_2/client/storage" }
+fp-account = { path = "../frontier_2/primitives/account" }
+fp-consensus = { path = "../frontier_2/primitives/consensus" }
+fp-dynamic-fee = { path = "../frontier_2/primitives/dynamic-fee" }
+fp-ethereum = { path = "../frontier_2/primitives/ethereum" }
+fp-evm = { path = "../frontier_2/primitives/evm" }
+fp-rpc = { path = "../frontier_2/primitives/rpc" }
+fp-self-contained = { path = "../frontier_2/primitives/self-contained" }
+fp-storage = { path = "../frontier_2/primitives/storage" }
+pallet-base-fee = { path = "../frontier_2/frame/base-fee" }
+pallet-dynamic-fee = { path = "../frontier_2/frame/dynamic-fee" }
+pallet-ethereum = { path = "../frontier_2/frame/ethereum" }
+pallet-evm = { path = "../frontier_2/frame/evm" }
+pallet-evm-chain-id = { path = "../frontier_2/frame/evm-chain-id" }
+pallet-evm-precompile-bn128 = { path = "../frontier_2/frame/evm/precompile/bn128" }
+pallet-evm-precompile-modexp = { path = "../frontier_2/frame/evm/precompile/modexp" }
+pallet-evm-precompile-sha3fips = { path = "../frontier_2/frame/evm/precompile/sha3fips" }
+pallet-evm-precompile-simple = { path = "../frontier_2/frame/evm/precompile/simple" }
+pallet-evm-test-vector-support = { path = "../frontier_2/frame/evm/test-vector-support" }
+pallet-hotfix-sufficients = { path = "../frontier_2/frame/hotfix-sufficients" }
+precompile-utils = { path = "../frontier_2/precompiles" }

--- a/cli/src/test/blockchain-tests/precompiles/ed25519-verifier.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/ed25519-verifier.test.ts
@@ -316,12 +316,16 @@ describe('Precompile: Ed25519Verifier.verify()', (): void => {
             }
         });
 
-        test('should revert for message exceeding 3MB limit', async () => {
+        test('should revert for message exceeding the 1.7MB limit', async () => {
             // Generate a keypair
             const pair = keyring.addFromMnemonic(mnemonicGenerate());
 
-            // Create a message larger than 3MB (3MB + 1 byte)
-            const largeMessage = 'A'.repeat(3145729);
+            // One byte over the precompile's MaxMessageSize bound (1_700_000).
+            // Kept under EIP-7623's calldata floor on purpose: an all-non-zero message costs
+            // ~40 gas/byte, so this call needs ~68M of the 75M block gas limit and still
+            // reaches the precompile's own size check. A 3MB message would need 125.8M and
+            // would die on the floor check with no revert data to assert against.
+            const largeMessage = 'A'.repeat(1_700_001);
             const messageBytes = new TextEncoder().encode(largeMessage);
 
             // Sign the message (this will work in substrate)

--- a/cli/src/test/blockchain-tests/precompiles/sr25519-verifier.test.ts
+++ b/cli/src/test/blockchain-tests/precompiles/sr25519-verifier.test.ts
@@ -285,12 +285,16 @@ describe('Precompile: Sr25519Verifier.verify()', (): void => {
             ).rejects.toThrow(/Value is too large for length/);
         });
 
-        test('should revert for message exceeding 3MB limit', async () => {
+        test('should revert for message exceeding the 1.7MB limit', async () => {
             // Generate a keypair
             const pair = keyring.addFromMnemonic(mnemonicGenerate());
 
-            // Create a message larger than 3MB (3MB + 1 byte)
-            const largeMessage = 'A'.repeat(3145729);
+            // One byte over the precompile's MaxMessageSize bound (1_700_000).
+            // Kept under EIP-7623's calldata floor on purpose: an all-non-zero message costs
+            // ~40 gas/byte, so this call needs ~68M of the 75M block gas limit and still
+            // reaches the precompile's own size check. A 3MB message would need 125.8M and
+            // would die on the floor check with no revert data to assert against.
+            const largeMessage = 'A'.repeat(1_700_001);
             const messageBytes = new TextEncoder().encode(largeMessage);
 
             // Sign the message (this will work in substrate)

--- a/precompiles/ed25519-verifier/src/lib.rs
+++ b/precompiles/ed25519-verifier/src/lib.rs
@@ -15,8 +15,16 @@ mod tests;
 /// Precompile for verifying ed25519 signatures.
 pub struct Ed25519VerifierPrecompile<Runtime>(PhantomData<Runtime>);
 
-// 3MB limit for message size
-type ConstU3MB = ConstU32<3145728>;
+// Maximum message size, 1.7MB.
+//
+// This bound has to stay reachable under EIP-7623's calldata floor, which prices a
+// transaction at `21000 + 10*zero + 40*non_zero` calldata bytes and hard-rejects one whose
+// gas limit falls below that. An all-non-zero message therefore costs ~40 gas per byte, so
+// BLOCK_GAS_LIMIT (75_000_000) admits at most (75_000_000 - 21000) / 40 = 1_874_475 bytes.
+// The previous 3MB bound sat above that ceiling and was unreachable: a 3MB message needed
+// 125_850_120 gas, so the transaction died on the floor check before this precompile ran,
+// and callers saw an out-of-gas with no revert data instead of a size error.
+type MaxMessageSize = ConstU32<1_700_000>;
 
 // 64 bytes for ed25519 signature
 type ED25519SignatureBytes = ConstU32<64>;
@@ -48,7 +56,7 @@ where
     #[precompile::view]
     fn verify(
         handle: &mut impl PrecompileHandle,
-        message: BoundedBytes<ConstU3MB>,
+        message: BoundedBytes<MaxMessageSize>,
         signature: BoundedBytes<ED25519SignatureBytes>,
         public_key: H256,
     ) -> EvmResult<bool> {

--- a/precompiles/ed25519-verifier/src/tests.rs
+++ b/precompiles/ed25519-verifier/src/tests.rs
@@ -20,7 +20,8 @@ const SMALL_ORDER_POINTS: [[u8; 32]; 8] = [
     hex_literal::hex!("c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac037a"),
 ];
 
-const THREE_MB: usize = 3 * 1024 * 1024; // 3,145,728 bytes
+// Mirrors `MaxMessageSize` in lib.rs.
+const MAX_MESSAGE_SIZE: usize = 1_700_000;
 
 fn precompiles() -> Precompiles<Runtime> {
     PrecompilesValue::get()
@@ -269,13 +270,13 @@ fn verify_signature_too_long_should_revert() {
 }
 
 #[test]
-fn verify_message_exceeding_3mb_should_revert() {
+fn verify_message_exceeding_max_size_should_revert() {
     ExtBuilder::default().build().execute_with(|| {
         let (pair, _seed) = ed25519::Pair::generate();
         let public = pair.public();
 
-        // 3MB + 1 byte exceeds the BoundedBytes<ConstU3MB> limit
-        let message = vec![0x42u8; THREE_MB + 1];
+        // One byte over the bound exceeds the BoundedBytes<MaxMessageSize> limit
+        let message = vec![0x42u8; MAX_MESSAGE_SIZE + 1];
         let signature = pair.sign(&message);
 
         let caller: H160 = Account::Alice.into();

--- a/precompiles/sr25519-verifier/src/lib.rs
+++ b/precompiles/sr25519-verifier/src/lib.rs
@@ -15,8 +15,16 @@ mod tests;
 /// Precompile for verifying Substrate sr25519 signatures.
 pub struct Sr25519VerifierPrecompile<Runtime>(PhantomData<Runtime>);
 
-// 3MB limit for message size
-type ConstU3MB = ConstU32<3145728>;
+// Maximum message size, 1.7MB.
+//
+// This bound has to stay reachable under EIP-7623's calldata floor, which prices a
+// transaction at `21000 + 10*zero + 40*non_zero` calldata bytes and hard-rejects one whose
+// gas limit falls below that. An all-non-zero message therefore costs ~40 gas per byte, so
+// BLOCK_GAS_LIMIT (75_000_000) admits at most (75_000_000 - 21000) / 40 = 1_874_475 bytes.
+// The previous 3MB bound sat above that ceiling and was unreachable: a 3MB message needed
+// 125_850_120 gas, so the transaction died on the floor check before this precompile ran,
+// and callers saw an out-of-gas with no revert data instead of a size error.
+type MaxMessageSize = ConstU32<1_700_000>;
 
 // 64 bytes for sr25519 signature
 type SR25519SignatureBytes = ConstU32<64>;
@@ -45,7 +53,7 @@ where
     #[precompile::view]
     fn verify(
         handle: &mut impl PrecompileHandle,
-        message: BoundedBytes<ConstU3MB>,
+        message: BoundedBytes<MaxMessageSize>,
         signature: BoundedBytes<SR25519SignatureBytes>,
         public_key: H256,
     ) -> EvmResult<bool> {

--- a/precompiles/sr25519-verifier/src/tests.rs
+++ b/precompiles/sr25519-verifier/src/tests.rs
@@ -2,7 +2,8 @@ use crate::mock::*;
 use precompile_utils::testing::*;
 use sp_core::{sr25519, Pair, H160, H256};
 
-const THREE_MB: usize = 3 * 1024 * 1024; // 3,145,728 bytes
+// Mirrors `MaxMessageSize` in lib.rs.
+const MAX_MESSAGE_SIZE: usize = 1_700_000;
 
 fn precompiles() -> Precompiles<Runtime> {
     PrecompilesValue::get()
@@ -251,13 +252,13 @@ fn verify_signature_too_long_should_revert() {
 }
 
 #[test]
-fn verify_message_exceeding_3mb_should_revert() {
+fn verify_message_exceeding_max_size_should_revert() {
     ExtBuilder::default().build().execute_with(|| {
         let (pair, _seed) = sr25519::Pair::generate();
         let public = pair.public();
 
-        // 3MB + 1 byte exceeds the BoundedBytes<ConstU3MB> limit
-        let message = vec![0x42u8; THREE_MB + 1];
+        // One byte over the bound exceeds the BoundedBytes<MaxMessageSize> limit
+        let message = vec![0x42u8; MAX_MESSAGE_SIZE + 1];
         let signature = pair.sign(&message);
 
         let caller: H160 = Account::Alice.into();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -452,13 +452,28 @@ const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 /// The maximum storage growth per block in bytes.
 const MAX_STORAGE_GROWTH: u64 = 400 * 1024;
 
-/// Pin the EVM hard fork to Cancun explicitly. `pallet_evm::Config::config()` defaults to
-/// whatever hard fork our Frontier fork ships (currently Osaka), which silently pulled in
-/// EIP-7623's calldata-floor gas pricing (40 gas per non-zero calldata byte) on the stable2512
-/// upgrade. That floor charges every call up front for raw calldata length before any contract
-/// or precompile logic runs, making our 3MB precompile message limits effectively unaffordable
-/// within BLOCK_GAS_LIMIT. Pin to Cancun to keep the gas economics this chain was tuned for.
-static CANCUN_EVM_CONFIG: fp_evm::Config = fp_evm::Config::cancun();
+/// Run the EVM at the Osaka hard fork, matching Ethereum mainnet's opcode and gas semantics.
+///
+/// `pallet_evm::Config::config()` would default to whatever hard fork our Frontier fork ships,
+/// which is Osaka today; naming it here makes the choice explicit rather than incidental, so a
+/// future Frontier bump cannot move consensus gas pricing under us without a deliberate edit.
+///
+/// Relative to the Cancun pin this replaces, Osaka turns on three EIPs:
+///
+/// - EIP-7702 (`has_eip_7702`): type-4 SetCode transactions. Under Cancun these were accepted
+///   and mined but their authorization lists were silently dropped, because the stack executor
+///   only applies them behind this flag.
+/// - EIP-7623 (`has_eip_7623`): the calldata floor, `21000 + 10*zero + 40*non_zero`, charged as
+///   `max(actual, floor)` and hard-rejected when a transaction's gas *limit* falls below it.
+///   Ordinary traffic is unaffected (the floor only binds when execution is cheaper than
+///   `6*zero + 24*non_zero`), but it roughly doubles the cost of the calldata-heavy,
+///   compute-light precompile paths and caps a single all-non-zero verifier message at ~1.79MB
+///   within BLOCK_GAS_LIMIT, down from ~3.76MB.
+/// - EIP-7939 (`has_eip_7939`): the CLZ opcode. Purely additive.
+///
+/// This is consensus-affecting: it must ship as a runtime upgrade under a new `spec_version`,
+/// never inside a rebuild that reuses the current one.
+static EVM_CONFIG: fp_evm::Config = fp_evm::Config::osaka();
 
 parameter_types! {
     pub BlockGasLimit: U256 = U256::from(BLOCK_GAS_LIMIT);
@@ -494,7 +509,7 @@ impl pallet_evm::Config for Runtime {
     type CreateInnerOriginFilter = ();
 
     fn config() -> &'static fp_evm::Config {
-        &CANCUN_EVM_CONFIG
+        &EVM_CONFIG
     }
 }
 


### PR DESCRIPTION
## What

Review-only companion to the frontier_2 EIP-7702 fix, on top of Beqa's `feat/evm-osaka-hard-fork`.

The osaka runtime pins `gluwa/frontier_2`, where the actual fix lives (rejecting type-4 SetCode transactions with an empty `to` — see companion PR against frontier_2; tracks polkadot-evm/frontier#1920). This branch adds a `[patch."https://github.com/gluwa/frontier_2"]` block repointing the frontier crates to the fix branch so the osaka runtime **compiles and runs against the fix** for review.

## Proven

- `cargo check -p creditcoin3-runtime` → clean (exit 0) against the patched frontier.

## Important — do not merge as-is

The `[patch]` is a **review-time build wiring**, not the real change. For the actual landing, the flow is:

1. Merge the frontier_2 fix branch (companion PR).
2. Bump the `gluwa/frontier_2` pin in this repo to that commit.
3. Drop this `[patch]` block.

The commit and the `[patch]` block are both clearly labeled `REVIEW-ONLY`.

Opened from a fork; for team review only.
