### PR TITLE
feat(proof-gen): derive block_confirmation_depth from on-chain MaturityStrategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10928,6 +10928,7 @@ dependencies = [
  "serde_yaml",
  "sp-core",
  "stream",
+ "supported-chains-primitives",
  "sysinfo 0.37.2",
  "thiserror 1.0.69",
  "tokio",

--- a/proof-gen-api-server/Cargo.toml
+++ b/proof-gen-api-server/Cargo.toml
@@ -58,6 +58,7 @@ tracing = { workspace = true }
 # Creditcoin / USC dependencies
 attestor-primitives = { workspace = true }
 cc-client = { workspace = true }
+supported-chains-primitives = { workspace = true }
 continuity = { workspace = true }
 eth = { workspace = true }
 hex = { workspace = true }

--- a/proof-gen-api-server/Cargo.toml
+++ b/proof-gen-api-server/Cargo.toml
@@ -58,13 +58,13 @@ tracing = { workspace = true }
 # Creditcoin / USC dependencies
 attestor-primitives = { workspace = true }
 cc-client = { workspace = true }
-supported-chains-primitives = { workspace = true }
 continuity = { workspace = true }
 eth = { workspace = true }
 hex = { workspace = true }
 merkle = { workspace = true }
 prometheus-client = { workspace = true }
 stream = { workspace = true, features = ["cc3"] }
+supported-chains-primitives = { workspace = true }
 sysinfo = { workspace = true }
 usc-abi-encoding = { workspace = true }
 

--- a/proof-gen-api-server/bin/server.rs
+++ b/proof-gen-api-server/bin/server.rs
@@ -84,13 +84,12 @@ pub struct ProofGenApiServer {
 
     #[arg(
         long,
-        default_value = "0",
         env = "BLOCK_CONFIRMATION_DEPTH",
-        help = "Number of blocks to lag behind the EVM chain tip when validating block existence. \
-                Blocks within this depth of the tip are rejected to guard against reorgs. \
-                Set to 0 for instant-finality chains. A typical safe value for Ethereum mainnet is 12."
+        help = "Reorg-protection depth override, in blocks. Omit to derive it from the chain's \
+                on-chain MaturityStrategy (recommended; matches the attestors). If set and it \
+                differs from the on-chain value, startup logs a warning."
     )]
-    block_confirmation_depth: u64,
+    block_confirmation_depth: Option<u64>,
 }
 
 #[tokio::main]

--- a/proof-gen-api-server/src/config.rs
+++ b/proof-gen-api-server/src/config.rs
@@ -30,9 +30,17 @@ pub struct ChainConfig {
     /// and you keep a more expensive "archive" endpoint for old data.
     pub eth_rpc_fallback_urls: Vec<String>,
     pub archiver_url: Option<String>,
-    /// Number of blocks to lag behind the EVM chain tip for reorg protection.
+    /// Reorg-protection depth override, in blocks.
+    ///
+    /// `None` (the default when the field is omitted) means: derive it at startup from the
+    /// chain's on-chain `MaturityStrategy` in the supported-chains pallet -- the same value the
+    /// attestors use, so this process cannot disagree with them. `Some(n)` pins an explicit
+    /// value; startup logs a WARN if it differs from the on-chain one.
+    ///
+    /// This used to be a plain `u64` defaulting to `0`, so *omitting* it silently disabled reorg
+    /// protection. That is the failure mode this change removes.
     /// See [`continuity::ContinuityConfig::block_confirmation_depth`].
-    pub block_confirmation_depth: u64,
+    pub block_confirmation_depth: Option<u64>,
 }
 
 /// Server configuration after CLI / file resolution.
