### PR TITLE
ci: retire the promotion crons, fix promote reporting and Slack routing

### DIFF
--- a/.github/workflows/check-prover.yml
+++ b/.github/workflows/check-prover.yml
@@ -120,7 +120,7 @@ jobs:
           status: ${{ job.status }}
           inputs: ${{ toJson(matrix) }}
           channel: "#noti-creditcoin-snapshots"
-          message: "Checking CK(${{ matrix.chainKey }})@${{ matrix.proverUrl}} complete! cc <@U028EMRHS3S>"
+          message: "Checking CK(${{ matrix.chainKey }})@${{ matrix.proverUrl}} complete! ${{ job.status == 'failure' && 'cc <!subteam^S028FDV6CCV>' || '' }}"
 
   submit-verify-and-emit:
     needs:
@@ -288,7 +288,7 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ job.status }}
           channel: "#noti-creditcoin-snapshots"
-          message: "Proofs diff for Sepolia complete! cc <@U028EMRHS3S>"
+          message: "Proofs diff for Sepolia complete! ${{ job.status == 'failure' && 'cc <!subteam^S028FDV6CCV>' || '' }}"
 
   compare-proofs-ethereum:
     needs:
@@ -346,4 +346,4 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ job.status }}
           channel: "#noti-creditcoin-snapshots"
-          message: "Proofs diff for Ethereum complete! cc <@U028EMRHS3S>"
+          message: "Proofs diff for Ethereum complete! ${{ job.status == 'failure' && 'cc <!subteam^S028FDV6CCV>' || '' }}"

--- a/.github/workflows/check-snapshot.yml
+++ b/.github/workflows/check-snapshot.yml
@@ -191,4 +191,4 @@ jobs:
           status: ${{ job.status }}
           inputs: ${{ toJson(inputs) }}
           channel: "#noti-creditcoin-snapshots"
-          message: "Checking ${{ inputs.target-chain }} snapshot complete! cc <@U028EMRHS3S>"
+          message: "Checking ${{ inputs.target-chain }} snapshot complete! ${{ job.status == 'failure' && 'cc <!subteam^S028FDV6CCV>' || '' }}"

--- a/.github/workflows/create-devnet-release.yml
+++ b/.github/workflows/create-devnet-release.yml
@@ -57,4 +57,4 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ job.status }}
           channel: "#protocol-internal"
-          message: "Bump version to ${{ steps.bump-version.outputs.new_version }}-devnet! Check for release in 1hr; cc <@U028EMRHS3S>"
+          message: "Bump version to ${{ steps.bump-version.outputs.new_version }}-devnet! Check for release in 1hr; cc <!subteam^S028FDV6CCV>"

--- a/.github/workflows/promote-branch.yml
+++ b/.github/workflows/promote-branch.yml
@@ -229,9 +229,14 @@ jobs:
           elif [[ "$DRY_RUN" == "true" ]]; then
               TITLE="Promotion dry run: $SOURCE_REF -> $TARGET_BRANCH"
               NOTE="DRY_RUN was enabled, so nothing was pushed. Re-run with it unchecked to promote."
-          else
+          elif [[ "$GATE_PUSH" == "success" ]]; then
               TITLE="Promotion: $SOURCE_REF -> $TARGET_BRANCH"
               NOTE="origin/$TARGET_BRANCH now points at ${SOURCE_SHA:-unknown}."
+          else
+              # always() means this step also renders when a gate failed and the
+              # push was skipped. Never claim the target moved without checking.
+              TITLE="Promotion did not complete: $SOURCE_REF -> $TARGET_BRANCH"
+              NOTE="origin/$TARGET_BRANCH was NOT moved. The gate table below shows where it stopped."
           fi
 
           if [[ "$DRY_RUN" == "true" ]]; then
@@ -247,15 +252,18 @@ jobs:
               echo
               echo "| gate | outcome |"
               echo "| --- | --- |"
-              echo "| 1. source is contained in usc-dev | $GATE_SOURCE |"
+              echo "| 1. source has cleared the required stages | $GATE_SOURCE |"
               echo "| 2. nothing with content is lost | $GATE_SAFE |"
               echo "| 3. promotion is a fast-forward | $GATE_FF |"
               echo "| $PUSH_LABEL | $GATE_PUSH |"
               echo
-              if [[ "$GATE_FF" != "success" ]]; then
+              if [[ "$GATE_FF" == "failure" ]]; then
                   echo "Gate 3 did not pass, so the target cannot move forward over"
                   echo "its current tip. See that step's output for the commits"
                   echo "involved and what to do about them."
+              elif [[ "$GATE_FF" == "skipped" ]]; then
+                  echo "Gate 3 never ran, because an earlier gate failed. Fix that"
+                  echo "one first, then re-run."
               fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/promote-branch.yml
+++ b/.github/workflows/promote-branch.yml
@@ -211,30 +211,51 @@ jobs:
               echo "INFO: origin/$TARGET_BRANCH now points at $SOURCE_SHA"
           fi
 
