### PR TITLE
fix(attestor): rebuild the Outbox listener's provider in place instead of exiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -707,7 +707,11 @@ jobs:
           # restart-to-rebuild path after a sustained failure budget ("N consecutive times"), and
           # alloy's close-frame notice when the ws endpoint is bounced. All three are designed
           # loud-recovery behavior during the induced outages, not faults.
-          ALLOWLIST='Failed to reconnect to CC3|Reconnected but at_latest failed|connection (error|lost)|Subscription error while fetching next block|Failed to start finalized-block subscription|ping failed|Outbox resolution still failing after prolonged retrying|Outbox resolution failed [0-9]+ consecutive times|outbox poll stalled \(no progress\)|Received close frame'
+          # Deliberately NOT allowlisted: "outbox poll stalled". The Outbox listener used to die on
+          # a sustained stall and surface here as a `task failed` ERROR, which this gate waved
+          # through. It now rebuilds its provider in place at WARN level, so any ERROR carrying that
+          # phrase again is a regression the gate must catch.
+          ALLOWLIST='Failed to reconnect to CC3|Reconnected but at_latest failed|connection (error|lost)|Subscription error while fetching next block|Failed to start finalized-block subscription|ping failed|Outbox resolution still failing after prolonged retrying|Outbox resolution failed [0-9]+ consecutive times|Received close frame'
           shopt -s nullglob
           LOGS=(./logs/attestor-*.json.*)
           if [ "${#LOGS[@]}" -eq 0 ]; then

--- a/attestor/attestor/src/tasks/write_ability/listener.rs
+++ b/attestor/attestor/src/tasks/write_ability/listener.rs
@@ -19,7 +19,7 @@ use alloy::rpc::types::eth::BlockNumberOrTag;
 use alloy::rpc::types::{BlockTransactionsKind, Filter};
 use alloy::sol_types::SolEvent;
 use anyhow::{Context, Result};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use write_ability::abi::IOutbox;
