### PR TITLE
feat(attestor): follow asc-contracts #45, bind the Outbox into the message hash

### DIFF
--- a/.github/workflows/write-ability-e2e.yml
+++ b/.github/workflows/write-ability-e2e.yml
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: gluwa/asc-contracts
-          ref: 434073943ec6828c3271bcf39114a04304e97d7f # main @ 2026-09-04 (#46 block-based timelock) — bump deliberately
+          ref: c83b3372349712dac96d6f4927a3f321282ec39d # main @ 2026-09-09 (#48 outbox in messageHash + Inbox allowlist, on top of #46) — bump deliberately
           path: asc-contracts
           # asc-contracts is private; the default GITHUB_TOKEN is scoped to creditcoin3 only and
           # gets "Repository not found". Use the org bot PAT (same one build-native uses cross-repo).

--- a/.github/workflows/write-ability-e2e.yml
+++ b/.github/workflows/write-ability-e2e.yml
@@ -109,7 +109,7 @@ jobs:
           # the *same* relayer code — `ref: main` made the e2e non-reproducible (the same commit
           # could pass or fail as the relayer's default branch moved). Bump this deliberately when
           # a relayer change needs to be exercised here.
-          ref: ea6a0b2802f878b51f8943a74baec9eb60931d92 # v0.5.0 (#43) — cursor persistence, settlement metrics, genesis fallback; bump deliberately
+          ref: f17231928ff611bf18298d7de75d27b53bb91e1b # main @ 2026-09-09 (#60 outbox in the message hash, 5-arg deliverMessage; includes #59 OutboxDiscovery mirror + #61 finalized-head scan) — bump deliberately
           path: asc-message-relayer
 
       # Fee-integrated write-ability contracts. The plain-ethers deploy scripts read their compiled