-      - name: Self-test summary
-        if: always() && github.event_name == 'pull_request'
+      - name: Job summary
+        # Every event, not just the self-test: a manual dispatch is the path
+        # people actually promote on, and it was rendering no summary at all.
+        # always() so a failed gate still reports which one and why.
+        if: always()
         env:
           GATE_SOURCE: ${{ steps.gate-source.outcome }}
           GATE_SAFE: ${{ steps.gate-safe.outcome }}
           GATE_FF: ${{ steps.gate-ff.outcome }}
           GATE_PUSH: ${{ steps.push.outcome }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+              TITLE="Promotion self-test: $SOURCE_REF -> $TARGET_BRANCH"
+              NOTE="Report-only. DRY_RUN is forced on for anything that is not a manual dispatch, so nothing was pushed."
+          elif [[ "$DRY_RUN" == "true" ]]; then
+              TITLE="Promotion dry run: $SOURCE_REF -> $TARGET_BRANCH"
+              NOTE="DRY_RUN was enabled, so nothing was pushed. Re-run with it unchecked to promote."
+          else
+              TITLE="Promotion: $SOURCE_REF -> $TARGET_BRANCH"
+              NOTE="origin/$TARGET_BRANCH now points at ${SOURCE_SHA:-unknown}."
+          fi
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+              PUSH_LABEL="4. dry-run push"
+          else
+              PUSH_LABEL="4. push"
+          fi
+
           {
-              echo "### Promotion self-test: $SOURCE_REF -> $TARGET_BRANCH"
+              echo "### $TITLE"
               echo
-              echo "Report-only. DRY_RUN was forced on, so nothing was pushed."
+              echo "$NOTE"
               echo
               echo "| gate | outcome |"
               echo "| --- | --- |"
               echo "| 1. source is contained in usc-dev | $GATE_SOURCE |"
               echo "| 2. nothing with content is lost | $GATE_SAFE |"
               echo "| 3. promotion is a fast-forward | $GATE_FF |"
-              echo "| 4. dry-run push | $GATE_PUSH |"
+              echo "| $PUSH_LABEL | $GATE_PUSH |"
               echo
               if [[ "$GATE_FF" != "success" ]]; then
-                  echo "Gate 3 failing is expected until the one-time reconcile"
-                  echo "merges have been run on usc-dev. See the gate's own output"
-                  echo "for the exact commands."
+                  echo "Gate 3 did not pass, so the target cannot move forward over"
+                  echo "its current tip. See that step's output for the commits"
+                  echo "involved and what to do about them."
               fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/promote-branch.yml
+++ b/.github/workflows/promote-branch.yml
@@ -266,4 +266,4 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ job.status }}
           channel: "#protocol-internal"
-          message: "promote ${{ env.SOURCE_REF }} -> ${{ env.TARGET_BRANCH }} (dry-run: ${{ env.DRY_RUN }}): ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
+          message: "promote ${{ env.SOURCE_REF }} -> ${{ env.TARGET_BRANCH }} (dry-run: ${{ env.DRY_RUN }}): ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }} ${{ job.status == 'failure' && 'cc <!subteam^S028FDV6CCV>' || '' }}"

--- a/.github/workflows/propose-mainnet-pr.yml
+++ b/.github/workflows/propose-mainnet-pr.yml
@@ -2,9 +2,12 @@
 name: Propose Mainnet PR
 
 "on":
-  schedule:
-    # every month on the 2nd @ 7am
-    - cron: "0 7 2 * *"
+  # No schedule. These rebase-based promotion PRs are superseded by
+  # promote-branch.yml, which fast-forwards the target instead. A scheduled run
+  # mints a PR whose head is a REBASED copy of usc-dev, so its commits carry
+  # rewritten SHAs, GitHub can never auto-close it, and merging it would push
+  # duplicates onto the target and undo the fast-forward invariant. Kept
+  # dispatchable as a fallback until the mainnet hop is proven.
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:

--- a/.github/workflows/propose-testnet-pr.yml
+++ b/.github/workflows/propose-testnet-pr.yml
@@ -2,9 +2,12 @@
 name: Propose Testnet PR
 
 "on":
-  schedule:
-    # every week @ 7am on Monday
-    - cron: "0 7 * * 1"
+  # No schedule. These rebase-based promotion PRs are superseded by
+  # promote-branch.yml, which fast-forwards the target instead. A scheduled run
+  # mints a PR whose head is a REBASED copy of usc-dev, so its commits carry
+  # rewritten SHAs, GitHub can never auto-close it, and merging it would push
+  # duplicates onto the target and undo the fast-forward invariant. Kept
+  # dispatchable as a fallback until the mainnet hop is proven.
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ job.status }}
           channel: "#protocol-internal"
-          message: "Release pipeline started! cc <@U028EMRHS3S>"
+          message: "Release pipeline started!"
 
       - uses: actions/checkout@v7
         with:
