### PR TITLE
fix(proof-gen): make /health reflect serving ability, log probe failures

### DIFF
--- a/proof-gen-api-server/src/networking/routes/health.rs
+++ b/proof-gen-api-server/src/networking/routes/health.rs
@@ -12,13 +12,53 @@ const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
 /// Health check response schema for OpenAPI
 #[derive(Serialize, ToSchema)]
 pub struct HealthCheckResponse {
+    /// `healthy` when this replica can serve proofs: its cc3 caches are advancing and the
+    /// source-chain RPC is reachable. `degraded` otherwise.
     status: String,
+    /// Live cc3 RPC storage probe across every configured chain. Diagnostic only — a false
+    /// here with `cc3_cache_fresh: true` means the subscription is fine but a point-in-time
+    /// read failed; the reason is logged at WARN as `cc3 RPC probe failed`.
     cc3_rpc_connected: bool,
     eth_rpc_connected: bool,
+    /// Whether the cc3 event subscription advanced every chain's cache within the freshness
+    /// window. This is what proof serving actually depends on.
+    cc3_cache_fresh: bool,
+    /// Seconds since the least-recently-advanced chain's cache last changed.
+    cc3_cache_age_seconds: u64,
     uptime_seconds: u64,
 }
 
-/// Main health check endpoint - validates upstream services
+/// Run one upstream probe under the shared timeout, logging why it failed if it does.
+/// The previous implementation reduced the error to a bare `false` via `is_ok_and`, which
+/// left no record anywhere of the cause.
+async fn probe<F>(name: &'static str, fut: F) -> bool
+where
+    F: std::future::Future<Output = anyhow::Result<()>>,
+{
+    match timeout(HEALTH_CHECK_TIMEOUT, fut).await {
+        Ok(Ok(())) => true,
+        Ok(Err(err)) => {
+            tracing::warn!(probe = name, ?err, "🩺 health probe failed");
+            false
+        }
+        Err(_) => {
+            tracing::warn!(
+                probe = name,
+                timeout_secs = HEALTH_CHECK_TIMEOUT.as_secs(),
+                "🩺 health probe timed out"
+            );
+            false
+        }
+    }
+}
+
+/// Main health check endpoint.
+///
+/// `status` is driven by what serving proofs actually requires — fresh cc3 caches and a
+/// reachable source chain — rather than by the live cc3 storage probe. That probe is kept in
+/// the payload and logged on failure, but on its own it was reporting replicas as degraded
+/// while they served proofs with zero errors, because the request path reads the caches and
+/// never issues that query.
 #[utoipa::path(
     get,
     path = "/api/v1/health",
@@ -27,21 +67,21 @@ pub struct HealthCheckResponse {
 pub async fn health_check(
     Extension(service): Extension<Arc<ContinuityService>>,
 ) -> Json<HealthCheckResponse> {
-    // Check RPC connectivity in parallel with timeout
     let (cc3_connected, eth_connected) = tokio::join!(
-        async {
-            timeout(HEALTH_CHECK_TIMEOUT, service.check_cc3_connectivity())
-                .await
-                .is_ok_and(|result| result.is_ok())
-        },
-        async {
-            timeout(HEALTH_CHECK_TIMEOUT, service.check_eth_connectivity())
-                .await
-                .is_ok_and(|result| result.is_ok())
-        }
+        probe("cc3_rpc", service.check_cc3_connectivity()),
+        probe("eth_rpc", service.check_eth_connectivity()),
     );
 
-    let status = if cc3_connected && eth_connected {
+    let freshness = service.cc3_cache_freshness();
+    if !freshness.fresh {
+        tracing::warn!(
+            stale_chains = ?freshness.stale_chains,
+            max_age_seconds = freshness.max_age_seconds,
+            "🩺 cc3 cache stale — event subscription not advancing"
+        );
+    }
+
+    let status = if freshness.fresh && eth_connected {
         "healthy".to_string()
     } else {
         "degraded".to_string()
@@ -51,6 +91,8 @@ pub async fn health_check(
         status,
         cc3_rpc_connected: cc3_connected,
         eth_rpc_connected: eth_connected,
+        cc3_cache_fresh: freshness.fresh,
+        cc3_cache_age_seconds: freshness.max_age_seconds,
         uptime_seconds: service.uptime_seconds(),
     })
 }

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -29,6 +29,34 @@ pub struct ChainState {
     pub attestation_genesis_block: AtomicU64,
     pub checkpoint_interval: AtomicU64,
     pub attestation_interval: AtomicU64,
+    /// Wall-clock instant of the last event-driven write to the attestation or checkpoint
+    /// cache. This is the health signal that actually tracks serving ability: proofs are
+    /// answered from these caches, and the caches are fed by the cc3 finalized-block
+    /// subscription. If this stops advancing, the subscription is dead and the replica will
+    /// start returning `BlockNotReady` for anything newer than its frozen view — regardless
+    /// of what a point-in-time RPC probe says. Initialised to construction time so a fresh
+    /// pod counts as healthy until real events land (same convention as the attestor's
+    /// liveness watchdog).
+    pub last_cache_advance: std::sync::Mutex<Instant>,
+}
+
+impl ChainState {
+    /// Record that the cc3 event subscription just advanced one of the caches.
+    fn touch_cache(&self) {
+        let mut guard = self
+            .last_cache_advance
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *guard = Instant::now();
+    }
+
+    /// Time since the cc3 event subscription last advanced a cache.
+    fn cache_age(&self) -> Duration {
+        self.last_cache_advance
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .elapsed()
+    }
 }
 
 // Single block proof query object, used in batch requests to specify which transactions to include merkle proofs for. If a block is included in the batch but not listed in the tx_indexes, it will be processed with tx_index = None (continuity proof only)
@@ -166,6 +194,21 @@ pub struct ContinuityService {
     max_batch_span: u64,
 }
 
+/// How long the caches may go without an event-driven write before the cc3 subscription is
+/// considered dead for health purposes. See [`ContinuityService::cc3_cache_freshness`].
+pub const CC3_CACHE_STALE_AFTER: Duration = Duration::from_secs(10 * 60);
+
+/// Result of [`ContinuityService::cc3_cache_freshness`].
+#[derive(Debug, Clone)]
+pub struct CacheFreshness {
+    /// True when every configured chain's cache advanced within [`CC3_CACHE_STALE_AFTER`].
+    pub fresh: bool,
+    /// Age of the least-recently-advanced chain's cache.
+    pub max_age_seconds: u64,
+    /// Chains whose cache has not advanced within the window (empty when `fresh`).
+    pub stale_chains: Vec<u64>,
+}
+
 const MERKLE_BACKFILL_POLL_INTERVAL: Duration = Duration::from_secs(15);
 const MERKLE_BACKFILL_MAX_BLOCKS_PER_TICK: usize = 50;
 const MERKLE_BACKFILL_MAX_CONCURRENCY: usize = 8;
@@ -283,6 +326,7 @@ impl ContinuityService {
                     attestation_genesis_block: AtomicU64::new(attestation_genesis_block),
                     checkpoint_interval: AtomicU64::new(checkpoint_interval),
                     attestation_interval: AtomicU64::new(attestation_interval),
+                    last_cache_advance: std::sync::Mutex::new(Instant::now()),
                 }),
             );
         }
