### PR TITLE
ci(try-runtime): only run when the migration surface actually changed

### DIFF
--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -73,9 +73,22 @@ jobs:
           # `pallet_x::migrations::v2::MigrateToV2` and `LazyMigrationV1ToV2` are all
           # caught. A false positive only costs a needless run, which is today's status
           # quo; a false negative would skip validation on a real migration.
-          if [ "${{ steps.filter.outputs.runtime_lib }}" = "true" ]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-            if git diff --unified=0 "origin/${{ github.base_ref }}...HEAD" -- runtime/src/lib.rs \
+          #
+          # The checkout above is `fetch-depth: 0`, so `origin/$base_ref` is already here.
+          # Do not re-fetch it with `--depth=1`: that grafts the base branch even in a
+          # complete clone, and the three-dot diff then dies with "no merge base" for any
+          # PR whose base has moved ahead. If the diff cannot be taken at all, run the job
+          # rather than swallow the error -- the whole point of the gate is that a false
+          # negative is the one outcome we cannot accept.
+          if [ "${{ github.event_name }}" = "pull_request" ] \
+             && [ "${{ steps.filter.outputs.runtime_lib }}" = "true" ]; then
+            if ! diff_output=$(git diff --unified=0 \
+                 "origin/${{ github.base_ref }}...HEAD" -- runtime/src/lib.rs); then
+              echo "WARN: cannot diff runtime/src/lib.rs against the base -- running to be safe"
+              echo "migrations=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if printf '%s\n' "$diff_output" \
                  | grep -E '^[+-]' \
                  | grep -vE '^(\+\+\+|---)' \
                  | grep -qiE 'migrat|OnRuntimeUpgrade'; then
@@ -90,7 +103,10 @@ jobs:
 
   try-runtime:
     needs: should-run
-    if: ${{ needs.should-run.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
+    # `needs:` alone would skip this job whenever the gate fails, taking the
+    # `workflow_dispatch` escape hatch down with it. `!cancelled()` keeps dispatch working
+    # regardless of what the gate did.
+    if: ${{ !cancelled() && (needs.should-run.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -23,7 +23,74 @@ env:
   CXXFLAGS: "-include cstdint"
 
 jobs:
+  # `runtime/src/lib.rs` has to stay in the trigger paths above, because the migration
+  # tuples live in it (`SingleBlockMigrations`, `pallet_migrations::Config::Migrations`).
+  # But that file also holds the entire rest of the runtime, so triggering on the filename
+  # alone runs this ~1h job for changes that cannot affect migrations at all -- an EVM
+  # config constant, a precompile bound, a weight tweak. This gate looks at what actually
+  # changed inside the file and only lets the expensive job through when the migration
+  # surface moved.
+  should-run:
+    runs-on: ubuntu-26.04
+    outputs:
+      migrations: ${{ steps.decide.outputs.migrations }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: "Examine which files have been modified by this PR"
+        uses: dorny/paths-filter@v4.0.2
+        id: filter
+        with:
+          filters: |
+            dedicated_migration_files:
+              - "**/migrations/**"
+              - "**/migrations.rs"
+            workflow:
+              - ".github/workflows/try-runtime.yml"
+            runtime_lib:
+              - "runtime/src/lib.rs"
+
+      - name: "Decide whether the migration surface changed"
+        id: decide
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Unambiguous: dedicated migration files, or this workflow itself.
+          if [ "${{ steps.filter.outputs.dedicated_migration_files }}" = "true" ] \
+             || [ "${{ steps.filter.outputs.workflow }}" = "true" ]; then
+            echo "INFO: migration files or this workflow changed"
+            echo "migrations=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # `runtime/src/lib.rs` changed. Inspect the diff hunks rather than the filename.
+          #
+          # The match is deliberately broad -- case-insensitive `migrat`, plus
+          # `OnRuntimeUpgrade` -- so that `SingleBlockMigrations`, `MultiBlockMigrator`,
+          # `pallet_x::migrations::v2::MigrateToV2` and `LazyMigrationV1ToV2` are all
+          # caught. A false positive only costs a needless run, which is today's status
+          # quo; a false negative would skip validation on a real migration.
+          if [ "${{ steps.filter.outputs.runtime_lib }}" = "true" ]; then
+            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            if git diff --unified=0 "origin/${{ github.base_ref }}...HEAD" -- runtime/src/lib.rs \
+                 | grep -E '^[+-]' \
+                 | grep -vE '^(\+\+\+|---)' \
+                 | grep -qiE 'migrat|OnRuntimeUpgrade'; then
+              echo "INFO: runtime/src/lib.rs changed and the migration surface moved"
+              echo "migrations=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "INFO: runtime/src/lib.rs changed, but not the migration surface -- skipping"
+          fi
+
+          echo "migrations=false" >> "$GITHUB_OUTPUT"
+
   try-runtime:
+    needs: should-run
+    if: ${{ needs.should-run.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Problem

The workflow triggers on `runtime/src/lib.rs`, and it has to — the migration tuples live there (`SingleBlockMigrations` at line 243, `pallet_migrations::Config::Migrations` at line 1082). But that file also holds the entire rest of the runtime, so **any** change to it starts a job that takes roughly an hour and scrapes live chain state, even when the change cannot affect migrations.

#1288 is the concrete case: an EVM config constant and two precompile bounds, no migrations registered, no storage touched — and it still triggered a full try-runtime run against live devnet.

## Change

A `should-run` gate, following the same `dorny/paths-filter` pattern `ci.yml` already uses.

- Dedicated migration files (`**/migrations/**`, `**/migrations.rs`) and edits to this workflow run unconditionally.
- For `runtime/src/lib.rs`, the gate inspects the **diff hunks** rather than the filename, and only proceeds when an added or removed line matches `migrat` (case-insensitive) or `OnRuntimeUpgrade`.
- `workflow_dispatch` still always runs.

The match is deliberately broad so that `SingleBlockMigrations`, `MultiBlockMigrator`, `pallet_x::migrations::v2::MigrateToV2` and `LazyMigrationV1ToV2` are all caught. A false positive costs one needless run — which is today's behaviour anyway — whereas a false negative would skip validation on a real migration. The bias is intentional.

## Verified

Against real and synthetic diffs, not just by inspection:

| Diff | Gate |
| --- | --- |
| **#1288** Osaka hard fork, real diff, no migrations | `skip` |
| new migration registered in `SingleBlockMigrations` | **run** |
| unrelated constant change in `lib.rs` | `skip` |

My first attempt at the pattern matched only `pallet_migrations` literally and **failed the positive case** — a registration like `pallet_foo::migrations::v2::MigrateToV2` slipped through. Caught by testing it; hence the broader match.

## Scope

This only changes *when* the job runs. It does nothing about the job failing when it does run, which is a separate problem: `remote-ext` gets rate-limited scraping live devnet, the state comes back incomplete, `Babe::authorities()` ends up empty, and `FindAuthorTruncated` panics indexing into it — surfacing as an opaque `BlockBuilder_finalize_block` trap rather than anything resembling the actual cause.

A snapshot-based approach fixes that and is being looked at separately. For reference, measured locally: a pallet-filtered testnet snapshot is 154 MB and takes 15 minutes to produce, after which `on-runtime-upgrade` against it runs in **4.5 seconds** and correctly reports the 131 → 133 migrations (`Session 0→1`, `Staking 15→16`, MBM finished in 1 block, entire state decodes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