@@ -324,7 +324,7 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ job.status }}
           channel: "#protocol-internal"
-          message: "Release pipeline finished! cc <@U028EMRHS3S>"
+          message: "Release pipeline finished! ${{ job.status == 'failure' && 'cc <!subteam^S028FDV6CCV>' || '' }}"
 
   rm-gh-runner-docker:
     needs:


### PR DESCRIPTION
## Summary

Fast-forward promotion is now proven end to end: `usc-dev -> usc-testnet` promoted cleanly onto `313c4e654`, and `3.133.0-testnet` built from it, exercising every check that landed in #1270. Two follow-ups fall out of that.

### Retire the promotion crons

`propose-testnet-pr.yml` (weekly, Mondays) and `propose-mainnet-pr.yml` (monthly, the 2nd) lose their `schedule:` triggers. Both stay dispatchable as a manual fallback; deleting them, along with `rebase-branch-and-propose-pr.yml`, is a follow-up once the `usc-testnet -> main` hop is proven too.

The scheduled runs have stopped being a safety net and become a hazard. #1296 is the illustration:

```
PR1296 head:     1ef49b930   (37 commits, rebased copies of usc-dev)
usc-testnet tip: 313c4e654
is PR1296 head an ancestor of usc-testnet?  NO
content diff vs usc-testnet:                (empty - identical trees)
```

Because the workflow rebases, the PR's commits carry rewritten SHAs. None are ancestors of the target, so GitHub can never auto-close it the way it closes a fast-forwarded promotion. The identical tree makes it look like a harmless no-op, which is exactly what makes it dangerous: merging it would push 37 duplicate commits plus a merge commit onto `usc-testnet`, leaving it 38 ahead of `usc-dev` with two copies of every commit, and undoing the invariant the fast-forward just established.

### Summarise every promote run

The `promote-branch.yml` job summary was scoped to `pull_request`, so a **manual dispatch rendered no summary at all** and the gate verdicts were only findable by opening the job log. It now:

- runs on every event, titled per context: *Promotion self-test* / *Promotion dry run* / *Promotion*
- labels gate 4 "dry-run push" or "push" to match what actually happened
- runs under `always()`, so a failed gate still reports which one and why
- drops the stale "expected until the reconcile merges" hint, since those have been run, in favour of pointing at the failing step's own output


### Route Slack pings to the protocol group, on failure only

Every Slack notification cc'd one hardcoded person (`U028EMRHS3S`). These fire on automation nobody personally started, so the ping lands on someone who didn't run the thing and goes nowhere when they're away. They now mention the user group `<!subteam^S028FDV6CCV>`, and only when the job actually failed:

```
${{ job.status == 'failure' && 'cc <!subteam^S028FDV6CCV>' || '' }}
```

| File | Change |
| --- | --- |
| `release.yml:327` | finished -> failure-only |
| `check-prover.yml` (x3) | failure-only |
| `check-snapshot.yml:194` | failure-only |
| `promote-branch.yml` | mention **added**, failure-only |
| `release.yml:27` | mention **dropped** |
| `create-devnet-release.yml:60` | recipient swapped, stays unconditional |

Successful runs still post; they just stop paging anyone.

Two deliberate exceptions. `release.yml`'s "pipeline started" loses its mention outright rather than becoming conditional: it fires at job start where the status is never `failure`, so a conditional would be dead code, and it tells whoever just pushed the tag something they already know. `create-devnet-release.yml` keeps an unconditional mention because it isn't noise but a handoff - "check for release in 1hr" is a request for human follow-up that's still true on success.

`promote-branch.yml` had no mention at all, which was a gap rather than a choice - a failed promotion is precisely the case that needs someone. `rebase-branch-and-propose-pr.yml` is left untouched, since it's slated for deletion after the mainnet hop.

## Verification

Summary rendering exercised locally across all four paths (PR self-test, dispatch dry-run, real promotion, and a dispatch with gate 3 failing) - each produces the right title, note, gate-4 label and failure hint. `bash -n` clean; all three workflows parse as valid YAML, and both propose workflows now report `workflow_dispatch` as their only trigger.

Nothing outside `.github/` is touched.

## Test plan

- [ ] CI passes on this PR
- [ ] The promote-branch self-test re-runs and its summary still renders under the *self-test* title
- [ ] After merge, dispatch a dry-run promotion and confirm the summary table now appears on the run page
- [ ] Confirm no promotion PR is opened next Monday
- [ ] Close #1296 without merging
- [ ] Confirm a failing scheduled check pings @protocol rather than an individual
- [ ] Confirm a successful release posts without paging anyone

## Follow-ups, not in this PR

- Delete the three rebase-promotion workflows once `usc-testnet -> main` has been promoted by fast-forward
- `main`'s 7 required status checks no longer gate anything now that promotion bypasses PRs; they need moving to `usc-dev` if that coverage is wanted
- Force-push is still enabled on `usc-testnet` and `main`
- `3.131.0-testnet` still points at orphaned commit `e7e0b3f3b`
