### PR TITLE
ci: fail fast and show the node log when Ethereum never comes up

### DIFF
--- a/.github/wait-for-ethereum.sh
+++ b/.github/wait-for-ethereum.sh
@@ -1,19 +1,58 @@
 #!/bin/bash
 
-# Note: both WS and HTTP are served via the same port
-TARGET_URL=${1:-http://127.0.0.1:8545}
-CURL_PARAMS="-H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[],\"id\":67}' $TARGET_URL"
+# Wait for an Ethereum JSON-RPC endpoint to start answering.
+#
+#   wait-for-ethereum.sh <url> [log-file]
+#
+# `log-file` is optional. When the wait times out its tail is printed, because the node's
+# stdout normally goes to a file under /var/tmp that is only reachable through the uploaded
+# artifact — without it a node that fails to start is indistinguishable from a slow one.
+#
+# The budget is deliberately modest. A node that is coming up answers inside a few seconds;
+# one that failed to bind its port never will, and a long budget only turns a fast failure
+# into an expensive silent one. Override with WAIT_FOR_ETHEREUM_TIMEOUT_SECS if a caller
+# genuinely needs longer.
 
-COUNTER=0
-# make sure there is a node running at TARGET_URL
-while [[ "$(eval curl -s -o /dev/null -w '%{http_code}' "$CURL_PARAMS")" != "200" && $COUNTER -lt 50 ]]; do
-    echo "INFO: $COUNTER - Not ready yet ....."
-    (( COUNTER=COUNTER+1 ))
-    sleep 50
+set -uo pipefail
+
+TARGET_URL=${1:-http://127.0.0.1:8545}
+LOG_FILE=${2:-}
+
+POLL_INTERVAL_SECS=2
+TIMEOUT_SECS=${WAIT_FOR_ETHEREUM_TIMEOUT_SECS:-300}
+MAX_ATTEMPTS=$(( TIMEOUT_SECS / POLL_INTERVAL_SECS ))
+
+probe() {
+    # Note: both WS and HTTP are served via the same port.
+    curl -s -o /dev/null -w '%{http_code}' \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":67}' \
+        "${TARGET_URL}"
+}
+
+for (( attempt = 0; attempt < MAX_ATTEMPTS; attempt++ )); do
+    if [[ "$(probe)" == "200" ]]; then
+        echo "INFO: ${TARGET_URL} ready after $(( attempt * POLL_INTERVAL_SECS ))s"
+        exit 0
+    fi
+    # Report every 30s rather than every attempt: at a 2s interval a per-attempt line would
+    # bury the rest of the step in noise for a wait that is usually over almost immediately.
+    if (( attempt > 0 && (attempt * POLL_INTERVAL_SECS) % 30 == 0 )); then
+        echo "INFO: ${TARGET_URL} not ready after $(( attempt * POLL_INTERVAL_SECS ))s ....."
+    fi
+    sleep "${POLL_INTERVAL_SECS}"
 done
 
-# fail if we still can't connect after 20 attempts
-set -e
+echo "ERROR: ${TARGET_URL} did not answer web3_clientVersion within ${TIMEOUT_SECS}s" >&2
 
-# Note: using eval b/c params are specified as string above
-eval curl "$CURL_PARAMS" > /dev/null
+if [[ -n "${LOG_FILE}" ]]; then
+    if [[ -f "${LOG_FILE}" ]]; then
+        echo "----- tail -n 100 ${LOG_FILE} -----" >&2
+        tail -n 100 "${LOG_FILE}" >&2
+        echo "----- end ${LOG_FILE} -----" >&2
+    else
+        echo "ERROR: no log at ${LOG_FILE} — the node likely never started" >&2
+    fi
+fi
+
+exit 1

--- a/.github/workflows/attestor-compatibility.yml
+++ b/.github/workflows/attestor-compatibility.yml
@@ -299,7 +299,7 @@ jobs:
 
       - name: Wait for Anvil
         run: |
-          .github/wait-for-ethereum.sh 'http://127.0.0.1:8141'
+          .github/wait-for-ethereum.sh 'http://127.0.0.1:8141' "${LOG_DIR}/anvil.log"
 
       # NOTE: no archiver here. The attestor pulls source-chain data and builds
       # its own continuity-proof merkle roots directly from --eth-url (via

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,8 +264,8 @@ jobs:
       - name: Check that creditcoin-node and anvil are running
         run: |
           .github/wait-for-creditcoin.sh 'http://127.0.0.1:9944'
-          .github/wait-for-ethereum.sh 'http://127.0.0.1:8141'
-          .github/wait-for-ethereum.sh 'http://127.0.0.1:8242'
+          .github/wait-for-ethereum.sh 'http://127.0.0.1:8141' /var/tmp/integration-test-attestor-network/anvil1.log
+          .github/wait-for-ethereum.sh 'http://127.0.0.1:8242' /var/tmp/integration-test-attestor-network/anvil2.log
 
       - name: Start archiver against Anvil1
         env:
@@ -552,7 +552,7 @@ jobs:
             >>/var/tmp/integration-test-attestor-network/anvil1.log 2>&1 &
           echo $! >/var/tmp/integration-test-attestor-network/anvil1.pid
 
-          .github/wait-for-ethereum.sh 'http://127.0.0.1:8141'
+          .github/wait-for-ethereum.sh 'http://127.0.0.1:8141' /var/tmp/integration-test-attestor-network/anvil1.log
           ~/.foundry/bin/cast rpc --rpc-url http://127.0.0.1:8141 anvil_mine 0xc8
 
           for _ in $(seq 1 18); do
@@ -1884,7 +1884,7 @@ jobs:
       - name: Check that creditcoin-node and anvil are running
         run: |
           .github/wait-for-creditcoin.sh 'http://127.0.0.1:9944'
-          .github/wait-for-ethereum.sh 'http://127.0.0.1:8141'
+          .github/wait-for-ethereum.sh 'http://127.0.0.1:8141' /var/tmp/archiver-testing/anvil.log
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v7


### PR DESCRIPTION
Found while diagnosing the "flaky" attestor CI jobs on the writeability branch.

## The problem

`.github/wait-for-ethereum.sh` polls every 50s for 50 attempts. An endpoint that is never going to answer therefore costs **41.7 minutes** before the step gives up, and it gives up with a bare `curl: (7)` — the node's stdout is redirected to a file under `/var/tmp` that is only reachable via the uploaded artifact, so nothing explaining the failure reaches the job output.

A real run of `integration-test-attestator-network` hit exactly this: 49 iterations of `INFO: N - Not ready yet .....`, then `curl: (7)`, and no way to tell whether Anvil crashed, failed to bind, or was merely slow.

## Changes

- **Poll every 2s against a 300s budget**, overridable with `WAIT_FOR_ETHEREUM_TIMEOUT_SECS`. Measured against a real run, a healthy node answers inside the *first* 50s sleep — so the old interval was also charging every one of the 14 call sites up to 50s on the happy path.
- **Optional log-file argument, tailed on timeout.** Wired into the five call sites that redirect the node to a file (`ci.yml` 267/268/555/1887, `attestor-compatibility.yml` 302). The remaining call sites let Anvil write straight to the job log, so they are already diagnosable and are left alone.
- Drop the `eval` + string-quoted curl arguments, fix the stale `after 20 attempts` comment (it was 50), and move `set -e` off a line where it only ever guarded the final probe.

## Verification

- `shellcheck` clean; `bash -n` clean; both edited workflows parse as YAML.
- Exercised locally: timeout path with a log (tails it), timeout with a missing log (says so), timeout with no log argument (unchanged behaviour for the other 9 call sites), and the success path against an endpoint that appears after 5s — detected in **6s**, where the old script would have taken 50s.

## Scope

This is CI hygiene only and is deliberately targeted at `usc-dev` so every branch picks it up. It does **not** fix the underlying flake — that is a separate, writeability-only bug in the attestor's Outbox resolver, handled in its own PR.