### PR TITLE
docs(precompiles): record how EIP-7702 delegations affect caller classification

### DIFF
--- a/runtime/src/precompiles.rs
+++ b/runtime/src/precompiles.rs
@@ -21,6 +21,24 @@ type EthereumPrecompilesChecks = (AcceptDelegateCall, CallableByContract, Callab
 /// Non-frontier/non-mainnet precompiles: delegatecall *not* allowed (see `common_checks` in precompile-utils).
 type NonEthereumPrecompileChecks = (CallableByContract, CallableByPrecompile);
 
+// NOTE on EIP-7702 and the two tuples above.
+//
+// `get_address_type` (precompile-utils `precompile_set.rs`) classifies a caller purely by whether
+// it has code. An EOA that has delegated under EIP-7702 carries 23 bytes of `0xef0100 || address`,
+// so it is classified `AddressType::Contract`, not `AddressType::EOA`, and is routed through the
+// `callable_by_smart_contract` gate instead of the unchecked EOA path.
+//
+// That is currently harmless: both tuples use bare `CallableByContract`, which defaults to
+// `ForAllSelectors` and therefore permits every selector. Verified against a delegated EOA on a
+// network running the EIP-7702-enabled configuration -- it reaches selector dispatch exactly as a
+// plain EOA does.
+//
+// It stops being harmless the moment a selector filter is added to restrict contract callers, e.g.
+// `CallableByContract<OnlySomeSelectors>`. At that point delegated EOAs get caught by the filter
+// even though their owner is an ordinary user, and the failure will look inexplicable from the
+// caller's side. If you narrow either tuple, decide deliberately whether delegated EOAs belong on
+// the permitted side of that filter.
+
 /// Upper bound on the Creditcoin-precompile numeric address band (covers 4049–5050 today with room above).
 ///
 /// Addresses from `AddressU64<1>` through this exclusive band are routed through the tuple below;


### PR DESCRIPTION
Comment only. No behaviour change.

## What

A note at the two precompile check-tuple definitions in `runtime/src/precompiles.rs`, recording an interaction that is invisible from the code as written.

## Why

`get_address_type` in precompile-utils classifies a caller purely on whether it has code:

```rust
let code_len = pallet_evm::Pallet::<R>::account_code_metadata(address).size;
if code_len == 0 { return Ok(AddressType::EOA); }
Ok(AddressType::Contract)
```

An EOA that has delegated under EIP-7702 carries 23 bytes of `0xef0100 || address`. So it is classified `AddressType::Contract`, not `AddressType::EOA`, and is routed through the `callable_by_smart_contract` gate rather than the unchecked EOA path.

**This is harmless today.** Both tuples use bare `CallableByContract`, which defaults to `ForAllSelectors` and therefore permits every selector. Verified against a delegated EOA on a network running the EIP-7702-enabled configuration: it reaches selector dispatch exactly as a plain EOA does.

**It stops being harmless the moment a selector filter narrows either tuple** — e.g. `CallableByContract<OnlySomeSelectors>`. Delegated EOAs would then be caught by a restriction aimed at contracts, even though the caller is an ordinary user, and the failure would be hard to attribute from either side.

The comment exists so that whoever narrows those tuples decides deliberately whether delegated EOAs belong on the permitted side of the filter, rather than discovering the interaction from a bug report.

## Notes

- Relevant now because the hard-fork switch to Osaka enables EIP-7702; under the current Cancun configuration delegations are never applied, so no EOA can be in this state yet.
- `cargo check -p creditcoin3-runtime` clean, `cargo fmt --all --check` clean.
- `check-version` will go red, as it does on any PR touching `runtime/` — the devnet release pipeline bumps the version, so that is expected rather than something to resolve here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