--- a/attestor/attestor/src/tasks/write_ability/listener.rs
+++ b/attestor/attestor/src/tasks/write_ability/listener.rs
@@ -521,6 +521,7 @@ async fn scan_range<P: Provider>(
                 let hash = message_hash(
                     decoded.data.messageId,
                     emitter,
+                    resolved.address,
                     resolved.destination_chain_key,
                     resolved.creditcoin_chain_id,
                     &payload,

--- a/attestor/attestor/src/tasks/write_ability/reobservation.rs
+++ b/attestor/attestor/src/tasks/write_ability/reobservation.rs
@@ -252,6 +252,7 @@ pub async fn reobserve<P: Provider>(
         let hash = message_hash(
             decoded.data.messageId,
             emitter,
+            resolved.address,
             resolved.destination_chain_key,
             resolved.creditcoin_chain_id,
             &payload,

--- a/attestor/attestor/tests/e2e_anvil.rs
+++ b/attestor/attestor/tests/e2e_anvil.rs
@@ -130,6 +130,7 @@ async fn outbox_publish_indexed_signed_and_reaches_quorum() {
     let expected = message_hash(
         message_id,
         emitter,
+        resolved.address,
         ck_b32,
         resolved.creditcoin_chain_id,
         &payload,

--- a/common/write-ability/src/hash.rs
+++ b/common/write-ability/src/hash.rs
@@ -1,40 +1,54 @@
 //! `messageHash` builder.
 //!
-//! Per PoC §5.2:
+//! Mirrors `Inbox.deliverMessage` on asc-contracts `feature/SMC-1646` (PR #45, merged 2026-09-04):
 //!
 //! ```solidity
 //! messageHash = keccak256(abi.encode(
 //!     bytes32 messageId,
 //!     address emitterAddress,
-//!     bytes32 destinationChainKey,
-//!     uint64  creditcoinChainId,
-//!     bytes   payload
+//!     address outbox,             // the source Outbox that published the message (#45)
+//!     bytes32 localChainKey,      // the destination chain key
+//!     uint256 sourceChainId,      // Creditcoin's eth_chainId
+//!     bytes   messagePayload
 //! ))
 //! ```
 //!
+//! `outbox` was added so a vote for a message on a retired or rogue Outbox can never be replayed as
+//! if the canonical one had published it; the Inbox also refuses `deliverMessage` for any Outbox
+//! that is not on its allowlist. The field sits after `emitterAddress` so all static words come
+//! first and the one dynamic field last. (The order is a style choice: this is `abi.encode`, whose
+//! head/tail layout makes every order unambiguous. Only `encodePacked` has the adjacent-dynamic
+//! collision problem.)
+//!
 //! This must be byte-identical to what attestors sign and what the inbox recomputes inside
-//! `validateVotes`. The golden-vector tests at the bottom of this file are the contract: any
-//! drift here will silently break delivery.
+//! `validateVotes`. The golden vectors at the bottom of this file were produced with Foundry
+//! (`cast abi-encode` + `cast keccak`) and are duplicated in asc-message-relayer; any drift here
+//! silently breaks delivery.
 
 use alloy::primitives::{keccak256, Address, B256, U256};
 use alloy::sol_types::SolValue;
 
 /// Compute `messageHash` exactly as the Solidity `validateVotes` will recompute it.
+///
+/// `outbox` is the Outbox the event was scanned from; the attestor knows it because it resolved
+/// that address before listening, and the relayer knows it for the same reason.
 #[must_use]
 pub fn message_hash(
     message_id: B256,
     emitter: Address,
+    outbox: Address,
     destination_chain_key: B256,
     creditcoin_chain_id: u64,
     payload: &[u8],
 ) -> B256 {
-    // `abi.encode(a, b, c, d, e)` in Solidity is the head-encoding of a tuple — `abi_encode_params`
+    // `abi.encode(a, b, c, d, e, f)` in Solidity is the head-encoding of a tuple — `abi_encode_params`
     // on a tuple type produces the same byte sequence. Using `abi_encode` on the tuple would wrap
     // it in an outer offset (Solidity-struct semantics), which is *not* what `abi.encode` does for
     // a free-standing argument list.
     let encoded = (
         message_id,
         emitter,
+        outbox,
         destination_chain_key,
         U256::from(creditcoin_chain_id),
         payload.to_vec(),
@@ -88,12 +102,15 @@ mod tests {
     use super::*;
     use alloy::primitives::{address, b256};
 
+    const OUTBOX: Address = address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
     /// Sanity vector: same input → same hash. Cheap deterministic check.
     #[test]
     fn deterministic() {
         let a = message_hash(
             b256!("1111111111111111111111111111111111111111111111111111111111111111"),
             address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            OUTBOX,
             b256!("0000000000000000000000000000000000000000000000000000000000000002"),
             102_031,
             b"hello",
@@ -101,11 +118,62 @@ mod tests {
         let b = message_hash(
             b256!("1111111111111111111111111111111111111111111111111111111111111111"),
             address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            OUTBOX,
             b256!("0000000000000000000000000000000000000000000000000000000000000002"),
             102_031,
             b"hello",
         );
         assert_eq!(a, b);
+    }
+
+    /// Golden vectors produced with Foundry against the #45 preimage:
+    /// `cast abi-encode 'f(bytes32,address,address,bytes32,uint256,bytes)' …` piped into
+    /// `cast keccak`. The same three constants live in asc-message-relayer's golden test; if
+    /// either side drifts from the Inbox, attestor signatures stop verifying on-chain.
+    #[test]
+    fn golden_vectors_match_cast_abi_encode() {
+        let m = b256!("1111111111111111111111111111111111111111111111111111111111111111");
+        let e = address!("2222222222222222222222222222222222222222");
+        let o = address!("3333333333333333333333333333333333333333");
+        let d = b256!("0000000000000000000000000000000000000000000000000000000000000008");
+        let cc = 42u64;
+
+        assert_eq!(
+            message_hash(m, e, o, d, cc, &[0xde, 0xad, 0xbe, 0xef]),
+            b256!("4b387cab474082acc4b1765537d74b87b4425bf4ecd4e375472106d63e12ff68"),
+            "six-field preimage with a 4-byte payload"
+        );
+        assert_eq!(
+            message_hash(m, e, o, d, cc, b""),
+            b256!("a5f139b554b2264af26a30ad40276a909055ca73db27a4e4d005baa1a3f8d013"),
+            "six-field preimage with an empty payload"
+        );
+        // The pre-#45 five-field hash of the same inputs. Must NOT match: this is the vote-format
+        // fork the coordinated attestor + relayer + Inbox redeploy exists for.
+        assert_ne!(
+            message_hash(m, e, o, d, cc, &[0xde, 0xad, 0xbe, 0xef]),
+            b256!("c99b69d3aef00fc024cdb4751aae2a8ea1467501e2fdd2824dd415a120deb5bd"),
+            "must not collide with the legacy five-field preimage"
+        );
+    }
+
+    /// Differing Outbox must produce different hashes (no cross-Outbox replay after rotation).
+    #[test]
+    fn outbox_sensitive() {
+        let m = b256!("1111111111111111111111111111111111111111111111111111111111111111");
+        let e = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let d = b256!("0000000000000000000000000000000000000000000000000000000000000002");
+
+        let h1 = message_hash(m, e, OUTBOX, d, 1, b"x");
+        let h2 = message_hash(
+            m,
+            e,
+            address!("cccccccccccccccccccccccccccccccccccccccc"),
+            d,
+            1,
+            b"x",
+        );
+        assert_ne!(h1, h2);
     }
 
     /// Differing payload bytes must produce different hashes.
@@ -115,8 +183,8 @@ mod tests {
         let e = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let d = b256!("0000000000000000000000000000000000000000000000000000000000000002");
 
-        let h1 = message_hash(m, e, d, 1, b"a");
-        let h2 = message_hash(m, e, d, 1, b"b");
+        let h1 = message_hash(m, e, OUTBOX, d, 1, b"a");
+        let h2 = message_hash(m, e, OUTBOX, d, 1, b"b");
         assert_ne!(h1, h2);
     }
 
@@ -219,8 +287,8 @@ mod tests {
         let e = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let d = b256!("0000000000000000000000000000000000000000000000000000000000000002");
 
-        let h1 = message_hash(m, e, d, 1, b"x");
-        let h2 = message_hash(m, e, d, 2, b"x");
+        let h1 = message_hash(m, e, OUTBOX, d, 1, b"x");
+        let h2 = message_hash(m, e, OUTBOX, d, 2, b"x");
         assert_ne!(h1, h2);
     }
 
@@ -233,6 +301,7 @@ mod tests {
         let h1 = message_hash(
             m,
             e,
+            OUTBOX,
             b256!("0000000000000000000000000000000000000000000000000000000000000002"),
             1,
             b"x",
@@ -240,6 +309,7 @@ mod tests {
         let h2 = message_hash(
             m,
             e,
+            OUTBOX,
             b256!("0000000000000000000000000000000000000000000000000000000000000007"),
             1,
             b"x",
@@ -253,12 +323,12 @@ mod tests {
         let h = message_hash(
             b256!("0000000000000000000000000000000000000000000000000000000000000000"),
             address!("0000000000000000000000000000000000000000"),
+            address!("0000000000000000000000000000000000000000"),
             b256!("0000000000000000000000000000000000000000000000000000000000000000"),
             0,
             b"",
         );
-        // Just assert non-zero, since the actual value should be locked down by an
-        // integration-tests/golden_hash.rs vector once the reference Solidity contract lands.
+        // Non-zero here; the exact value is pinned by `golden_vectors_match_cast_abi_encode`.
         assert_ne!(h, B256::ZERO);
     }
 }

--- a/usc-messaging/scripts/deploy-dest-devnet.mts
+++ b/usc-messaging/scripts/deploy-dest-devnet.mts
@@ -47,8 +47,15 @@ console.log("deployer:", wallet.address, "balance:", ethers.formatEther(await pr
 // Post-#23: SimpleInbox is gone; Inbox(chainKey, creditcoinChainId, validator, messageDispatcher, owner)
 // where the dispatcher must be a deployed contract — so the consumer dApp goes first.
 const dapp = await deploy("MockDestination", ART("mocks/TestMocks.sol", "MockDestination"));
+// asc-contracts #48: Inbox(…, initialOutboxes) — comma-separated source Outbox addresses in
+// INITIAL_OUTBOXES, or empty and the owner calls setSupportedOutbox(outbox, true) before delivery.
+const INITIAL_OUTBOXES = (process.env.INITIAL_OUTBOXES ?? "").split(",").map((a) => a.trim()).filter(Boolean)
+  .map((a) => ethers.getAddress(a));
 const inbox = await deploy("Inbox", ART("write-ability/Inbox.sol", "Inbox"),
-  [LOCAL_CHAIN_KEY, CREDITCOIN_CHAIN_ID, VALIDATOR, await dapp.getAddress(), wallet.address]);
+  [LOCAL_CHAIN_KEY, CREDITCOIN_CHAIN_ID, VALIDATOR, await dapp.getAddress(), wallet.address, INITIAL_OUTBOXES]);
+console.log(INITIAL_OUTBOXES.length
+  ? `  Inbox allowlist: ${INITIAL_OUTBOXES.join(", ")}`
+  : "  Inbox allowlist empty — call Inbox.setSupportedOutbox(outbox, true) before the relayer can deliver");
 
 const addrs = existsSync(OUT) ? JSON.parse(readFileSync(OUT, "utf8")) : {};
 addrs.dest = {

--- a/usc-messaging/scripts/deploy-dest-ethers.mts
+++ b/usc-messaging/scripts/deploy-dest-ethers.mts
@@ -58,8 +58,11 @@ const validator = await deploy("EOAValidator", ART("write-ability/EOAValidator.s
   [wallet.address, await registry.getAddress(), 3, 20, 1]);
 const dapp = await deploy("MockDestination", ART("mocks/TestMocks.sol", "MockDestination"));
 // Inbox requires its messageDispatcher to already have code, so the dApp must be deployed first.
+// asc-contracts #48: the Inbox only delivers from allowlisted source Outboxes (`initialOutboxes`,
+// `setSupportedOutbox`). The Outbox does not exist yet at this point — deploy-source-ethers.mts
+// creates it via CREATE2 and allowlists it on this Inbox right after — so start empty.
 const inbox = await deploy("Inbox", ART("write-ability/Inbox.sol", "Inbox"),
-  [LOCAL_CHAIN_KEY, CREDITCOIN_CHAIN_ID, await validator.getAddress(), await dapp.getAddress(), wallet.address]);
+  [LOCAL_CHAIN_KEY, CREDITCOIN_CHAIN_ID, await validator.getAddress(), await dapp.getAddress(), wallet.address, []]);
 
 const addrs = existsSync(OUT) ? JSON.parse(readFileSync(OUT, "utf8")) : {};
 addrs.dest = {

--- a/usc-messaging/scripts/deploy-source-devnet.mts
+++ b/usc-messaging/scripts/deploy-source-devnet.mts
@@ -47,6 +47,27 @@ async function deploy(name: string, art: any, args: any[] = []) {
   return c;
 }
 
+// Destination-side admin call: Inbox.setSupportedOutbox(outbox, true) on Sepolia. Idempotent
+// (EnumerableSet add of an existing member is a no-op) and verified by reading it back.
+async function allowlistOutboxOnInbox(inboxAddr: string, outboxAddr: string) {
+  const sepoliaRpc = process.env.SEPOLIA_RPC;
+  if (!sepoliaRpc) throw new Error("set SEPOLIA_RPC so the new Outbox can be allowlisted on the destination Inbox");
+  const destProvider = new ethers.JsonRpcProvider(sepoliaRpc, DEST_CHAIN_ID, { staticNetwork: true, polling: true });
+  const destWallet = new ethers.Wallet(key, destProvider);
+  const inbox = new ethers.Contract(inboxAddr, ART("write-ability/Inbox.sol", "Inbox").abi, destWallet);
+  if (await (inbox as any).isSupportedOutbox(outboxAddr)) {
+    console.log(`  Inbox ${inboxAddr} already allowlists ${outboxAddr}`);
+  } else {
+    console.log(`  allowlisting Outbox ${outboxAddr} on Sepolia Inbox ${inboxAddr}…`);
+    await (await (inbox as any).setSupportedOutbox(outboxAddr, true)).wait();
+    if (!(await (inbox as any).isSupportedOutbox(outboxAddr))) {
+      throw new Error(`Inbox.setSupportedOutbox did not land for ${outboxAddr}`);
+    }
+    console.log("  Inbox.isSupportedOutbox confirmed");
+  }
+  destProvider.destroy();
+}
+
 async function main() {
   const addrs = JSON.parse(readFileSync(OUT, "utf8"));
   if (!addrs.dest?.inbox) throw new Error("need dest.inbox — run deploy-dest-devnet first");
@@ -104,6 +125,11 @@ async function main() {
 
   const outbox = new ethers.Contract(outboxAddr, ART("write-ability/Outbox.sol", "Outbox").abi, wallet);
   await (await outbox.setTrustedForwarder(rcAddr, true)).wait();
+
+  // asc-contracts #48: the Sepolia Inbox delivers only from allowlisted Outboxes. When
+  // deploy-dest-devnet.mts ran without INITIAL_OUTBOXES (this Outbox did not exist yet) its
+  // allowlist is empty, so add the new Outbox now, as the Inbox owner (same DEPLOYER_KEY).
+  await allowlistOutboxOnInbox(addrs.dest.inbox, outboxAddr);
 
   const ackValidator = await deploy("AcknowledgmentValidator",
     ART("write-ability/AcknowledgementValidator.sol", "AcknowledgmentValidator"),

--- a/usc-messaging/scripts/deploy-source-ethers.mts
+++ b/usc-messaging/scripts/deploy-source-ethers.mts
@@ -84,6 +84,23 @@ async function registerFactoryBeforeOutbox(factory: string) {
   }
 }
 
+// Destination-side admin call: Inbox.setSupportedOutbox(outbox, true) as the Inbox owner (anvil
+// account 0, the same key deploy-dest-ethers.mts deploys with). Verified by reading it back.
+async function allowlistOutboxOnInbox(dest: { rpc: string; chainId: number; inbox: string }, outboxAddr: string) {
+  const ANVIL0 = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+  const destProvider = new ethers.JsonRpcProvider(dest.rpc, dest.chainId, { staticNetwork: true });
+  destProvider.pollingInterval = 500;
+  const destWallet = new ethers.Wallet(ANVIL0, destProvider);
+  const inbox = new ethers.Contract(dest.inbox, ART("write-ability/Inbox.sol", "Inbox").abi, destWallet);
+  console.log(`  allowlisting Outbox ${outboxAddr} on destination Inbox ${dest.inbox}…`);
+  await (await (inbox as any).setSupportedOutbox(outboxAddr, true)).wait();
+  if (!(await (inbox as any).isSupportedOutbox(outboxAddr))) {
+    throw new Error(`Inbox.setSupportedOutbox did not land for ${outboxAddr}`);
+  }
+  console.log("  Inbox.isSupportedOutbox confirmed");
+  destProvider.destroy();
+}
+
 async function main() {
   const addrs = JSON.parse(readFileSync(OUT, "utf8"));
   if (!addrs.dest?.inbox) throw new Error("need dest.inbox");
@@ -144,6 +161,11 @@ async function main() {
 
   const outbox = new ethers.Contract(outboxAddr, ART("write-ability/Outbox.sol", "Outbox").abi, wallet);
   await (await outbox.setTrustedForwarder(rcAddr, true)).wait();
+
+  // asc-contracts #48: the destination Inbox delivers only from allowlisted Outboxes and binds the
+  // Outbox into the attested messageHash. deploy-dest-ethers.mts deployed it with an empty
+  // allowlist (this Outbox did not exist yet); add it now, from the same anvil admin key.
+  await allowlistOutboxOnInbox(addrs.dest, outboxAddr);
 
   // Acknowledgment round-trip: deploy the AcknowledgmentValidator for the destination chain key,
   // make it the Outbox's validator (only it may call acknowledgeMessage), then point it at the


### PR DESCRIPTION
Companion to asc-contracts #48 (the #45 Inbox change, merged to main 9 Sep as `c83b3372`) and asc-message-relayer #60 (merged 9 Sep as `f1723192`). **Vote-format fork**: attestors, relayer and Inbox must roll in one window; ship in the same attestor image as #1304, #1308 and #1317.

## What changes

- `common/write-ability::message_hash` gains `outbox` after `emitterAddress`, matching the merged Inbox:
  `keccak256(abi.encode(messageId, emitterAddress, outbox, localChainKey, sourceChainId, messagePayload))`
- Listener and reobservation worker pass `resolved.address`, which `IndexedMessage` already carried.
- e2e_anvil recomputation updated.

## Golden vectors

Generated with Foundry, shared verbatim with asc-message-relayer `tests/golden_hash.rs`:

```
cast abi-encode 'f(bytes32,address,address,bytes32,uint256,bytes)' 0x11..11 0x22..22 0x33..33 0x00..08 42 0xdeadbeef | cast keccak
→ 0x4b387cab474082acc4b1765537d74b87b4425bf4ecd4e375472106d63e12ff68
empty payload → 0xa5f139b554b2264af26a30ad40276a909055ca73db27a4e4d005baa1a3f8d013
legacy 5-field preimage (must differ) → 0xc99b69d3aef00fc024cdb4751aae2a8ea1467501e2fdd2824dd415a120deb5bd
```

## Verification

`cargo fmt`, `cargo clippy -p write-ability -p attestor --tests -D warnings`, `cargo test -p write-ability` (19), `cargo test -p attestor write_ability` (85), `e2e_anvil` compiles. Expect the usual branch-inherent reds (`target-branch-check`, storage-version compares, `attestor-compatibility`).

## Rollout

Deploy order: new Inbox on Sepolia from asc-contracts main `c83b3372` with Outbox 0x95FE… allowlisted (`INITIAL_OUTBOXES` or `setSupportedOutbox`), then this attestor image on all three usc-devnet clusters together with relayer `main-f172319`. Router/envelope (#36) can follow in a later window. Messages published before the cutover cannot be delivered on the new Inbox; drain first.

https://claude.ai/code/session_01Kv6y52MHgtgkWmnJhdXbHB

> **Status 9 Sep 08:35 UTC.** Rebased onto writeability-off-usc-dev; e2e pins moved to asc-contracts `c83b3372` and relayer `f1723192`; e2e deploy scripts follow the new Inbox constructor (dest deploys with an empty allowlist, source calls `setSupportedOutbox` after the CREATE2 Outbox and reads it back; `deploy-dest-devnet.mts` takes `INITIAL_OUTBOXES`). First e2e with the full new hash stack on both sides. Remaining known reds are branch-inherent (target-branch-check, storage-version compare, attestor-compatibility).