### PR TITLE
chore: refresh Cargo.lock after the usc-dev merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18193,7 +18193,7 @@ dependencies = [
 
 [[package]]
 name = "write-ability"
-version = "3.132.0"
+version = "3.133.0"
 dependencies = [
  "alloy",
  "parity-scale-codec",


### PR DESCRIPTION
Unblocks `build / build-wasm-runtime` on #1215 — the job that produces the runtime we need for cc3-devnet.

## Why it still failed after the merge

The merge brought the workspace version to `3.133.0`, but `Cargo.lock` kept `write-ability` at `3.132.0`, so srtool's `--locked` build still fails:

```
error: the lock file /build/Cargo.lock needs to be updated but --locked was passed
```

Every crate that exists on **both** branches picked up `usc-dev`'s `3.133.0` during the textual lockfile merge. `common/write-ability` exists **only on this branch**, so `usc-dev`'s lockfile had no entry to merge from and the stale version survived — while the crate itself inherits the workspace version through `version.workspace = true`.

## The change

```diff
-version = "3.132.0"
+version = "3.133.0"
```

That is the entire diff.

## Verified

- `cargo metadata --locked` passes (this is srtool's constraint, and what was failing)
- `cargo check -p creditcoin3-runtime --locked` clean
- zero remaining `3.132.0` occurrences in `Cargo.lock`