### PR TITLE
ci: pin the azure-cli apt repo, unbreak the runtime upgrade checks

### DIFF
--- a/.github/install-azure-cli.sh
+++ b/.github/install-azure-cli.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# NOTE: needs to be executed via sudo
+
+# Installs the Azure CLI from Microsoft's apt repository.
+#
+# We pin the repository to a fixed Ubuntu codename instead of using
+# https://aka.ms/InstallAzureCLIDeb, which derives the codename from the
+# running system. Our self-hosted runners moved to linode/ubuntu26.04
+# (resolute), and Microsoft publishes dist metadata for resolute but ships no
+# packages in it:
+#
+#     dists/resolute/main/binary-amd64/Packages -> 200, 0 bytes
+#     dists/noble/main/binary-amd64/Packages    -> 200, 22 KB
+#
+# So InRelease downloads fine and apt then reports "Unable to locate package
+# azure-cli". Pinning is safe because the azure-cli deb bundles its own Python
+# and depends only on C libraries (libc6, libffi8, libssl3t64, libuuid1,
+# zlib1g, libbz2-1.0), all of which resolute still ships.
+#
+# Revisit REPO_CODENAME once Microsoft publishes for a newer release.
+
+set -euo pipefail
+
+REPO_CODENAME="noble"
+KEYRING="/etc/apt/keyrings/microsoft.gpg"
+
+mkdir -p /etc/apt/keyrings
+
+curl -sLS https://packages.microsoft.com/keys/microsoft.asc \
+    | gpg --dearmor --yes -o "$KEYRING"
+chmod go+r "$KEYRING"
+
+cat > /etc/apt/sources.list.d/azure-cli.list <<EOF
+deb [arch=$(dpkg --print-architecture) signed-by=$KEYRING] https://packages.microsoft.com/repos/azure-cli/ $REPO_CODENAME main
+EOF
+
+apt-get update
+apt-get install -y azure-cli
+
+az version

--- a/.github/workflows/check-snapshot.yml
+++ b/.github/workflows/check-snapshot.yml
@@ -101,10 +101,8 @@ jobs:
 
       - name: Install azure-cli
         run: |
-          sudo apt remove azure-cli -y && sudo apt autoremove -y
-          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-          sudo apt install -y jq unzip
-          az version
+          sudo apt-get install -y jq unzip
+          sudo .github/install-azure-cli.sh
 
       - name: Azure Login with OIDC
         uses: azure/login@v3

--- a/.github/workflows/check-snapshot.yml
+++ b/.github/workflows/check-snapshot.yml
@@ -101,8 +101,8 @@ jobs:
 
       - name: Install azure-cli
         run: |
-          sudo apt-get install -y jq unzip
           sudo .github/install-azure-cli.sh
+          sudo apt-get install -y jq unzip
 
       - name: Azure Login with OIDC
         uses: azure/login@v3

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -275,10 +275,8 @@ jobs:
 
       - name: Install azure-cli
         run: |
-          sudo apt remove azure-cli -y && sudo apt autoremove -y
-          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-          sudo apt install -y jq
-          az version
+          sudo apt-get install -y jq
+          sudo .github/install-azure-cli.sh
 
       - name: Azure Login with OIDC
         uses: azure/login@v3

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -275,8 +275,8 @@ jobs:
 
       - name: Install azure-cli
         run: |
-          sudo apt-get install -y jq
           sudo .github/install-azure-cli.sh
+          sudo apt-get install -y jq
 
       - name: Azure Login with OIDC
         uses: azure/login@v3


### PR DESCRIPTION
## Summary

`runtime-upgrade.yml` has failed **every run since 2026-08-17**, and `check-testnet-snapshot.yml` since **2026-08-29**. Both die at the same step:

```
job:  live-sync-creditcoin / check-snapshot
step: Install azure-cli
E: Unable to locate package azure-cli
```

These are the pre-flight checks for a runtime upgrade, and they have been down through the whole `3.133.0-testnet` release, which carries stable2512 with spec `131 -> 133` and `transaction_version 2 -> 3`.

## Cause

The self-hosted runners moved to `linode/ubuntu26.04` (codename `resolute`), and `https://aka.ms/InstallAzureCLIDeb` derives the apt repo codename from the running system. Microsoft publishes **dist metadata** for resolute but ships **no packages** in it:

```
dists/resolute/main/binary-amd64/Packages -> 200,  0 bytes,  0 azure-cli entries
dists/noble/main/binary-amd64/Packages    -> 200, 22 KB,    32 azure-cli entries
```

So `InRelease` downloads happily (which is why the log looks like the repo is fine) and `apt` then finds nothing to install.

## Fix

Replace the auto-detecting installer with `.github/install-azure-cli.sh`, following the existing `install-solidity-compiler.sh` convention, pinning the repo to a codename Microsoft actually publishes for.

Pinning is safe here rather than merely expedient: the azure-cli deb bundles its own Python and depends only on C libraries. Verified against the resolute archive index that it ships every one:

```
Depends: libbz2-1.0, libc6, libffi8, libgcc-s1, libssl3t64, libuuid1, zlib1g
resolute main/binary-amd64:  libbz2-1.0  libffi8  libssl3t64  libuuid1  zlib1g   [all present]
```

The script carries a comment explaining why it is pinned and a note to revisit `REPO_CODENAME` once Microsoft publishes for a newer release.

Also drops the leading `sudo apt remove azure-cli -y`. It exists to clear a preinstalled copy, but on a fresh VM there is nothing to remove and it emits its **own** `Unable to locate package azure-cli` earlier in the log, which reads exactly like the real failure. That cost real time while diagnosing this.

## Verification

Static checks only; the real proof is a run on the self-hosted runner.

- `bash -n` clean on the new script; both workflows parse as valid YAML
- No `aka.ms/InstallAzureCLIDeb` call sites remain
- `dists/noble/InRelease` returns 200 and the index offers `azure-cli` for `amd64`
- Every runtime dependency of the deb confirmed present in the resolute archive

## Test plan

- [ ] CI passes on this PR
- [ ] Dispatch `Check Testnet Snapshot` and confirm `Install azure-cli` succeeds and `az version` prints
- [ ] Dispatch `Runtime Upgrade` against testnet and confirm it gets past install
- [ ] Then use it to validate `131 -> 133` before applying the upgrade on-chain

## Not in this PR

- `try-runtime.yml` is separately broken: zero successes in the last 30 runs. It panics in `on_finalize` at an unchecked `Babe::authorities()[author_index]` index in `FindAuthorTruncated`. That code is **byte-identical to what `main` already runs**, so it is not a regression from this release; the run also logged repeated `Rate limit exceeded` from `remote-ext`, which would leave the authorities list short and produce exactly that bounds panic. Worth its own investigation.
