### PR TITLE
ci: stop the automated monthly devnet release cron

### DIFF
--- a/.github/workflows/create-devnet-release.yml
+++ b/.github/workflows/create-devnet-release.yml
@@ -2,9 +2,6 @@
 name: Create Devnet release
 
 "on":
-  schedule:
-    # every month, on the 2nd @ 6am
-    - cron: "0 6 2 * *"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Removes the monthly `schedule` cron trigger from `create-devnet-release.yml`
- Workflow stays available via `workflow_dispatch` for manual runs
- `check-devnet-snapshot.yml` (unrelated snapshot health check) is left untouched

## Test plan
- [ ] Confirm the workflow no longer appears with a scheduled trigger in the Actions tab
- [ ] Confirm manual dispatch still works