@@ -60,7 +68,8 @@ impl Config {
                 eth_rpc_url: "http://mock".to_string(),
                 eth_rpc_fallback_urls: Vec::new(),
                 archiver_url: None,
-                block_confirmation_depth: 0,
+                // Mock config has no chain to resolve against; pin explicitly.
+                block_confirmation_depth: Some(0),
             }],
             max_batch_size: DEFAULT_MAX_BATCH_SIZE,
             max_batch_span: DEFAULT_MAX_BATCH_SPAN,
@@ -118,10 +127,11 @@ pub struct ChainConfigFile {
     pub eth_rpc_fallback_urls: Vec<String>,
     #[serde(default)]
     pub archiver_url: Option<String>,
-    /// Number of blocks to lag behind the EVM chain tip for reorg protection.
-    /// Defaults to 0 (no lag) for backward compatibility.
+    /// Reorg-protection depth override. **Omit it** to derive the depth from the chain's on-chain
+    /// `MaturityStrategy` (recommended -- matches the attestors by construction). Set it only to
+    /// deliberately pin a value; startup warns if it disagrees with the chain.
     #[serde(default)]
-    pub block_confirmation_depth: u64,
+    pub block_confirmation_depth: Option<u64>,
 }
 
 fn default_max_batch_size() -> NonZeroUsize {
@@ -295,6 +305,34 @@ chains:
 "#;
         let cfg = parse(yaml).expect("yaml should parse");
         assert!(cfg.chains[0].eth_rpc_fallback_urls.is_empty());
+    }
+
+    #[test]
+    fn yaml_without_depth_is_none_not_zero() {
+        // Regression guard: omitting the field must mean "derive from chain", never "0".
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 8
+    eth_rpc_url: "http://localhost:8545"
+"#;
+        let cfg = parse(yaml).expect("yaml should parse");
+        assert_eq!(cfg.chains[0].block_confirmation_depth, None);
+    }
+
+    #[test]
+    fn yaml_with_explicit_depth_is_some() {
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 8
+    eth_rpc_url: "http://localhost:8545"
+    block_confirmation_depth: 64
+"#;
+        let cfg = parse(yaml).expect("yaml should parse");
+        assert_eq!(cfg.chains[0].block_confirmation_depth, Some(64));
     }
 
     #[test]

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -138,6 +138,60 @@ impl Server {
             })?
             .ok_or_else(|| anyhow!("Failed to get supported chain for chain_key {chain_key}"))?;
         let supported_chain_id = supported_chain.chain_id;
+
+        // Reorg-protection depth. The source of truth is the chain's MaturityStrategy in the
+        // supported-chains pallet -- the same value the attestors act on -- so derive it from the
+        // `supported_chain` we already fetched unless the operator pinned an override. An
+        // unparseable or depth-less strategy is a real misconfiguration and fails startup
+        // outright: a prover guessing its reorg window is worse than one that is down.
+        let on_chain_depth: u64 = {
+            let strategy = supported_chains_primitives::MaturityStrategy::try_from(
+                supported_chain.maturity_strategy.as_str(),
+            )
+            .map_err(|e| {
+                anyhow!(
+                    "chain_key {chain_key}: invalid on-chain maturity strategy {:?}: {e:?}",
+                    supported_chain.maturity_strategy
+                )
+            })?;
+            strategy.maturity_delay().ok_or_else(|| {
+                anyhow!(
+                    "chain_key {chain_key}: maturity strategy {strategy:?} has no block-depth \
+                     equivalent; set block_confirmation_depth explicitly"
+                )
+            })?
+        };
+        let block_confirmation_depth = match chain.block_confirmation_depth {
+            None => {
+                tracing::info!(
+                    chain_key,
+                    block_confirmation_depth = on_chain_depth,
+                    maturity_strategy = %supported_chain.maturity_strategy,
+                    "⛓️  reorg-protection depth derived from on-chain MaturityStrategy"
+                );
+                on_chain_depth
+            }
+            Some(explicit) if explicit == on_chain_depth => {
+                tracing::info!(
+                    chain_key,
+                    block_confirmation_depth = explicit,
+                    "⛓️  reorg-protection depth pinned in config; matches on-chain MaturityStrategy"
+                );
+                explicit
+            }
+            Some(explicit) => {
+                tracing::warn!(
+                    chain_key,
+                    configured = explicit,
+                    on_chain = on_chain_depth,
+                    maturity_strategy = %supported_chain.maturity_strategy,
+                    "⛓️  reorg-protection depth pinned in config DISAGREES with the on-chain \
+                     MaturityStrategy the attestors use; this prover will confirm blocks on a \
+                     different schedule from them. Remove block_confirmation_depth to derive it."
+                );
+                explicit
+            }
+        };
         // Source-chain block encoding from CC3 metadata, rather than assuming V1.
         let chain_encoding =
             usc_abi_encoding::common::EncodingVersion::from(supported_chain.chain_encoding);
