### PR TITLE
fix(archiver): verify source chain_id against the Creditcoin registration on every start

### DIFF
--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -86,33 +86,79 @@ async fn main() -> Result<()> {
         }
     }
 
-    // ── Determine finalization lag ────────────────────────────────────────────────────
-    // If a finalization lag parameter is passed, we use that. Otherwise fall back to
-    // the lag from our on chain MaturityStrategy.
-    let finaliztion_lag = if let Some(lag) = cfg.finalization_lag_override {
-        tracing::info!(lag = lag, "Using cfg.finalization_lag_override");
-        lag
-    } else {
-        // Fetch maturity strategy
-        let lag = get_on_chain_finalization_lag(&cfg).await?;
-        tracing::info!(lag = lag, "Using on chain lag from MaturityStrategy");
-        lag
+    // ── Source chain identity ───────────────────────────────────────────
+    // Connect both RPC endpoints up front. They must agree on `chain_id`, and when
+    // `CHAIN_KEY` is set that `chain_id` must be the one registered on Creditcoin for
+    // this archiver's chain key. Both are fatal: archiving the wrong chain under a
+    // given archive name silently corrupts every proof later built from it.
+    let ws_client = eth::Client::new(cfg.rpc_ws.as_str(), None).await?;
+    let http_client = eth::Client::new(cfg.rpc_http.as_str(), None).await?;
+    if ws_client.chain_id() != http_client.chain_id() {
+        return Err(anyhow!(
+            "chain_id's from ws vs http don't match! ws_chain_id: {}, http_chain_id: {}",
+            ws_client.chain_id(),
+            http_client.chain_id(),
+        ));
+    }
+    let source_chain_id = ws_client.chain_id();
+
+    // ── Registered chain (Creditcoin) ───────────────────────────────────
+    // Previously this lookup only ran when FINALIZATION_LAG was unset, so every
+    // deployment that pinned the lag skipped the chain_id verification along with it.
+    // The verification now runs whenever CHAIN_KEY is available.
+    let on_chain_lag = match cfg.chain_key {
+        Some(chain_key) => {
+            let cc3_client = CcClient::new_read_only(&cfg.cc3_rpc_url)
+                .await
+                .with_context(|| {
+                    format!(
+                        "Creditcoin3 RPC failed at cc3_rpc_url={}. \
+                         Ensure the node is up, the URL scheme (ws/wss) matches, and network/firewall allows the connection.",
+                        cfg.cc3_rpc_url
+                    )
+                })?;
+            let chain = cc3_client
+                .get_supported_chain(chain_key)
+                .await
+                .context("Failed to retrieve supported chain")?
+                .ok_or_else(|| {
+                    anyhow!(
+                        "No such supported chain. Check that provided chain_key is valid. chain_key: {chain_key}"
+                    )
+                })?;
+            let chain_name = String::from_utf8_lossy(&chain.chain_name).into_owned();
+
+            if chain.chain_id != source_chain_id {
+                return Err(anyhow!(
+                    "source chain_id {} does not match the chain registered on Creditcoin under \
+                     chain_key {} (chain_id {}, name {:?}); check RPC_HTTP/RPC_WS",
+                    source_chain_id,
+                    chain_key,
+                    chain.chain_id,
+                    chain_name,
+                ));
+            }
+            tracing::info!(
+                chain_key,
+                chain_id = source_chain_id,
+                name = %chain_name,
+                "source chain verified against Creditcoin registration"
+            );
+
+            Some(on_chain_finalization_lag(chain.maturity_strategy.as_str())?)
+        }
+        None => {
+            tracing::warn!(
+                chain_id = source_chain_id,
+                "CHAIN_KEY not set: cannot verify that RPC_HTTP/RPC_WS serve the chain registered \
+                 on Creditcoin; a misconfigured endpoint would be archived silently"
+            );
+            None
+        }
     };
 
-    // ── Url Consistency Checks ────────────────────────────────────────────────────
-    // If http and ws urls point to chains with different `chain_id`s, we treat that
-    // as a fatal error.
-    {
-        let ws_client = eth::Client::new(cfg.rpc_ws.as_str(), None).await?;
-        let http_client = eth::Client::new(cfg.rpc_http.as_str(), None).await?;
-        if ws_client.chain_id() != http_client.chain_id() {
-            return Err(anyhow!(
-                "chain_id's from ws vs http don't match! ws_chain_id: {}, http_chain_id: {}",
-                ws_client.chain_id(),
-                http_client.chain_id(),
-            ));
-        }
-    }
+    // ── Determine finalization lag ──────────────────────────────────────
+    let finaliztion_lag = resolve_finalization_lag(cfg.finalization_lag_override, on_chain_lag)?;
 
     // ── Backfill gaps ────────────────────────────────────────────────────
     if cfg.backfill {
@@ -189,13 +235,9 @@ async fn main() -> Result<()> {
     }
 
     // ── Connect to chain ────────────────────────────────────────────────
-    // WS client for StreamRoots (subscriptions + block fetching).
-    let ws_client = eth::Client::new(cfg.rpc_ws.as_str(), None).await?;
-    let chain_id = ws_client.chain_id();
-    tracing::info!(chain_id, ws = %cfg.rpc_ws, http = %cfg.rpc_http, "connected to chain");
-
-    // HTTP client for chain head tracking.
-    let http_client = eth::Client::new(cfg.rpc_http.as_str(), None).await?;
+    // Reuse the verified clients: WS for StreamRoots (subscriptions + block fetching),
+    // HTTP for chain head tracking.
+    tracing::info!(chain_id = source_chain_id, ws = %cfg.rpc_ws, http = %cfg.rpc_http, "connected to chain");
 
     // ── Root stream (with automatic reconnection) ───────────────────────
     let stream_config = stream_eth::roots::ConfigBuilder::new()
@@ -419,56 +461,76 @@ fn format_eta(remaining: u64, rate: f64) -> String {
     }
 }
 
-async fn get_on_chain_finalization_lag(cfg: &Config) -> Result<u64> {
-    // Check that chain_key is present in config
-    let chain_key = if let Some(ck) = cfg.chain_key {
-        ck
-    } else {
-        return Err(anyhow!(
-            "Either cfg.finalization_lag_override or cfg.chain_key must be set!"
-        ));
-    };
-
-    // Temp eth client for checking that chain_id matches expected.
-    let eth_client = eth::Client::new(cfg.rpc_http.as_str(), None).await?;
-
-    // Temp cc3 client for getting finalization lag
-    let cc3_client =
-        CcClient::new_read_only(&cfg.cc3_rpc_url)
-            .await
-            .with_context(|| {
-                format!(
-                    "Creditcoin3 RPC failed at cc3_rpc_url={}. \
-                        Ensure the node is up, the URL scheme (ws/wss) matches, and network/firewall allows the connection.",
-                    cfg.cc3_rpc_url
-                )
-            })?;
-
-    let supported_chain = cc3_client
-        .get_supported_chain(chain_key)
-        .await
-        .context("Failed to retrieve supported chain")?
-        .ok_or(anyhow!(
-            "No such supported chain. Check that provided chain_key is valid. chain_key: {chain_key}"
-        ))?;
-
-    if supported_chain.chain_id != eth_client.chain_id() {
-        return Err(anyhow!(
-            "Source chain id doesn't match registered id on Creditcoin under chain_key. chain_key: {}, creditcoin_source_id: {}, eth_rpc_source_id: {}",
-            chain_key,
-            supported_chain.chain_id,
-            eth_client.chain_id()
-        ));
-    }
-
-    let strategy_enum: supported_chains_primitives::MaturityStrategy = supported_chain
-        .maturity_strategy
-        .as_str()
+/// Maturity delay implied by an on-chain `MaturityStrategy` string
+/// (e.g. `"EvmFinalized"` → 64, `"FixedDelay: 5"` → 5).
+fn on_chain_finalization_lag(maturity_strategy: &str) -> Result<u64> {
+    let strategy: supported_chains_primitives::MaturityStrategy = maturity_strategy
         .try_into()
         .map_err(|e| anyhow!("Invalid maturity strategy: {e:?}"))?;
 
-    // Return final maturity delay
-    strategy_enum.maturity_delay().ok_or(anyhow!(
-        "No maturity delay for strategy: strategy_enum: {strategy_enum:?}"
-    ))
+    strategy
+        .maturity_delay()
+        .ok_or_else(|| anyhow!("No maturity delay for strategy: {strategy:?}"))
+}
+
+/// Pick the finalization lag. An explicit `FINALIZATION_LAG` always wins so operators
+/// keep an escape hatch, but a value that disagrees with the on-chain registration is
+/// logged loudly: the attestors follow the on-chain strategy, and a lag below theirs
+/// means the archiver flushes roots for blocks they do not yet consider mature.
+fn resolve_finalization_lag(override_lag: Option<u64>, on_chain_lag: Option<u64>) -> Result<u64> {
+    match (override_lag, on_chain_lag) {
+        (Some(lag), Some(on_chain)) if lag != on_chain => {
+            tracing::warn!(
+                lag,
+                on_chain,
+                "FINALIZATION_LAG differs from the on-chain MaturityStrategy the attestors use"
+            );
+            Ok(lag)
+        }
+        (Some(lag), _) => {
+            tracing::info!(lag, "Using cfg.finalization_lag_override");
+            Ok(lag)
+        }
+        (None, Some(lag)) => {
+            tracing::info!(lag, "Using on chain lag from MaturityStrategy");
+            Ok(lag)
+        }
+        (None, None) => Err(anyhow!(
+            "Either FINALIZATION_LAG or CHAIN_KEY (with CC3_RPC_URL) must be set"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn on_chain_lag_follows_maturity_strategy() {
+        assert_eq!(on_chain_finalization_lag("EvmFinalized").unwrap(), 64);
+        assert_eq!(on_chain_finalization_lag("EvmSafe").unwrap(), 32);
+        assert_eq!(on_chain_finalization_lag("FixedDelay: 5").unwrap(), 5);
+    }
+
+    #[test]
+    fn on_chain_lag_rejects_unknown_strategy() {
+        assert!(on_chain_finalization_lag("Bogus").is_err());
+    }
+
+    #[test]
+    fn override_wins_even_when_it_disagrees_with_chain() {
+        assert_eq!(resolve_finalization_lag(Some(64), Some(64)).unwrap(), 64);
+        assert_eq!(resolve_finalization_lag(Some(10), Some(64)).unwrap(), 10);
+        assert_eq!(resolve_finalization_lag(Some(0), None).unwrap(), 0);
+    }
+
+    #[test]
+    fn on_chain_lag_used_without_override() {
+        assert_eq!(resolve_finalization_lag(None, Some(5)).unwrap(), 5);
+    }
+
+    #[test]
+    fn neither_source_is_an_error() {
+        assert!(resolve_finalization_lag(None, None).is_err());
+    }
 }


### PR DESCRIPTION
## Problem

The archiver's chain_id verification lived inside `get_on_chain_finalization_lag`, which only ran when `FINALIZATION_LAG` was **unset**. Every deployed archiver pins `FINALIZATION_LAG` (the chart always renders it), so the check has never run in production.

Today on cc3-devnet a fresh `bsc-mainnet` archiver (chain_key 8 → chainId 56) came up against an RPC pair that actually served **BSC testnet (chain_id 97)** and started archiving it under the mainnet archive name. The only hint was `chain_id=97` inside an INFO line. Caught by eye within ~90s and the PVC was wiped; a proof-gen pointed at that archiver would have served testnet roots as mainnet.

## Change

- **Decouple verification from lag lookup.** Connect both RPC clients once; require ws/http `chain_id` agreement (existing check); then, if `CHAIN_KEY` is set, fetch the `SupportedChain` from cc3 and **fail hard** if its `chain_id` differs from the RPC's. This runs regardless of whether the lag is overridden.
- **Without `CHAIN_KEY`** the archiver still starts (chart compatibility) but logs a WARN that the source chain is unverified.
- **Lag resolution is a pure function** (`resolve_finalization_lag`): override wins, on-chain otherwise, neither → error. An override that disagrees with the on-chain `MaturityStrategy` is logged at WARN — attestors follow the on-chain value, and a smaller archiver lag flushes roots they do not yet consider mature (this is the drift we hit on usc-devnet: archiver 10 / prover 32 / attestors 64).
- **Reuse the two verified clients** for the stream and head tracker instead of reconnecting: one fewer handshake per endpoint at startup (rate-limited providers have tripped on the startup burst).
- Unit tests for strategy → lag and the resolution matrix.

## Behaviour matrix

| `CHAIN_KEY` | `FINALIZATION_LAG` | RPC chain_id vs registration | Result |
|---|---|---|---|
| set | any | mismatch | **exit with error** |
| set | set, ≠ on-chain | match | start, WARN about lag drift |
| set | set, = on-chain | match | start |
| set | unset | match | start with on-chain lag |
| unset | set | n/a | start, WARN "source chain unverified" |
| unset | unset | n/a | exit: one of the two is required |

## Verification

`cargo check/test/clippy -D warnings -p archiver` clean; 15 tests pass (5 new).

## Follow-up (cc-networks-iac)

Charts should always pass `CHAIN_KEY` + `CC3_RPC_URL` so the verification is active on every archiver, independent of `finalizationLagFromChain`. Separate PR.