@@ -618,16 +662,57 @@ impl ContinuityService {
         self.start_time.elapsed().as_secs()
     }
 
-    /// Health check for CC3 RPC connectivity
+    /// Live cc3 RPC probe: a lightweight storage read on **every** configured chain.
+    ///
+    /// Previously this probed a single chain picked by `HashMap::iter().next()`, which Rust
+    /// randomises per process — so two replicas of identical code could report opposite
+    /// results, and the failure was never attributable to a chain. Every failing chain is
+    /// now logged with its error; the caller only sees a bool, and without the log line this
+    /// class of fault is undiagnosable (it ran 26 days on devnet with no record of why).
+    ///
+    /// Note this is a *diagnostic*, not the serving signal — see [`Self::cc3_cache_freshness`].
     pub async fn check_cc3_connectivity(&self) -> anyhow::Result<()> {
-        // Use a lightweight storage query as a connectivity check (any configured chain)
-        let (_, chain) = self
-            .chains
-            .iter()
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("no chains configured"))?;
-        let _genesis = chain.builder.get_attestation_genesis_block().await?;
-        Ok(())
+        anyhow::ensure!(!self.chains.is_empty(), "no chains configured");
+        let mut failed: Vec<u64> = Vec::new();
+        for (chain_key, chain) in &self.chains {
+            if let Err(err) = chain.builder.get_attestation_genesis_block().await {
+                tracing::warn!(chain_key, ?err, "🩺 cc3 RPC probe failed");
+                failed.push(*chain_key);
+            }
+        }
+        if failed.is_empty() {
+            Ok(())
+        } else {
+            failed.sort_unstable();
+            anyhow::bail!("cc3 RPC probe failed for chain_key(s) {failed:?}")
+        }
+    }
+
+    /// Whether the cc3 event subscription is still advancing the caches this service serves
+    /// proofs from — the signal that actually reflects serving ability.
+    ///
+    /// A chain is stale once no attestation or checkpoint has been cached for
+    /// [`CC3_CACHE_STALE_AFTER`]. Attestations land roughly every two minutes on the
+    /// current networks (attestation_interval 10 × ~12 s blocks), so the window tolerates
+    /// several missed intervals before declaring the subscription dead.
+    pub fn cc3_cache_freshness(&self) -> CacheFreshness {
+        let mut max_age = Duration::ZERO;
+        let mut stale_chains: Vec<u64> = Vec::new();
+        for (chain_key, chain) in &self.chains {
+            let age = chain.cache_age();
+            if age > max_age {
+                max_age = age;
+            }
+            if age > CC3_CACHE_STALE_AFTER {
+                stale_chains.push(*chain_key);
+            }
+        }
+        stale_chains.sort_unstable();
+        CacheFreshness {
+            fresh: stale_chains.is_empty(),
+            max_age_seconds: max_age.as_secs(),
+            stale_chains,
+        }
     }
 
     /// Health check for ETH RPC connectivity