@@ -198,14 +198,18 @@ fn next_failure_count(prev: u32, poll_ok: bool, made_progress: bool) -> u32 {
 /// is preferred over `start_block`/head so a restart resumes exactly where it left off, and after
 /// every poll that advances the scan the new position is saved.
 ///
-/// The listener owns `provider` so it can replace it: after [`MAX_CONSECUTIVE_POLL_FAILURES`]
-/// stalled polls it calls `reconnect` and swaps the fresh connection in without leaving the loop
-/// (the scan cursor, finality tracker and cancellation wiring all survive). `reconnect` must
-/// produce the same provider type; in production that is `connect_l1_provider` bound to the
+/// `shared_provider` is the write-ability task's one Creditcoin L1 connection, shared with the
+/// Outbox rotation monitor and the reobservation worker. alloy provider clones share a single
+/// pubsub backend, so when that backend dies every clone dies with it. The listener is the one
+/// loop that counts stalls, so it is the one that heals: after [`MAX_CONSECUTIVE_POLL_FAILURES`]
+/// stalled polls it calls `reconnect`, swaps the fresh connection into its own hot path, and
+/// publishes it through the channel so the siblings pick it up on their next use — nobody leaves
+/// their loop (the scan cursor, finality tracker and cancellation wiring all survive). `reconnect`
+/// must produce the same provider type; in production that is `connect_l1_provider` bound to the
 /// configured RPC URL.
 #[allow(clippy::too_many_arguments)]
 pub async fn watch<P, R, Fut>(
-    mut provider: P,
+    shared_provider: watch::Sender<P>,
     reconnect: R,
     resolved: ResolvedOutbox,
     block_confirmation_depth: u64,
@@ -215,10 +219,14 @@ pub async fn watch<P, R, Fut>(
     token: CancellationToken,
 ) -> Result<()>
 where
-    P: Provider,
+    P: Provider + Clone,
     R: Fn() -> Fut,
     Fut: Future<Output = Result<P>>,
 {
+    // Local handle for the hot path; the channel is only touched on a rebuild. Cloning an alloy
+    // provider is an `Arc` bump. Start from whatever is current, which after a rotation re-spawn
+    // may already be a rebuilt connection rather than the boot-time one.
+    let mut provider = shared_provider.borrow().clone();
     // Cursor precedence: a persisted position wins over `start_block`/head so a restart resumes
     // rather than skipping down-time messages (default config) or replaying the whole history from
     // `start_block`. To force a different start position, remove the cursor file.
@@ -375,10 +383,14 @@ where
                             );
                             match reconnect().await {
                                 Ok(fresh) => {
+                                    // Publish first so the rotation monitor and reobservation
+                                    // worker stop using the dead backend on their next tick, then
+                                    // take it for our own hot path.
+                                    shared_provider.send_replace(fresh.clone());
                                     provider = fresh;
                                     tracing::info!(
                                         last_seen,
-                                        "🔌 Creditcoin L1 EVM provider rebuilt; resuming Outbox scan from cursor"
+                                        "🔌 Creditcoin L1 EVM provider rebuilt and shared with the rotation monitor and reobservation worker; resuming Outbox scan from cursor"
                                     );
                                 }
                                 Err(rebuild_err) => {

--- a/attestor/attestor/src/tasks/write_ability/listener.rs
+++ b/attestor/attestor/src/tasks/write_ability/listener.rs
@@ -10,6 +10,7 @@
 //! Polling (rather than `eth_subscribe`) avoids the silent-stream-stall failure mode, matching the
 //! relayer.
 
+use std::future::Future;
 use std::time::{Duration, Instant};
 
 use alloy::primitives::{Address, B256};
@@ -37,17 +38,23 @@ pub const DEFAULT_POLL_INTERVAL_SECS: u64 = 6;
 /// the listener.
 const RPC_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Consecutive *stalled* polls before the listener gives up and returns `Err`. Only a poll that
-/// errored **and** made no forward progress counts (see [`next_failure_count`]); a slow backfill
-/// that keeps advancing the scan resets the budget, so catching up across many polls never trips
-/// this. The write-ability task harvests the eventual error and propagates it to the supervisor,
-/// which restarts the pod — rebuilding the provider from scratch. This is the reconnect story for
-/// the write-ability EVM provider: unlike the block-attestation path (wrapped in the reconnecting
-/// `eth::Client`), this provider is a bare alloy connection whose pubsub service exits permanently
-/// after a single failed reconnect, so a routine RPC blip would otherwise silently kill message
-/// voting for the process lifetime (C1). At the 6s cadence this rides out ~1 minute of fast errors,
-/// or (with `RPC_TIMEOUT`) a few minutes of a black-holed endpoint, before restarting — long enough
-/// to absorb a transient blip, short enough that a dead provider does not strand quorum indefinitely.
+/// Consecutive *stalled* polls before the listener declares its provider dead and rebuilds it in
+/// place via the `reconnect` hook handed to [`watch`]. Only a poll that errored **and** made no
+/// forward progress counts (see [`next_failure_count`]); a slow backfill that keeps advancing the
+/// scan resets the budget, so catching up across many polls never trips this.
+///
+/// This is the reconnect story for the write-ability EVM provider: unlike the block-attestation
+/// path (wrapped in the reconnecting `eth::Client`), this provider is a bare alloy connection whose
+/// pubsub service exits permanently after a single failed reconnect (`backend connection task has
+/// stopped`), so a routine RPC blip would otherwise silently kill message voting for the process
+/// lifetime (C1). The listener used to return `Err` here and let the supervisor restart the whole
+/// attestor — which took block attestation down with it and, because every attestor in a cluster
+/// shares one RPC endpoint, killed whole clusters within seconds of each other (31 Aug 2026: all
+/// six kc/we attestors, two deliveries that day at exactly quorum). Rebuilding the connection in
+/// place is the same fix the Outbox resolver got in #1304. At the 6s cadence this rides out ~1
+/// minute of fast errors, or (with `RPC_TIMEOUT`) a few minutes of a black-holed endpoint, before
+/// the first rebuild attempt; a failed rebuild keeps the old handle and tries again after another
+/// full budget.
 const MAX_CONSECUTIVE_POLL_FAILURES: u32 = 10;
 
 /// Blocks to rewind a *persisted* cursor by on resume. The cursor is saved once a poll's range has
@@ -175,9 +182,8 @@ pub struct IndexedMessage {
 /// A poll that either completed (`poll_ok`) or advanced the scan (`made_progress`) resets the budget
 /// to zero; only a fully *stalled* poll — errored **and** zero forward progress — increments it.
 /// This is what stops a slow-but-progressing backfill (which may encounter a later RPC failure after
-/// advancing earlier chunks) from tripping [`MAX_CONSECUTIVE_POLL_FAILURES`] and restarting the
-/// whole process, block attestation included. Pure so the rule is unit-testable without an RPC or
-/// timers.
+/// advancing earlier chunks) from tripping [`MAX_CONSECUTIVE_POLL_FAILURES`] and rebuilding a
+/// provider that is in fact healthy. Pure so the rule is unit-testable without an RPC or timers.
 fn next_failure_count(prev: u32, poll_ok: bool, made_progress: bool) -> u32 {
     if poll_ok || made_progress {
         0
@@ -191,15 +197,28 @@ fn next_failure_count(prev: u32, poll_ok: bool, made_progress: bool) -> u32 {
 /// `cursor` persists the scan position (`last_seen`) across restarts: on boot the persisted value
 /// is preferred over `start_block`/head so a restart resumes exactly where it left off, and after
 /// every poll that advances the scan the new position is saved.
-pub async fn watch<P: Provider>(
-    provider: &P,
+///
+/// The listener owns `provider` so it can replace it: after [`MAX_CONSECUTIVE_POLL_FAILURES`]
+/// stalled polls it calls `reconnect` and swaps the fresh connection in without leaving the loop
+/// (the scan cursor, finality tracker and cancellation wiring all survive). `reconnect` must
+/// produce the same provider type; in production that is `connect_l1_provider` bound to the
+/// configured RPC URL.
+#[allow(clippy::too_many_arguments)]
+pub async fn watch<P, R, Fut>(
+    mut provider: P,
+    reconnect: R,
     resolved: ResolvedOutbox,
     block_confirmation_depth: u64,
     start_block: Option<u64>,
     cursor: CursorStore,
     tx: mpsc::Sender<IndexedMessage>,
     token: CancellationToken,
-) -> Result<()> {
+) -> Result<()>
+where
+    P: Provider,
+    R: Fn() -> Fut,
+    Fut: Future<Output = Result<P>>,
+{
     // Cursor precedence: a persisted position wins over `start_block`/head so a restart resumes
     // rather than skipping down-time messages (default config) or replaying the whole history from
     // `start_block`. To force a different start position, remove the cursor file.
@@ -293,7 +312,7 @@ pub async fn watch<P: Provider>(
                         return Ok(());
                     }
                     outcome = poll_once(
-                        provider, &resolved, &policy, &mut finality, &mut last_seen, &tx,
+                        &provider, &resolved, &policy, &mut finality, &mut last_seen, &tx,
                     ) => outcome,
                 };
 
@@ -320,11 +339,11 @@ pub async fn watch<P: Provider>(
 
                 // Progress-aware failure budget: a poll that either completed or *advanced the scan*
                 // resets the budget; only a fully stalled poll (errored AND zero forward progress)
-                // counts toward the restart threshold. A wide backfill (far-behind start_block, or a
+                // counts toward the rebuild threshold. A wide backfill (far-behind start_block, or a
                 // long Outbox-resolve wait) can legitimately advance several chunks before a later
                 // RPC fails — counting that progressing-but-unfinished poll as a failure would
-                // trip `MAX_CONSECUTIVE_POLL_FAILURES` and restart the whole process (taking block
-                // attestation down with it) even while it was catching up the entire time.
+                // trip `MAX_CONSECUTIVE_POLL_FAILURES` and tear down a healthy connection even
+                // while it was catching up the entire time.
                 consecutive_failures =
                     next_failure_count(consecutive_failures, outcome.is_ok(), made_progress);
                 match outcome {
@@ -340,23 +359,43 @@ pub async fn watch<P: Provider>(
                     }
                     // Stalled poll (no progress): the budget was incremented above.
                     Err(err) => {
-                        // Give up after a sustained *stalled* run. Returning Err lets the
-                        // write-ability task harvest it and restart the pod, which rebuilds this
-                        // (non-self-healing) provider — the only reconnect path it has (C1).
                         if consecutive_failures >= MAX_CONSECUTIVE_POLL_FAILURES {
-                            return Err(err).with_context(|| {
-                                format!(
-                                    "outbox poll stalled (no progress) {consecutive_failures} times \
-                                     in a row — RPC connection is likely dead; restarting to rebuild it"
-                                )
-                            });
+                            // The bare alloy connection does not come back on its own once its
+                            // pubsub task has exited (C1), so swap it for a fresh one here rather
+                            // than exiting and taking block attestation down with us. Reset the
+                            // budget either way: a failed rebuild keeps the old handle and earns
+                            // another full window before the next attempt, so a long RPC outage
+                            // produces a warning every ~minute instead of a crash loop.
+                            consecutive_failures = 0;
+                            tracing::warn!(
+                                error = %format!("{err:#}"),
+                                stalled_polls = MAX_CONSECUTIVE_POLL_FAILURES,
+                                last_seen,
+                                "🔌 outbox poll stalled for a full window — rebuilding the Creditcoin L1 EVM provider in place"
+                            );
+                            match reconnect().await {
+                                Ok(fresh) => {
+                                    provider = fresh;
+                                    tracing::info!(
+                                        last_seen,
+                                        "🔌 Creditcoin L1 EVM provider rebuilt; resuming Outbox scan from cursor"
+                                    );
+                                }
+                                Err(rebuild_err) => {
+                                    tracing::warn!(
+                                        error = %format!("{rebuild_err:#}"),
+                                        "🔌 could not rebuild the Creditcoin L1 EVM provider; keeping the current handle and retrying"
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                %err,
+                                consecutive_failures,
+                                max = MAX_CONSECUTIVE_POLL_FAILURES,
+                                "outbox poll stalled with no progress; will retry"
+                            );
                         }
-                        tracing::warn!(
-                            %err,
-                            consecutive_failures,
-                            max = MAX_CONSECUTIVE_POLL_FAILURES,
-                            "outbox poll stalled with no progress; will retry"
-                        );
                     }
                 }
             }

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -678,7 +678,6 @@ pub async fn run(
 
     // Listener runs as a child task feeding us finalized messages; we sign, count, and publish.
     let (tx, mut rx) = mpsc::channel(common::constants::CAPACITY_CHANNEL);
-    let listener_provider = provider.clone();
     let listener_token = shared.token.clone();
     let confirmation_depth = cfg.block_confirmation_depth;
     // Fall back to the pre-resolution head (not "now") so the resolve-wait window is covered.
@@ -696,11 +695,16 @@ pub async fn run(
         "🗂️ persisting Outbox scan cursor across restarts"
     );
     let listener_tx = tx.clone();
-    // The listener owns its provider and rebuilds it through this hook after a sustained stall
-    // (see `listener::MAX_CONSECUTIVE_POLL_FAILURES`) instead of exiting the task — the sibling of
-    // the resolver's in-place rebuild above. Kept as an inline closure so its future yields the
-    // very same opaque provider type `listener_provider` has; a named helper would mint a second
-    // `impl Provider` that the listener's `P` could not unify with.
+    // One shared Creditcoin L1 handle for the listener, the rotation monitor and the reobservation
+    // worker. alloy clones share a pubsub backend, so a dead connection is dead for all three; the
+    // listener is the loop that detects the stall (see `listener::MAX_CONSECUTIVE_POLL_FAILURES`),
+    // rebuilds through the hook below and publishes the fresh provider here, and the two siblings
+    // clone the latest value before each use. Sibling of the resolver's in-place rebuild above;
+    // nobody exits the task any more. The hook is an inline closure on purpose: its future yields
+    // the very same opaque provider type the channel carries, where a named helper would mint a
+    // second `impl Provider` that the listener's `P` could not unify with.
+    let (l1_provider_tx, l1_provider_rx) = watch::channel(provider.clone());
+    let listener_provider = l1_provider_tx.clone();
     let listener_rpc = rpc.clone();
     let listener_reconnect = move || {
         let rpc = listener_rpc.clone();
@@ -730,7 +734,7 @@ pub async fn run(
     // recovers here instead of leaving the chain key paused indefinitely.
     let (resolved_tx, mut resolved_rx) = watch::channel(Some(resolved));
     let mut outbox_monitor = {
-        let provider = provider.clone();
+        let provider = l1_provider_rx.clone();
         let cfg = cfg.clone();
         let token = shared.token.clone();
         let destination_chain_key = state.destination_chain_key;
@@ -755,7 +759,7 @@ pub async fn run(
     // if the shared provider black-holes. The bounded `reobs_rx` channel already drops excess, so a
     // flood is bounded to serial, deadline-capped work here.
     let mut reobs_worker = {
-        let provider = provider.clone();
+        let provider = l1_provider_rx.clone();
         let state = state.clone();
         let shared = shared.clone();
         let signer = signer.clone();
@@ -901,7 +905,9 @@ pub async fn run(
                         new_outbox = %resolved.address,
                         "🔄 governance/factory rotation detected — switching Outbox listener"
                     );
-                    let listener_provider = provider.clone();
+                    // Hand the replacement listener the shared handle, not a boot-time clone: if
+                    // the previous listener rebuilt the connection, this one starts on the live one.
+                    let listener_provider = l1_provider_tx.clone();
                     let listener_token = shared.token.clone();
                     let cursor_store = cursor::CursorStore::new(
                         &cfg.state_dir,
@@ -1045,8 +1051,8 @@ fn child_exit_error(
 /// with no finalized replacement Outbox publishes `None` immediately so consumers stop signing the
 /// de-registered Outbox while discovery continues.
 #[allow(clippy::too_many_arguments)]
-async fn run_outbox_monitor<P: Provider>(
-    provider: P,
+async fn run_outbox_monitor<P: Provider + Clone>(
+    provider_rx: watch::Receiver<P>,
     cfg: Config,
     destination_chain_key: B256,
     mut cursor: resolver::OutboxDiscoveryCursor,
@@ -1072,6 +1078,10 @@ async fn run_outbox_monitor<P: Provider>(
                 // Same per-attempt bound as the activation loop: an unbounded resolve against a
                 // black-holed RPC would wedge rotation detection silently (the chunked cursor keeps
                 // whatever progress the attempt made, so a timeout costs nothing).
+                // Take the latest shared connection as a separate statement: a `borrow()` inside
+                // the `timeout(...)` expression would hold the watch read guard across the await
+                // and block the listener's `send_replace` for the length of an RPC attempt.
+                let provider = provider_rx.borrow().clone();
                 let attempt = tokio::time::timeout(
                     RPC_ATTEMPT_TIMEOUT,
                     resolver::resolve(
@@ -1181,8 +1191,8 @@ fn rotation_action(
 /// The bounded `reobs_rx` channel drops excess at the p2p ingest, so a flood is naturally bounded to
 /// serial, deadline-capped work here.
 #[allow(clippy::too_many_arguments)]
-async fn run_reobservation_worker<P: alloy::providers::Provider>(
-    provider: P,
+async fn run_reobservation_worker<P: alloy::providers::Provider + Clone>(
+    provider_rx: watch::Receiver<P>,
     mut resolved_rx: watch::Receiver<Option<resolver::ResolvedOutbox>>,
     state: Arc<MessageVoteState>,
     shared: Arc<Shared>,
@@ -1211,6 +1221,9 @@ async fn run_reobservation_worker<P: alloy::providers::Provider>(
                     tracing::warn!(message_id = ?request.message_id, "dropping reobservation request while no Outbox is active");
                     continue;
                 };
+                // Latest shared connection, cloned as its own statement so the watch read guard is
+                // released before the deadline-capped RPC work below.
+                let provider = provider_rx.borrow().clone();
                 let handle = handle_reobservation(
                     &provider, &resolved, &state, &shared.metrics, &signer, our_address, chain_key,
                     confirmation_depth, &mut limiter, request,

--- a/attestor/attestor/src/tasks/write_ability/mod.rs
+++ b/attestor/attestor/src/tasks/write_ability/mod.rs
@@ -696,9 +696,20 @@ pub async fn run(
         "🗂️ persisting Outbox scan cursor across restarts"
     );
     let listener_tx = tx.clone();
+    // The listener owns its provider and rebuilds it through this hook after a sustained stall
+    // (see `listener::MAX_CONSECUTIVE_POLL_FAILURES`) instead of exiting the task — the sibling of
+    // the resolver's in-place rebuild above. Kept as an inline closure so its future yields the
+    // very same opaque provider type `listener_provider` has; a named helper would mint a second
+    // `impl Provider` that the listener's `P` could not unify with.
+    let listener_rpc = rpc.clone();
+    let listener_reconnect = move || {
+        let rpc = listener_rpc.clone();
+        async move { connect_l1_provider(rpc.as_str()).await }
+    };
     let listener = tokio::spawn(async move {
         listener::watch(
-            &listener_provider,
+            listener_provider,
+            listener_reconnect,
             resolved,
             confirmation_depth,
             scan_from,
@@ -906,9 +917,15 @@ pub async fn run(
                     // `scan_from` only when the log carried no block number keeps the old behaviour
                     // for that (not normally reachable) case.
                     let swap_start = resolved.created_at_block.or(scan_from);
+                    let listener_rpc = rpc.clone();
+                    let listener_reconnect = move || {
+                        let rpc = listener_rpc.clone();
+                        async move { connect_l1_provider(rpc.as_str()).await }
+                    };
                     listener = Some(tokio::spawn(async move {
                         listener::watch(
-                            &listener_provider,
+                            listener_provider,
+                            listener_reconnect,
                             resolved,
                             confirmation_depth,
                             swap_start,


### PR DESCRIPTION
## Problem

The write-ability Outbox listener polls Creditcoin L1 over a bare alloy connection whose pubsub task exits permanently after one failed reconnect. Its only recovery was to `return Err` after 10 stalled polls and let the supervisor kill the whole attestor, block attestation included.

Every attestor in a cluster shares one RPC endpoint, so one upstream blip took whole clusters down together. On 31 Aug all six kc/we attestors exited with:

```
⛔ task failed err="write-ability: outbox listener died: outbox poll stalled (no progress)
10 times in a row — RPC connection is likely dead; restarting to rebuild it:
backend connection task has stopped"
```

kc at 14:01:09–12, we at 17:36:04–05. Two deliveries that day landed at exactly quorum (7 of 10).

This is the sibling of #1304, which fixed the same pattern in the Outbox **resolver**. The **listener** path was left as-is.

## Fix

- The write-ability task holds **one `tokio::sync::watch` channel carrying the L1 provider**, shared by the listener, the Outbox rotation monitor and the reobservation worker. alloy clones share a pubsub backend, so a dead connection is dead for all three.
- `listener::watch` is the only loop that counts stalls, so it heals: after a full stall window it logs a WARN, opens a fresh connection through a `reconnect` hook, publishes it with `send_replace`, then adopts it. Scan cursor, finality tracker and cancellation wiring survive. A failed rebuild keeps the old handle and waits another window: a long outage is one warning a minute, not a crash loop.
- `run_outbox_monitor` and `run_reobservation_worker` clone the latest provider before each use, as a separate statement so the watch read guard is released before any await (addresses Bugbot's finding on the first push).
- The rotation re-spawn hands the new listener the shared handle, not a boot-time clone.
- Both spawn sites pass an inline closure around `connect_l1_provider`. Inline on purpose: a named helper would return a second opaque `impl Provider` that the listener's generic cannot unify with.
- `ci.yml`: removed `outbox poll stalled (no progress)` from the attestor-network ERROR allowlist. It only existed because the listener's death surfaced as a `task failed` ERROR during the induced Anvil outage and the gate let it through. The path is WARN now, so an ERROR with that phrase is a regression the gate should catch.

## Verification

- `cargo fmt --check`, `cargo check -p attestor --tests`, `cargo clippy -p attestor --tests -D warnings`: clean
- `cargo test -p attestor write_ability`: 85 passed
- One `#[allow(clippy::too_many_arguments)]` on `watch`, same as four sibling functions in this module

## Rollout

Ship in the same attestor image as #1304 and #1308 (usc-devnet still runs the 25 Aug image). Should go out together with the `outbox`-in-hash change from asc-contracts #45 so the clusters roll once.

https://claude.ai/code/session_01Kv6y52MHgtgkWmnJhdXbHB