@@ -224,15 +278,15 @@ impl Server {
             .attestation_interval(attestation_interval)
             .checkpoint_interval(checkpoint_interval)
             .last_checkpoint_block(last_checkpoint_block)
-            .block_confirmation_depth(chain.block_confirmation_depth)
+            .block_confirmation_depth(block_confirmation_depth)
             .build();
 
-        if chain.block_confirmation_depth > 0 {
+        if block_confirmation_depth > 0 {
             debug!(
                 chain_key,
-                block_confirmation_depth = chain.block_confirmation_depth,
+                block_confirmation_depth,
                 "⛓️  EVM reorg protection: accepting blocks only up to {} blocks behind chain tip",
-                chain.block_confirmation_depth
+                block_confirmation_depth
             );
         }
 


### PR DESCRIPTION
## Problem

`block_confirmation_depth` in proof-gen was a hand-typed `u64` with `#[serde(default)]`, so **omitting it silently meant `0` — no reorg protection.** The attestors read the same quantity from the chain's `MaturityStrategy` in the supported-chains pallet (`EvmFinalized ⇒ 64`, `EvmSafe ⇒ 32`, `EvmLatest ⇒ 0`, `FixedDelay:n`). Two different sources for one safety parameter is how usc-dev ended up with attestors at 64 and the prover at 32 — and it could just as easily have been 0.

## Change

`block_confirmation_depth` becomes `Option<u64>` in the YAML, the CLI (`--block-confirmation-depth` / `BLOCK_CONFIRMATION_DEPTH`), and `ChainConfig`.

- **`None` (omitted) → derived at startup** from `supported_chain.maturity_strategy`, which `build_continuity_for_chain` already fetches — no additional RPC call. This is the recommended setting; the prover then agrees with the attestors by construction.
- **`Some(n)` → explicit pin.** Startup logs INFO if it matches the chain, **WARN if it disagrees**, naming both values and stating the consequence (prover confirms blocks on a different schedule from the attestors).
- **Fails startup** if the on-chain strategy is unparseable or has no block-depth equivalent. A prover guessing its reorg window is worse than one that is down. Approved as intended behaviour.

Resolved depth is logged at INFO on every boot so it is visible without reading config.

## Effect on existing deployments

Every current values file sets the field explicitly, so **no deployment changes behaviour on upgrade** — they log INFO (match) or WARN (mismatch) and keep their pinned value. To adopt derivation, delete the line. The only semantic change is for configs that *omitted* the field: they previously ran with 0 and will now run with the chain's value, which is the fix.

## Not in scope

The archiver already derives its lag from chain (`FINALIZATION_LAG` is an override; unset → on-chain lookup) — but only on this branch; no tagged release up to 3.133 has it. Until an archiver release ships it, its `finalizationLag` must stay explicit in IaC.

## Testing

`cargo check -p proof-gen-api-server --tests --bins` clean, no warnings. `cargo test -p proof-gen-api-server`: **78 passed**, including two new config tests — omitted field parses to `None` (regression guard against the old `0` default), explicit field parses to `Some(64)`. `cargo fmt` applied.
