### PR TITLE
ci(scout): compare PR builds against the published image instead of inventorying them

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -72,23 +72,40 @@ jobs:
       # where continue-on-error silently masked this for every PR build. Uses the read-only
       # gluwabot/DOCKERHUB_SCOUT_TOKEN credential (never DOCKER_PUSH_*) since PR builds run untrusted
       # Dockerfile/build-script content and must not see a push-capable credential.
-      - name: Docker Scout - CVE scan (${{ github.repository }})
+      # `compare`, not `cves`: a full-inventory scan is dominated by the base image's CVE
+      # backlog, identical on every PR and unrelated to its diff — which had gluwa-bot posting
+      # the same ~130-CVE wall on every Rust-touching PR. Comparing the PR's build against the
+      # *published* image instead makes the comment show only what the PR changes (packages and
+      # CVEs added/removed relative to what is deployed). NOTE: on PR runs `version-string` is
+      # literally "latest", so both sides of the compare print as `gluwa/creditcoin3:latest` —
+      # the `local://` / `registry://` schemes are what distinguish the PR's local build from
+      # the published Docker Hub image.
+      - name: Docker Scout - compare ${{ github.repository }} against published :latest
         continue-on-error: true
         uses: docker/scout-action@v1.23.1
         with:
-          command: cves
+          command: compare
           image: local://${{ github.repository }}:${{ inputs.version-string }}
+          to: registry://${{ github.repository }}:latest
+          # Keep the comment to the actual delta — unchanged packages are exactly the
+          # inventory noise this step exists to eliminate.
+          ignore-unchanged: true
           dockerhub-user: ${{ secrets.DOCKERHUB_SCOUT_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_SCOUT_TOKEN }}
           exit-code: false
-          # DO-2336/DO-2338: without this, the action's default "one comment per job"
-          # behavior means the 3rd scan below silently overwrites the first two's
-          # results in the same PR comment. keep-previous-comments preserves all 3.
-          keep-previous-comments: true
+          # This is now the only step that comments (the two scans below are summary-only), so
+          # the action's default replace-my-previous-comment behavior gives one live comparison
+          # per PR instead of the DO-2336 pile-up.
+          keep-previous-comments: false
           # gluwa-bot PAT (pull-requests:write only) — GITHUB_TOKEN's own permissions
           # couldn't be elevated without a hard startup_failure (see comment above).
           github-token: ${{ secrets.GLUWA_BOT_PR }}
 
+      # Summary-only (write-comment: false): no published moving tag exists for this image
+      # (only versioned indexer-for-<x.y.z>-<net> tags), so there is no stable baseline to compare
+      # against — and its base layers are shared with the node image, whose compare above
+      # already surfaces PR-introduced CVEs as the PR comment. Full inventory stays visible in
+      # the job summary and in the weekly Scout report.
       - name: Docker Scout - CVE scan (${{ github.repository }}:indexer-for-${{ inputs.version-string }})
         continue-on-error: true
         uses: docker/scout-action@v1.23.1
@@ -98,14 +115,13 @@ jobs:
           dockerhub-user: ${{ secrets.DOCKERHUB_SCOUT_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_SCOUT_TOKEN }}
           exit-code: false
-          # DO-2336/DO-2338: without this, the action's default "one comment per job"
-          # behavior means the 3rd scan below silently overwrites the first two's
-          # results in the same PR comment. keep-previous-comments preserves all 3.
-          keep-previous-comments: true
-          # gluwa-bot PAT (pull-requests:write only) — GITHUB_TOKEN's own permissions
-          # couldn't be elevated without a hard startup_failure (see comment above).
-          github-token: ${{ secrets.GLUWA_BOT_PR }}
+          write-comment: false
 
+      # Summary-only (write-comment: false): no published moving tag exists for this image
+      # (only versioned proof-gen-stress-test-for-<x.y.z>-<net> tags), so there is no stable baseline to compare
+      # against — and its base layers are shared with the node image, whose compare above
+      # already surfaces PR-introduced CVEs as the PR comment. Full inventory stays visible in
+      # the job summary and in the weekly Scout report.
       - name: Docker Scout - CVE scan (${{ github.repository }}:proof-gen-stress-test-for-${{ inputs.version-string }})
         continue-on-error: true
         uses: docker/scout-action@v1.23.1
@@ -115,13 +131,7 @@ jobs:
           dockerhub-user: ${{ secrets.DOCKERHUB_SCOUT_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_SCOUT_TOKEN }}
           exit-code: false
-          # DO-2336/DO-2338: without this, the action's default "one comment per job"
-          # behavior means the 3rd scan below silently overwrites the first two's
-          # results in the same PR comment. keep-previous-comments preserves all 3.
-          keep-previous-comments: true
-          # gluwa-bot PAT (pull-requests:write only) — GITHUB_TOKEN's own permissions
-          # couldn't be elevated without a hard startup_failure (see comment above).
-          github-token: ${{ secrets.GLUWA_BOT_PR }}
+          write-comment: false
 
       - name: Export docker image into a file
         run: |


### PR DESCRIPTION
Fixes the gluwa-bot CVE-wall comments appearing on nearly every PR (e.g. #1308, #1215).

## Why it spammed

`docker.yml` triggers on any PR touching `**.rs`/`**.toml` into main/usc-dev/usc-testnet, and `build-docker.yml` ran three `docker scout cves` scans with the action's default `write-comment: true`. A full-inventory scan is dominated by the base image's CVE backlog — **2 critical / 13 high today, identical from PR to PR, unrelated to the diff**. (The tag in the comment is also misleading: on PR runs `version-string` is literally `latest`, so the PR's own local build gets scanned wearing the published image's name.)

## Change

- **Node image: `cves` → `compare`** against `registry://gluwa/creditcoin3:latest` — the actually-published image — with `ignore-unchanged: true`. The PR comment now shows only packages/CVEs the PR **adds or removes relative to what is deployed**: an empty delta is a small comment, a real regression is finally visible instead of buried in inventory. `local://` vs `registry://` schemes distinguish the two sides (both print as `:latest` on PR runs — noted inline).
- **Indexer + proof-gen-stress-test: keep full `cves`, add `write-comment: false`.** No published moving tag exists for either (only versioned `<flavor>-for-x.y.z-<net>` tags), so there is no stable compare baseline — and their base layers are shared with the node image, whose compare already surfaces PR-introduced CVEs. Inventories stay in the job summary and the weekly Scout report (`docker-scout-weekly-report.yml`).
- With a single commenting step left, the DO-2336 `keep-previous-comments` workaround inverts: default replace-behavior now yields **one live comparison comment per PR** instead of three piling up per push — set to `false` on the compare step, moot on the others.

## Notes

- Auth unchanged: the same read-only `DOCKERHUB_SCOUT_*` credential covers the registry side of the compare; comments still post via the `GLUWA_BOT_PR` PAT.
- `exit-code: false` + `continue-on-error` retained — informational, never gates (DO-2217/DO-2338 stance unchanged). If we later want to *fail* PRs that add criticals, `compare` is the right substrate for that gate.
- Verified `to`, `ignore-unchanged`, `write-comment` all exist as inputs in `scout-action@v1.23.1`'s action.yaml; workflow YAML parses.
- On release builds (`x.y.z-mainnet` etc.) the compare runs new-release-vs-previous-latest, which is a sensible report there too.