### PR TITLE
chore(deps): bump frontier_2 pin for the stable2512 RPC/EVM fixes (feeHistory DoS, EIP-7702 metering, filter DoS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4605,7 +4605,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4617,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "fc-cli"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "clap",
  "ethereum-types 0.15.1",
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4651,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4704,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4774,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4976,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4994,7 +4994,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -5005,7 +5005,7 @@ dependencies = [
 [[package]]
 name = "fp-dynamic-fee"
 version = "1.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "async-trait",
  "sp-core",
@@ -5015,7 +5015,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -5027,7 +5027,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "environmental",
  "evm",
@@ -5043,7 +5043,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -5059,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5071,7 +5071,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9106,7 +9106,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9138,7 +9138,7 @@ dependencies = [
 [[package]]
 name = "pallet-dynamic-fee"
 version = "4.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "fp-dynamic-fee",
  "fp-evm",
@@ -9153,7 +9153,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -9176,7 +9176,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "environmental",
  "ethereum",
@@ -9200,7 +9200,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "fp-evm",
  "num",
@@ -9353,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9457,7 +9457,7 @@ dependencies = [
 [[package]]
 name = "pallet-hotfix-sufficients"
 version = "1.0.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10638,7 +10638,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "derive_more 1.0.0",
  "environmental",
@@ -10667,7 +10667,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#811278146e6d09c81b12a2afd25a3cd05e5cd17e"
+source = "git+https://github.com/gluwa/frontier_2?branch=stable2512_patch_no_extension#d9249d6440f35d1688a34692c32e3a15c62a6ad5"
 dependencies = [
  "case",
  "num_enum 0.7.6",


### PR DESCRIPTION
## What

Bumps the locked `gluwa/frontier_2` rev (`stable2512_patch_no_extension`) from `811278146` to `d9249d644`, pulling in three fixes to bugs that exist in our stable2512 patch branch.

## Fixes included

**1. `eth_feeHistory` node-crash (gluwa/frontier_2#20, ports upstream #1896) — DoS**
A single **unauthenticated** request with an oversized `blockCount` (e.g. `2^64`) crashed the entire node process: `impl From<BlockCount> for u64` narrowed with `U256::as_u64()`, which panics, and the cast happened before the 1024-block clamp. Now saturates to `u64::MAX`.

**2. EIP-7702 delegation writes bypass the storage-growth limit (gluwa/frontier_2#21, ports upstream #1901) — consensus**
`set_delegation` wrote `AccountCodes`/`AccountCodesMetadata` without recording storage growth. With `GasLimitStorageGrowthRatio` non-zero (ours is `BLOCK_GAS_LIMIT / 400 KiB`) and Osaka/EIP-7702 enabled in 3.133.0, a type-4 SetCode transaction could grow state past the per-tx safety cap and succeed where it should revert with `OutOfGas`. Now metered like contract deployment.

**3. Filter API bypasses the `eth_getLogs` range cap (gluwa/frontier_2#22, adapts upstream #1824) — DoS**
The 2048-block cap was enforced only in `logs()`; `eth_newFilter` / `eth_getFilterLogs` / `eth_getFilterChanges` ran the same unbounded log scan. Now the cap is enforced at filter creation and on `getFilterLogs`.

## Scope

`git compare 811278146...d9249d644` touches only `client/rpc/src/eth/filter.rs` and `frame/evm/src/runner/stack.rs` — no dependency-graph change, polkadot-sdk rev unchanged (`3b3ed758`). This is a **Cargo.lock-only** bump; `Cargo.toml` tracks the branch (no rev pin).

## ⚠️ Consensus note

Fix #2 (EIP-7702 metering) is **consensus-affecting** and must take effect under a new runtime `spec_version` — it should ship as part of a runtime upgrade, not a node-only rebuild.

## Verification

- `cargo check --locked -p creditcoin3-node` — succeeds against the new rev (no polkadot-sdk drift).
- feeHistory: node-death reproduced on an unpatched build; fixed build (this rev) returns a normal result and stays up.
- Upstream audit that surfaced #2 and #3, and the ruled-out candidates, is recorded internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