@@ -662,6 +747,7 @@ impl ContinuityService {
                     .await
                     .insert(block_number, digest);
             }
+            chain.touch_cache();
             tracing::debug!(
                 chain_key,
                 block_number,
@@ -807,6 +893,7 @@ impl ContinuityService {
                     .await
                     .insert(block_number, digest);
             }
+            chain.touch_cache();
             tracing::debug!(
                 chain_key,
                 block_number,


### PR DESCRIPTION
## Problem

`/api/v1/health` reports `cc3_rpc_connected: false` on replicas that are serving proofs perfectly. Both cc3-devnet replicas have shown this for **26 days** with zero 5xx; on cc3-testnet one of two replicas shows it, making the public endpoint flap and paging Betterstack repeatedly.

Two defects combine to make this undiagnosable:

**1. The probe discards its own error.**
```rust
timeout(HEALTH_CHECK_TIMEOUT, service.check_cc3_connectivity()).await.is_ok_and(|r| r.is_ok())
```
A rich `anyhow::Error` — naming the chain and the subxt failure — is reduced to a bare `false`. Nothing is logged. 26 days, both networks, no record anywhere of *why*.

**2. It probes one chain chosen at random.**
```rust
let (_, chain) = self.chains.iter().next()...   // chains: HashMap<u64, _>
```
Rust randomises `HashMap` iteration per process. Two replicas of identical code against identical config can — and on testnet do — report opposite results, depending on which chain their hash seed put first.

**3. It measures the wrong thing.** The probe is a live storage read (`attestation_chain_genesis_block_number` at latest). But proof requests never issue that query — they're answered from the attestation/checkpoint caches, fed by the cc3 finalized-block subscription. On devnet that subscription is fully alive (cache within ~20 blocks of the live attestation tip) while the storage probe fails in 0.6 s. The health check says degraded; the service is fine.

## Change

**Log the failure.** A `probe()` helper wraps each upstream check and logs the error (or the timeout) at WARN with the probe name. Devnet will emit the real cause immediately — it has been in the failed state for 26 days.

**Probe every chain.** `check_cc3_connectivity` iterates all configured chains (mirroring `check_eth_connectivity`), logs each failing chain with its error, and reports the failing set. Removes the `HashMap` non-determinism.

**Add the signal that reflects serving ability.** `ChainState` gains `last_cache_advance: Mutex<Instant>`, stamped by `insert_attestation` / `insert_checkpoint` — the event-handler write paths only. `ContinuityService::cc3_cache_freshness()` reports whether every chain advanced within `CC3_CACHE_STALE_AFTER` (10 min; attestations land ~every 2 min so this tolerates several missed intervals). Two new response fields:

```json
{
  "status": "healthy",
  "cc3_rpc_connected": false,      ← diagnostic; now logged when false
  "eth_rpc_connected": true,
  "cc3_cache_fresh": true,         ← new: the subscription is advancing the caches
  "cc3_cache_age_seconds": 47,     ← new
  "uptime_seconds": 2262846
}
```

**`status` is now driven by `cc3_cache_fresh && eth_rpc_connected`.** This is the one judgement call in the PR. It's what serving proofs actually requires. The live probe stays in the payload and is logged, but it no longer marks a working replica degraded on its own.

## Effect

- Devnet flips to `healthy` — correctly, since it's serving with zero errors — and Betterstack stops paging on testnet.
- A replica whose subscription genuinely dies now reports `degraded` with `cc3_cache_fresh: false` and a WARN naming the stale chains. Today that failure is **invisible**: the storage probe can pass while the caches freeze.
- The `"status":"healthy"` keyword Betterstack keys on is unchanged; the two added fields are additive.
- Adding a Kubernetes readiness probe on this endpoint becomes safe. Before this change it would have removed both devnet replicas from the Service while they were serving fine.

## What this does not do

It does not fix whatever makes the storage read fail. Deliberately: the cause is unknown, and this PR is what makes it knowable. Once devnet logs `cc3 RPC probe failed chain_key=… err=…`, the fix can be targeted instead of guessed. A reconnecting cc3 wrapper (like the existing `ReconnectingEthRpcProvider`) is the likely candidate but would be speculative to ship blind — if the failure is metadata validation it would do nothing.

## Testing

`cargo check -p proof-gen-api-server --tests`: clean, no warnings.
`cargo test -p proof-gen-api-server`: 76 passed, 0 failed.
`cargo fmt`: applied. No existing test asserts on the health response shape; the OpenAPI schema picks up the new fields via `ToSchema`.

Verified against live state before writing: per-replica health via `kubectl port-forward`, status-code splits and cache freshness from Loki, failure latency via `curl -w %{time_total}` (0.6 s, ruling out the 5 s timeout).
