### PR TITLE
ci(abi-gate): cover OutboxDiscovery and bump the asc-contracts pin

### DIFF
--- a/.github/workflows/write-ability-e2e.yml
+++ b/.github/workflows/write-ability-e2e.yml
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: gluwa/asc-contracts
-          ref: e300c16676efc850a5b382033d666bc9c3a0ce23 # main @ 2026-08-17 (post-#23/#28 v3 RelayerQuote struct) — bump deliberately
+          ref: a4d05d7b6f49b01592233fb34ce7a9212c178ee9 # main @ 2026-09-03 (post-#38 OutboxDiscovery + automatic timelock) — bump deliberately
           path: asc-contracts
           # asc-contracts is private; the default GITHUB_TOKEN is scoped to creditcoin3 only and
           # gets "Repository not found". Use the org bot PAT (same one build-native uses cross-repo).

--- a/.github/workflows/write-ability-e2e.yml
+++ b/.github/workflows/write-ability-e2e.yml
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: gluwa/asc-contracts
-          ref: a4d05d7b6f49b01592233fb34ce7a9212c178ee9 # main @ 2026-09-03 (post-#38 OutboxDiscovery + automatic timelock) — bump deliberately
+          ref: 434073943ec6828c3271bcf39114a04304e97d7f # main @ 2026-09-04 (#46 block-based timelock) — bump deliberately
           path: asc-contracts
           # asc-contracts is private; the default GITHUB_TOKEN is scoped to creditcoin3 only and
           # gets "Repository not found". Use the org bot PAT (same one build-native uses cross-repo).

--- a/common/write-ability/src/abi.rs
+++ b/common/write-ability/src/abi.rs
@@ -55,6 +55,65 @@ sol! {
         );
     }
 
+    /// OutboxDiscovery (asc-contracts #38) — the registry that replaces factory-log scanning as
+    /// the source of truth for "which Outbox serves this chain key". Only the surface we actually
+    /// read is mirrored.
+    ///
+    /// The timelock events matter to us specifically: `activeOutboxes` filters an Outbox out the
+    /// moment its scheduled removal time passes, so membership disappearing is NOT our signal to
+    /// stop watching one. These events give the effective time in advance, and the cancel events
+    /// stop us acting at a time that was called off.
+    #[sol(rpc)]
+    #[derive(Debug)]
+    contract IOutboxDiscovery {
+        /// Registered as active for `chainKey`. Its block is each listener's start block: the
+        /// registry exposes no creation height, and starting at the current head would silently
+        /// skip every `MessagePublished` below it.
+        event OutboxRegistered(
+            uint32 indexed chainKey,
+            address indexed outbox,
+            address indexed registrar
+        );
+
+        /// Removal scheduled. `effectiveTime` is a unix TIMESTAMP (seconds), not a block number —
+        /// listeners are block-indexed, so callers convert.
+        event OutboxRemovalScheduled(
+            uint32 indexed chainKey,
+            address indexed outbox,
+            uint64 effectiveTime
+        );
+
+        /// Default change scheduled. Also fires with `effectiveTime == block.timestamp` when the
+        /// first live Outbox for a chain key auto-becomes the default (no delay, because there was
+        /// no prior default to drain).
+        event DefaultOutboxChangeScheduled(
+            uint32 indexed chainKey,
+            address indexed outbox,
+            uint64 effectiveTime
+        );
+
+        event PendingDefaultCancelled(uint32 indexed chainKey);
+        event PendingRemovalCancelled(uint32 indexed chainKey, address indexed outbox);
+
+        /// Authoritative replacement for scanning `OutboxCreated`.
+        function defaultOutbox(uint32 chainKey) external view returns (address);
+
+        /// Every Outbox still serving `chainKey`, due-removed entries already filtered out. We
+        /// watch all of them and drain before dropping a listener.
+        function activeOutboxes(uint32 chainKey) external view returns (address[] memory);
+
+        function isActiveOutbox(uint32 chainKey, address outbox) external view returns (bool);
+
+        /// Sole home for the deployer address now that the runtime's stored factory address is
+        /// being retired (agreed with Kevin, 2026-09-01).
+        function defaultDeployer() external view returns (address);
+
+        /// Cold-start reads: an attestor booting after a schedule event still needs the pending
+        /// state, since the event is already in the past.
+        function pendingDefaultOutbox(uint32 chainKey) external view returns (address outbox, uint64 effectiveTime);
+        function pendingRemovalTime(uint32 chainKey, address outbox) external view returns (uint64 effectiveTime);
+    }
+
     #[sol(rpc)]
     #[derive(Debug)]
     contract IChainInfo {

--- a/common/write-ability/src/abi.rs
+++ b/common/write-ability/src/abi.rs
@@ -75,21 +75,24 @@ sol! {
             address indexed registrar
         );
 
-        /// Removal scheduled. `effectiveTime` is a unix TIMESTAMP (seconds), not a block number —
-        /// listeners are block-indexed, so callers convert.
+        /// Removal scheduled. `effectiveBlock` is a source-chain BLOCK NUMBER, compared against
+        /// `block.number` (asc-contracts #46 moved the timelock off unix time so it cannot drift
+        /// with block production). Listeners are block-indexed too, so no conversion: keep the
+        /// Outbox listener alive until the finalized head passes `effectiveBlock`, then drop it
+        /// (drain-before-drop). `timelock()` and `MIN_TIMELOCK` (1200) are in blocks as well.
         event OutboxRemovalScheduled(
             uint32 indexed chainKey,
             address indexed outbox,
-            uint64 effectiveTime
+            uint64 effectiveBlock
         );
 
-        /// Default change scheduled. Also fires with `effectiveTime == block.timestamp` when the
+        /// Default change scheduled. Also fires with `effectiveBlock == block.number` when the
         /// first live Outbox for a chain key auto-becomes the default (no delay, because there was
         /// no prior default to drain).
         event DefaultOutboxChangeScheduled(
             uint32 indexed chainKey,
             address indexed outbox,
-            uint64 effectiveTime
+            uint64 effectiveBlock
         );
 
         event PendingDefaultCancelled(uint32 indexed chainKey);
@@ -110,8 +113,8 @@ sol! {
 
         /// Cold-start reads: an attestor booting after a schedule event still needs the pending
         /// state, since the event is already in the past.
-        function pendingDefaultOutbox(uint32 chainKey) external view returns (address outbox, uint64 effectiveTime);
-        function pendingRemovalTime(uint32 chainKey, address outbox) external view returns (uint64 effectiveTime);
+        function pendingDefaultOutbox(uint32 chainKey) external view returns (address outbox, uint64 effectiveBlock);
+        function pendingRemovalBlock(uint32 chainKey, address outbox) external view returns (uint64 effectiveBlock);
     }
 
     #[sol(rpc)]

--- a/common/write-ability/tests/abi_surface.rs
+++ b/common/write-ability/tests/abi_surface.rs
@@ -20,7 +20,7 @@
 
 use alloy::primitives::keccak256;
 use alloy::sol_types::{SolCall, SolEvent};
-use write_ability::abi::{IOutbox, IOutboxFactory, IVoteValidator};
+use write_ability::abi::{IOutbox, IOutboxDiscovery, IOutboxFactory, IVoteValidator};
 
 /// Canonical signature string ("name(type1,type2,…)") for an ABI item in a hardhat artifact.
 /// Elementary and array types are already canonical in the artifact's `type` field; tuples would
@@ -130,6 +130,63 @@ fn mirrored_abi_surface_matches_compiled_contracts() {
         IOutboxFactory::OutboxCreated::SIGNATURE,
         IOutboxFactory::OutboxCreated::SIGNATURE_HASH.0,
     );
+
+    // OutboxDiscovery (asc-contracts #38). Both events and reads are asserted: a moved topic0
+    // silently blinds a subscription, and a moved selector makes a read revert with empty
+    // returndata, which the registry-first resolver would see as "no Outbox for this chain".
+    let discovery = contracts.join("deployer/OutboxDiscovery.sol/OutboxDiscovery.json");
+    for (sig, topic0) in [
+        (
+            IOutboxDiscovery::OutboxRegistered::SIGNATURE,
+            IOutboxDiscovery::OutboxRegistered::SIGNATURE_HASH.0,
+        ),
+        (
+            IOutboxDiscovery::OutboxRemovalScheduled::SIGNATURE,
+            IOutboxDiscovery::OutboxRemovalScheduled::SIGNATURE_HASH.0,
+        ),
+        (
+            IOutboxDiscovery::DefaultOutboxChangeScheduled::SIGNATURE,
+            IOutboxDiscovery::DefaultOutboxChangeScheduled::SIGNATURE_HASH.0,
+        ),
+        (
+            IOutboxDiscovery::PendingDefaultCancelled::SIGNATURE,
+            IOutboxDiscovery::PendingDefaultCancelled::SIGNATURE_HASH.0,
+        ),
+        (
+            IOutboxDiscovery::PendingRemovalCancelled::SIGNATURE,
+            IOutboxDiscovery::PendingRemovalCancelled::SIGNATURE_HASH.0,
+        ),
+    ] {
+        assert_event_mirrored(&discovery, sig, topic0);
+    }
+    for (sig, selector) in [
+        (
+            "defaultOutbox(uint32)",
+            IOutboxDiscovery::defaultOutboxCall::SELECTOR,
+        ),
+        (
+            "activeOutboxes(uint32)",
+            IOutboxDiscovery::activeOutboxesCall::SELECTOR,
+        ),
+        (
+            "isActiveOutbox(uint32,address)",
+            IOutboxDiscovery::isActiveOutboxCall::SELECTOR,
+        ),
+        (
+            "defaultDeployer()",
+            IOutboxDiscovery::defaultDeployerCall::SELECTOR,
+        ),
+        (
+            "pendingDefaultOutbox(uint32)",
+            IOutboxDiscovery::pendingDefaultOutboxCall::SELECTOR,
+        ),
+        (
+            "pendingRemovalTime(uint32,address)",
+            IOutboxDiscovery::pendingRemovalTimeCall::SELECTOR,
+        ),
+    ] {
+        assert_function_mirrored(&discovery, sig, selector);
+    }
 
     let validator = contracts.join("EOAValidator.sol/EOAValidator.json");
     assert_function_mirrored(

--- a/common/write-ability/tests/abi_surface.rs
+++ b/common/write-ability/tests/abi_surface.rs
@@ -181,8 +181,8 @@ fn mirrored_abi_surface_matches_compiled_contracts() {
             IOutboxDiscovery::pendingDefaultOutboxCall::SELECTOR,
         ),
         (
-            "pendingRemovalTime(uint32,address)",
-            IOutboxDiscovery::pendingRemovalTimeCall::SELECTOR,
+            "pendingRemovalBlock(uint32,address)",
+            IOutboxDiscovery::pendingRemovalBlockCall::SELECTOR,
         ),
     ] {
         assert_function_mirrored(&discovery, sig, selector);

--- a/usc-messaging/scripts/add-quoter.mts
+++ b/usc-messaging/scripts/add-quoter.mts
@@ -41,7 +41,7 @@ async function main() {
   const quoterAddr = addrs.source?.quoter;
   if (!quoterAddr) throw new Error(`no source.quoter in ${OUT}`);
 
-  const art = ART("write-ability/USCRelayingQuoter.sol", "USCRelayingQuoter");
+  const art = ART("write-ability/ASCRelayingQuoter.sol", "ASCRelayingQuoter");
   const quoter = new ethers.Contract(quoterAddr, art.abi, wallet);
 
   const already = await quoter.isAuthorizedQuoter(quoterEOA).catch(() => null);

--- a/usc-messaging/scripts/deploy-source-devnet.mts
+++ b/usc-messaging/scripts/deploy-source-devnet.mts
@@ -54,7 +54,7 @@ async function main() {
   console.log("deployer:", owner, "balance:", ethers.formatEther(await provider.getBalance(owner)), "CTC, nonce:", await wallet.getNonce());
 
   const attest = await deploy("MockERC20", ART("mocks/MockERC20.sol", "MockERC20"), ["Attest", "ATTEST"]);
-  const proof = await deploy("USCProofVerifier", ART("write-ability/common/USCProofVerifier.sol", "USCProofVerifier"));
+  const proof = await deploy("ASCProofVerifier", ART("write-ability/common/ASCProofVerifier.sol", "ASCProofVerifier"));
   const decoder = await deploy("EVMDeliveryDecoder", ART("write-ability/common/EVMDeliveryDecoder.sol", "EVMDeliveryDecoder"), [owner]);
   const twap = await deploy("TWAPReader", ART("write-ability/TWAPReader.sol", "TWAPReader"), [owner, owner]);
   await (await (twap as any).setWindow(60)).wait();
@@ -62,7 +62,7 @@ async function main() {
   // Registry starts empty on devnet; owner can updateAttestorSet later if the vault flow needs it.
   const registry = await deploy("AttestorRegistry", ART("write-ability/AttestorRegistry.sol", "AttestorRegistry"), [owner, []]);
   const factory = await deploy("OutboxFactory", ART("write-ability/deployer/OutboxFactory.sol", "OutboxFactory"));
-  const quoter = await deploy("USCRelayingQuoter", ART("write-ability/USCRelayingQuoter.sol", "USCRelayingQuoter"), [owner, await twap.getAddress(), owner]);
+  const quoter = await deploy("ASCRelayingQuoter", ART("write-ability/ASCRelayingQuoter.sol", "ASCRelayingQuoter"), [owner, await twap.getAddress(), owner]);
 
   // Outbox.coreFee() reads through IFeeRegistry, NOT the quoter. This slot used to be handed the
   // quoter, which is a different interface: coreFee() then reverted, and fix-fee-registry.mts

--- a/usc-messaging/scripts/deploy-source-ethers.mts
+++ b/usc-messaging/scripts/deploy-source-ethers.mts
@@ -91,7 +91,7 @@ async function main() {
   console.log("deployer:", owner, "nonce:", await wallet.getNonce());
 
   const attest = await deploy("MockERC20", ART("mocks/MockERC20.sol", "MockERC20"), ["Attest", "ATTEST"]);
-  const proof = await deploy("USCProofVerifier", ART("write-ability/common/USCProofVerifier.sol", "USCProofVerifier"));
+  const proof = await deploy("ASCProofVerifier", ART("write-ability/common/ASCProofVerifier.sol", "ASCProofVerifier"));
   const decoder = await deploy("EVMDeliveryDecoder", ART("write-ability/common/EVMDeliveryDecoder.sol", "EVMDeliveryDecoder"), [owner]);
   const twap = await deploy("TWAPReader", ART("write-ability/TWAPReader.sol", "TWAPReader"), [owner, owner]);
   // Start the TWAP observation clock NOW with a short window: read() reverts
@@ -104,7 +104,7 @@ async function main() {
   const factory = await deploy("OutboxFactory", ART("write-ability/deployer/OutboxFactory.sol", "OutboxFactory"));
   // Indexer discovery is fail-closed: authenticate OutboxCreated against governance registration.
   await registerFactoryBeforeOutbox(await factory.getAddress());
-  const quoter = await deploy("USCRelayingQuoter", ART("write-ability/USCRelayingQuoter.sol", "USCRelayingQuoter"), [owner, await twap.getAddress(), owner]);
+  const quoter = await deploy("ASCRelayingQuoter", ART("write-ability/ASCRelayingQuoter.sol", "ASCRelayingQuoter"), [owner, await twap.getAddress(), owner]);
   // Outbox.coreFee() reads through IFeeRegistry, NOT the quoter — FeeRegistry wraps this chain's
   // own chain-info precompile (ICoreFeeProvider.get_core_fee(uint32), selector 0x5b023376, fixed
   // address AddressU64<4051> per runtime/src/precompiles.rs). An unconfigured chain_key reads back

--- a/usc-messaging/scripts/set-oracle-devnet.mts
+++ b/usc-messaging/scripts/set-oracle-devnet.mts
@@ -43,7 +43,7 @@ async function main() {
   const addrs = JSON.parse(readFileSync(OUT, "utf8"));
   const targets: Array<[string, string, string, string]> = [
     ["TWAPReader", addrs.source?.twapReader, "write-ability/TWAPReader.sol", "TWAPReader"],
-    ["USCRelayingQuoter", addrs.source?.quoter, "write-ability/USCRelayingQuoter.sol", "USCRelayingQuoter"],
+    ["ASCRelayingQuoter", addrs.source?.quoter, "write-ability/ASCRelayingQuoter.sol", "ASCRelayingQuoter"],
   ];
   for (const [label, addr, artPath, artName] of targets) {
     if (!addr) throw new Error(`missing address for ${label} in ${OUT}`);


### PR DESCRIPTION
asc-contracts #38 merged this morning (`a4d05d7`) with OutboxDiscovery plus the automatic timelock. Our ABI drift gate was pinned at `e300c166`, main @ **2026-08-17** — before the contract existed. So nothing was checking the surface the registry-first resolver is about to depend on.

## What this adds

`IOutboxDiscovery` mirrored in `common/write-ability` (only the surface we read), asserted against the compiled artifact:

**Events (5)** — `OutboxRegistered`, `OutboxRemovalScheduled`, `DefaultOutboxChangeScheduled`, `PendingDefaultCancelled`, `PendingRemovalCancelled`
**Reads (6)** — `defaultOutbox(uint32)`, `activeOutboxes(uint32)`, `isActiveOutbox`, `defaultDeployer()`, `pendingDefaultOutbox`, `pendingRemovalTime`

Both halves matter for different failure modes. A moved topic0 silently blinds a subscription, and the timelock events are our only advance notice before a default changes or an Outbox is removed. A moved selector makes a read revert with empty returndata, which the resolver **cannot distinguish from "no Outbox registered for this chain key"** — it would resolve to nothing and idle, which is the quiet failure this gate exists to prevent.

## Two things captured in doc comments

- **`effectiveTime` is a unix timestamp, not a block number.** Didac asked for a block; the contract ships seconds. Our listeners are block-indexed, so there is a conversion to write. Worth being explicit before someone assumes it is a height.
- **`activeOutboxes()` filters an Outbox out the moment its scheduled removal time passes**, before `cleanup` runs. So membership disappearing is *not* the signal to stop watching one — we drain on our own in-flight state. Confirmed with Kevin on the #38 thread.

## Deliberately not asserted

`activeOutboxCount` — it existed in the revision I reviewed and was **dropped before merge**. Asserting it would have failed against a function that no longer exists.

## Verification

Ran the gate against a fresh `npx hardhat compile` of merged main. It **failed first, exactly as designed**, naming the stale pre-timelock `DefaultOutboxSet` / `OutboxRemoved` events still in my local artifacts — then passed once recompiled. That is the gate proving it can actually catch drift rather than passing vacuously.

`cargo test -p write-ability` and `-p attestor --lib` (140) pass, clippy `-D warnings` clean, fmt clean, workflow YAML parses, and the pinned SHA is verified to resolve to the #38 merge commit on `main`.

## Update 7 Sep

asc-contracts #46 moved the OutboxDiscovery timelock from unix time to block numbers. Mirror updated: `effectiveTime` → `effectiveBlock` on `OutboxRemovalScheduled` / `DefaultOutboxChangeScheduled` and in `pendingDefaultOutbox`; `pendingRemovalTime` → `pendingRemovalBlock`; `timelock()` and `MIN_TIMELOCK` (1200) are in blocks. Event topics are unchanged by a parameter rename, so only the function selector assertion moves; the listener is block-indexed already, so drain-before-drop needs no conversion. e2e checkout re-pinned to main @ `434073943`. Local: fmt, clippy `-D warnings` on `write-ability` + `attestor`, `write-ability` tests green; the e2e's ABI gate runs in CI against the new pin.

https://claude.ai/code/session_01Kv6y52MHgtgkWmnJhdXbHB
