### PR TITLE
feat(proof-gen): make cache memory configurable per chain and budget it

### DIFF
--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -460,6 +460,14 @@ impl Client {
         self
     }
 
+    /// Handle to the in-process block cache, if one was enabled.
+    ///
+    /// Lets a caller observe cache occupancy without routing through the RPC provider traits.
+    #[must_use]
+    pub fn block_cache(&self) -> Option<std::sync::Arc<mem_block_cache::MemBlockCache>> {
+        self.mem_cache.clone()
+    }
+
     /// Build a [`Client`] with ordered fallback RPC URLs.
     ///
     /// `url` is the primary URL: tried first for every operation, and the

--- a/common/eth/src/mem_block_cache.rs
+++ b/common/eth/src/mem_block_cache.rs
@@ -50,6 +50,28 @@ impl MemBlockCache {
         evict_to_capacity(&mut map, self.capacity);
     }
 
+    /// Configured maximum number of blocks.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Occupancy snapshot: `(blocks, transactions)`.
+    ///
+    /// Each entry holds a whole block's *decoded* transactions and receipts, which on a
+    /// high-throughput chain is the largest per-chain allocation in the process. A byte figure
+    /// is not offered on purpose: the decoded alloy types are deeply nested, so any cheap
+    /// estimate would be more misleading than the counts. Blocks against
+    /// [`Self::capacity`] shows saturation; transactions show scale.
+    #[must_use]
+    pub fn occupancy(&self) -> (usize, usize) {
+        let map = self.lock();
+        let blocks = map.len();
+        let transactions = map.values().map(|block| block.items.len()).sum();
+
+        (blocks, transactions)
+    }
+
     fn lock(&self) -> std::sync::MutexGuard<'_, BTreeMap<u64, OrderedBlock>> {
         // A poisoned lock only happens if a holder panicked while mutating; the map is plain data
         // with no broken invariant, so recover the guard rather than propagate the panic.
@@ -82,6 +104,17 @@ mod tests {
         evict_to_capacity(&mut map, 3);
         // The 3 highest block numbers survive; the lowest 7 are evicted.
         assert_eq!(map.keys().copied().collect::<Vec<_>>(), vec![8, 9, 10]);
+    }
+
+    #[test]
+    fn capacity_is_reported_as_configured() {
+        use super::MemBlockCache;
+        use std::num::NonZeroUsize;
+
+        let cache = MemBlockCache::new(NonZeroUsize::new(96).expect("96 is non-zero"));
+        assert_eq!(cache.capacity(), 96);
+        // Nothing cached yet, so no blocks and no transactions.
+        assert_eq!(cache.occupancy(), (0, 0));
     }
 
     #[test]

--- a/common/merkle/src/keccak_merkle_tree.rs
+++ b/common/merkle/src/keccak_merkle_tree.rs
@@ -79,6 +79,18 @@ impl KeccakMerkleTree {
             .unwrap_or_default()
     }
 
+    /// Approximate heap footprint of this tree, in bytes.
+    ///
+    /// Counts every level's hashes plus the per-level `Vec` headers. Callers that cache
+    /// trees need this to budget their memory, and `levels` is private so they cannot
+    /// measure it themselves.
+    pub fn heap_bytes(&self) -> usize {
+        let headers = core::mem::size_of::<Vec<H256>>().saturating_mul(self.levels.len());
+        self.levels.iter().fold(headers, |acc, level| {
+            acc.saturating_add(core::mem::size_of::<H256>().saturating_mul(level.len()))
+        })
+    }
+
     /// Generate a Merkle proof for a specific leaf index
     ///
     /// # Errors
@@ -244,5 +256,30 @@ mod tests {
                 max_index: 1,
             })
         );
+    }
+
+    #[test]
+    fn heap_bytes_grows_with_leaf_count_and_is_zero_when_empty() {
+        assert_eq!(KeccakMerkleTree::new(&[]).heap_bytes(), 0);
+
+        let small = KeccakMerkleTree::new(&[vec![1], vec![2]]);
+        let large = KeccakMerkleTree::new(&(0..64u8).map(|n| vec![n]).collect::<Vec<_>>());
+
+        assert!(small.heap_bytes() > 0);
+        assert!(
+            large.heap_bytes() > small.heap_bytes(),
+            "64 leaves ({}) should outweigh 2 leaves ({})",
+            large.heap_bytes(),
+            small.heap_bytes()
+        );
+    }
+
+    #[test]
+    fn heap_bytes_counts_every_level() {
+        // 4 leaves => levels of 4, 2, 1 hashes = 7 hashes across 3 level vecs.
+        let tree = KeccakMerkleTree::new(&[vec![1], vec![2], vec![3], vec![4]]);
+        let expected = 7 * core::mem::size_of::<H256>() + 3 * core::mem::size_of::<Vec<H256>>();
+
+        assert_eq!(tree.heap_bytes(), expected);
     }
 }

--- a/proof-gen-api-server/.env.example
+++ b/proof-gen-api-server/.env.example
@@ -25,9 +25,9 @@ ENABLE_PROMETHEUS_METRICS=false
 PROMETHEUS_HOST=0.0.0.0
 PROMETHEUS_PORT=9090
 
-# Optional: Redis URL for Ethereum block caching
+# [DEPRECATED — ignored] Block caching is in-process only; these are no longer read.
+# Size the in-process caches with each chain's `cache:` block in the YAML config instead.
 # REDIS_URL=redis://127.0.0.1:6379
-# Optional: Set to true/1/yes when using Redis Cluster (e.g. ElastiCache cluster mode)
 # REDIS_CLUSTER_MODE=false
 
 # [DEPRECATED — ignored] The indexer is no longer used; this setting has no effect.
@@ -43,6 +43,13 @@ MAX_BATCH_SIZE=10
 
 # Number of blocks to lag behind the EVM chain tip when validating block existence.
 # Blocks within this window are rejected to guard against reorgs.
-# Default: 0 (no lag, suitable for instant-finality chains).
-# Recommended: 12 for Ethereum mainnet (~2 min at 12 s/block).
-# BLOCK_CONFIRMATION_DEPTH=0
+# When UNSET (recommended), this is derived from the chain's on-chain MaturityStrategy -- the
+# same value the attestors act on, so this process cannot disagree with them. Set it only to
+# deliberately pin a value; startup warns if it disagrees with the chain.
+# Note: in --config (YAML) mode this env var is ignored; use the per-chain
+# `block_confirmation_depth` field instead.
+# BLOCK_CONFIRMATION_DEPTH=32
+
+# Per-chain cache sizing (merkle_retention_blocks, merkle_max_bytes, block_cache_capacity,
+# merkle_backfill_enabled, checkpoint_cache_max_entries) is expressed only in the YAML config,
+# under each chain's `cache:` block. See config.example.yaml.

--- a/proof-gen-api-server/bin/server.rs
+++ b/proof-gen-api-server/bin/server.rs
@@ -151,6 +151,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 eth_rpc_fallback_urls: Vec::new(),
                 archiver_url: args.archiver_url,
                 block_confirmation_depth: args.block_confirmation_depth,
+                // Per-chain cache sizing is expressed in the YAML config only, like
+                // `eth_rpc_fallback_urls`. Legacy single-chain mode takes the defaults.
+                cache: proof_gen_api_server::config::ChainCacheConfig::default(),
             }],
             max_batch_size: args.max_batch_size,
             max_batch_span: args.max_batch_span,

--- a/proof-gen-api-server/config.example.yaml
+++ b/proof-gen-api-server/config.example.yaml
@@ -16,8 +16,11 @@ chains:
     eth_rpc_url: "http://localhost:8545"
     # archiver_url: "http://localhost:8080"  # optional per chain
     block_confirmation_depth: 32  # Blocks to lag behind chain tip for reorg protection.
-    #                              # Suggested: 32 for Ethereum-style L1 chains; tune per source chain.
-    #                              # Default when omitted: 0 (no lag), only safe for local/dev networks.
+    #                              # OMIT THIS to derive it from the chain's on-chain
+    #                              # MaturityStrategy -- the same value the attestors act on, so
+    #                              # this process cannot disagree with them. That is the
+    #                              # recommended setting. Set it only to deliberately pin a
+    #                              # value; startup warns if it disagrees with the chain.
     #
     # Ordered fallback RPC URLs (optional).
     # The eth client always tries `eth_rpc_url` (primary) first for every
@@ -37,6 +40,44 @@ chains:
   # Second local chain (e.g. second Anvil on another port) — uncomment for multi-chain dev/CI:
   - chain_key: 3
     eth_rpc_url: "http://localhost:8546"
+    #
+    # Per-chain cache sizing (all optional; omit the whole `cache:` block for the defaults).
+    #
+    # Why this exists: by default the merkle-proof cache retains
+    # `attestation_interval * checkpoint_interval * 4` source blocks, all read from chain. That
+    # couples cache memory to attestation cadence, so raising `attestation_interval` to *reduce*
+    # attestation load on a fast chain multiplies this cache by the same factor. On a chain with
+    # both a wide window and dense blocks that is enough to exhaust the process.
+    # cache:
+    #   # Retention window in source blocks. Omit to derive it as described above.
+    #   # Pin it to size the cache independently of attestation cadence.
+    #   merkle_retention_blocks: 1000
+    #
+    #   # Soft byte budget for the merkle cache. When set, the effective retention window is
+    #   # narrowed using the cache's own measured bytes-per-block, so the resident set stays
+    #   # within budget no matter how many transactions the chain puts in a block. Eviction
+    #   # itself stays height-ordered, and the window never shrinks below one attestation
+    #   # interval. Omit for an unbudgeted cache.
+    #   merkle_max_bytes: 805306368  # 768 MiB
+    #
+    #   # Capacity of the raw block cache, in blocks (default 512). Each entry holds a whole
+    #   # block's *decoded* transactions and receipts, which is the largest single per-chain
+    #   # allocation on a high-tx chain, and it overlaps the merkle cache above. Lower it for
+    #   # dense chains.
+    #   block_cache_capacity: 96
+    #
+    #   # Whether the background worker keeps the retention window warm (default true).
+    #   # true  => window always full, so memory sits at its ceiling continuously.
+    #   # false => fill only when a proof needs a block; much smaller resident set, at the cost
+    #   #          of first-request latency for any uncached block.
+    #   merkle_backfill_enabled: true
+    #
+    #   # Cap on retained checkpoint digests. Omit (the default) to retain every checkpoint.
+    #   # CAUTION: a proof is bracketed by the checkpoint immediately BELOW the queried block,
+    #   # and a cache miss has no fallback to chain state -- the request fails. Setting this
+    #   # therefore caps how far back proofs can be served, to roughly
+    #   # `max_entries * attestation_interval * checkpoint_interval` blocks. Opt in knowingly.
+    #   checkpoint_cache_max_entries: 20000
 
 max_batch_size: 10
 # Maximum allowed block span (highest − lowest block) in a single batch request.

--- a/proof-gen-api-server/config.example.yaml
+++ b/proof-gen-api-server/config.example.yaml
@@ -58,7 +58,8 @@ chains:
     #   # within budget no matter how many transactions the chain puts in a block. Eviction
     #   # itself stays height-ordered, and the window never shrinks below one attestation
     #   # interval. Omit for an unbudgeted cache.
-    #   merkle_max_bytes: 805306368  # 768 MiB
+    #   # Accepts a readable size or a plain byte count: "768MiB", "1GiB", "800MB", 805306368.
+    #   merkle_max_bytes: "768MiB"
     #
     #   # Capacity of the raw block cache, in blocks (default 512). Each entry holds a whole
     #   # block's *decoded* transactions and receipts, which is the largest single per-chain

--- a/proof-gen-api-server/src/config.rs
+++ b/proof-gen-api-server/src/config.rs
@@ -16,6 +16,68 @@ pub const DEFAULT_MAX_BATCH_SIZE: NonZeroUsize = match NonZeroUsize::new(10) {
 /// from forcing proof generation over an extremely large block range.
 pub const DEFAULT_MAX_BATCH_SPAN: u64 = 1_000;
 
+/// Default per-chain capacity (512 blocks) of the in-process raw block cache.
+///
+/// Each cached entry holds a whole source block's **decoded** transactions and receipts, so
+/// this is the single largest per-chain allocation on a high-tx chain. Override it per chain
+/// via `cache.block_cache_capacity`.
+pub const DEFAULT_BLOCK_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(512) {
+    Some(n) => n,
+    None => panic!("512 is non-zero"),
+};
+
+/// Per-chain cache sizing, resolved from the optional `cache:` block of a chain entry.
+///
+/// Every field defaults to the historical behavior, so omitting `cache:` entirely changes
+/// nothing. These exist because cache memory used to be a function purely of the chain's
+/// on-chain attestation cadence and its transaction density -- neither of which this process
+/// controls -- which let a high-throughput chain exhaust the whole process.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainCacheConfig {
+    /// Merkle-proof cache retention window, in source blocks.
+    ///
+    /// `None` derives it as `attestation_interval * checkpoint_interval * 4` from the chain's
+    /// live on-chain intervals. That coupling is the catch: raising `attestation_interval` to
+    /// *reduce* attestation load multiplies this window by the same factor. Pin it here to
+    /// size the cache independently of attestation cadence.
+    pub merkle_retention_blocks: Option<u64>,
+    /// Soft byte budget for the merkle-proof cache.
+    ///
+    /// `None` means unbudgeted. When set, the effective retention window is narrowed using the
+    /// cache's own measured bytes-per-block so the cache stays within budget regardless of how
+    /// many transactions the chain puts in a block. Eviction itself stays height-ordered.
+    pub merkle_max_bytes: Option<u64>,
+    /// Capacity of the raw (decoded) block cache, in blocks. Defaults to
+    /// [`DEFAULT_BLOCK_CACHE_CAPACITY`].
+    pub block_cache_capacity: NonZeroUsize,
+    /// Whether the background worker proactively fills the retention window.
+    ///
+    /// `true` (default) keeps the window warm at all times, which also means memory sits at
+    /// its ceiling continuously. `false` fills the cache only when a proof actually needs a
+    /// block, trading first-request latency for a much smaller resident set.
+    pub merkle_backfill_enabled: bool,
+    /// Cap on retained checkpoint-digest entries.
+    ///
+    /// `None` (default) retains every checkpoint, which is what proof serving needs: a proof
+    /// is bracketed by the checkpoint immediately *below* the queried block, and there is no
+    /// fallback to chain state on a miss. Setting this therefore caps how far back proofs can
+    /// be served -- roughly `max_entries * attestation_interval * checkpoint_interval` blocks
+    /// -- in exchange for bounding a cache that otherwise only ever grows. Opt in knowingly.
+    pub checkpoint_cache_max_entries: Option<usize>,
+}
+
+impl Default for ChainCacheConfig {
+    fn default() -> Self {
+        Self {
+            merkle_retention_blocks: None,
+            merkle_max_bytes: None,
+            block_cache_capacity: DEFAULT_BLOCK_CACHE_CAPACITY,
+            merkle_backfill_enabled: true,
+            checkpoint_cache_max_entries: None,
+        }
+    }
+}
+
 /// One source chain (EVM) served by this process, keyed on Creditcoin3.
 #[derive(Debug, Clone)]
 pub struct ChainConfig {
@@ -41,6 +103,8 @@ pub struct ChainConfig {
     /// protection. That is the failure mode this change removes.
     /// See [`continuity::ContinuityConfig::block_confirmation_depth`].
     pub block_confirmation_depth: Option<u64>,
+    /// Per-chain cache sizing. Defaults reproduce the historical behavior.
+    pub cache: ChainCacheConfig,
 }
 
 /// Server configuration after CLI / file resolution.
@@ -70,6 +134,7 @@ impl Config {
                 archiver_url: None,
                 // Mock config has no chain to resolve against; pin explicitly.
                 block_confirmation_depth: Some(0),
+                cache: ChainCacheConfig::default(),
             }],
             max_batch_size: DEFAULT_MAX_BATCH_SIZE,
             max_batch_span: DEFAULT_MAX_BATCH_SPAN,
@@ -132,6 +197,32 @@ pub struct ChainConfigFile {
     /// deliberately pin a value; startup warns if it disagrees with the chain.
     #[serde(default)]
     pub block_confirmation_depth: Option<u64>,
+    /// Optional per-chain cache sizing. Omit the whole block to keep the defaults.
+    ///
+    /// ```yaml
+    /// cache:
+    ///   merkle_retention_blocks: 1000
+    ///   merkle_max_bytes: 805306368
+    ///   block_cache_capacity: 96
+    /// ```
+    #[serde(default)]
+    pub cache: ChainCacheConfigFile,
+}
+
+/// YAML layout of a chain's `cache:` block. Every field is optional; see
+/// [`ChainCacheConfig`] for what each one means and what omitting it does.
+#[derive(Debug, Default, Deserialize)]
+pub struct ChainCacheConfigFile {
+    #[serde(default)]
+    pub merkle_retention_blocks: Option<u64>,
+    #[serde(default)]
+    pub merkle_max_bytes: Option<u64>,
+    #[serde(default)]
+    pub block_cache_capacity: Option<NonZeroUsize>,
+    #[serde(default)]
+    pub merkle_backfill_enabled: Option<bool>,
+    #[serde(default)]
+    pub checkpoint_cache_max_entries: Option<usize>,
 }
 
 fn default_max_batch_size() -> NonZeroUsize {
@@ -155,12 +246,14 @@ impl ConfigFile {
             }
             let eth_rpc_fallback_urls =
                 validate_fallback_urls(c.chain_key, c.eth_rpc_fallback_urls)?;
+            let cache = resolve_cache_config(c.chain_key, c.cache)?;
             chains.push(ChainConfig {
                 chain_key: c.chain_key,
                 eth_rpc_url: c.eth_rpc_url,
                 eth_rpc_fallback_urls,
                 archiver_url: c.archiver_url,
                 block_confirmation_depth: c.block_confirmation_depth,
+                cache,
             });
         }
         Ok(Config {
@@ -173,6 +266,50 @@ impl ConfigFile {
             max_batch_span: self.max_batch_span,
         })
     }
+}
+
+/// Resolve a chain's `cache:` block, filling omitted fields with their defaults.
+///
+/// # Errors
+///
+/// A zero for any of the sizing knobs. Zero is never a meaningful value here and it reads as
+/// "unlimited" to the unwary, when it would in fact mean "cache nothing" -- so reject it and
+/// point at the field that actually expresses the intent.
+///
+/// `chain_key` is included in error messages to help users locate the offending entry in a
+/// multi-chain config.
+fn resolve_cache_config(chain_key: u64, file: ChainCacheConfigFile) -> Result<ChainCacheConfig> {
+    if file.merkle_retention_blocks == Some(0) {
+        bail!(
+            "chain_key {chain_key}: `cache.merkle_retention_blocks` must be greater than 0; \
+             omit it to derive the window from the chain's attestation intervals"
+        );
+    }
+    if file.merkle_max_bytes == Some(0) {
+        bail!(
+            "chain_key {chain_key}: `cache.merkle_max_bytes` must be greater than 0; \
+             omit it for an unbudgeted cache"
+        );
+    }
+    if file.checkpoint_cache_max_entries == Some(0) {
+        bail!(
+            "chain_key {chain_key}: `cache.checkpoint_cache_max_entries` must be greater than 0; \
+             omit it to retain every checkpoint"
+        );
+    }
+
+    let defaults = ChainCacheConfig::default();
+    Ok(ChainCacheConfig {
+        merkle_retention_blocks: file.merkle_retention_blocks,
+        merkle_max_bytes: file.merkle_max_bytes,
+        block_cache_capacity: file
+            .block_cache_capacity
+            .unwrap_or(defaults.block_cache_capacity),
+        merkle_backfill_enabled: file
+            .merkle_backfill_enabled
+            .unwrap_or(defaults.merkle_backfill_enabled),
+        checkpoint_cache_max_entries: file.checkpoint_cache_max_entries,
+    })
 }
 
 /// Validate a chain's `eth_rpc_fallback_urls` (purely structural — no network
@@ -351,5 +488,157 @@ chains:
             err.contains("`eth_rpc_fallback_urls[0]` is empty"),
             "expected empty-url error, got: {err}"
         );
+    }
+
+    #[test]
+    fn yaml_without_cache_block_uses_defaults() {
+        // Regression guard: omitting `cache:` must reproduce the historical behavior exactly,
+        // i.e. derive the retention window and leave the caches unbudgeted.
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 8
+    eth_rpc_url: "http://localhost:8545"
+"#;
+        let cfg = parse(yaml).expect("yaml should parse");
+
+        assert_eq!(cfg.chains[0].cache, ChainCacheConfig::default());
+        assert_eq!(cfg.chains[0].cache.merkle_retention_blocks, None);
+        assert_eq!(cfg.chains[0].cache.merkle_max_bytes, None);
+        assert_eq!(cfg.chains[0].cache.checkpoint_cache_max_entries, None);
+        assert!(cfg.chains[0].cache.merkle_backfill_enabled);
+        assert_eq!(
+            cfg.chains[0].cache.block_cache_capacity,
+            DEFAULT_BLOCK_CACHE_CAPACITY
+        );
+    }
+
+    #[test]
+    fn yaml_with_cache_block_is_parsed() {
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 8
+    eth_rpc_url: "http://localhost:8545"
+    cache:
+      merkle_retention_blocks: 1000
+      merkle_max_bytes: 805306368
+      block_cache_capacity: 96
+      merkle_backfill_enabled: false
+      checkpoint_cache_max_entries: 20000
+"#;
+        let cfg = parse(yaml).expect("yaml should parse");
+        let cache = &cfg.chains[0].cache;
+
+        assert_eq!(cache.merkle_retention_blocks, Some(1000));
+        assert_eq!(cache.merkle_max_bytes, Some(805_306_368));
+        assert_eq!(cache.block_cache_capacity.get(), 96);
+        assert!(!cache.merkle_backfill_enabled);
+        assert_eq!(cache.checkpoint_cache_max_entries, Some(20_000));
+    }
+
+    #[test]
+    fn partial_cache_block_keeps_other_defaults() {
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 8
+    eth_rpc_url: "http://localhost:8545"
+    cache:
+      merkle_retention_blocks: 1000
+"#;
+        let cfg = parse(yaml).expect("yaml should parse");
+        let cache = &cfg.chains[0].cache;
+
+        assert_eq!(cache.merkle_retention_blocks, Some(1000));
+        assert_eq!(cache.block_cache_capacity, DEFAULT_BLOCK_CACHE_CAPACITY);
+        assert!(cache.merkle_backfill_enabled);
+    }
+
+    #[test]
+    fn cache_block_rejects_zero_sizes() {
+        for (field, value) in [
+            ("merkle_retention_blocks", "0"),
+            ("merkle_max_bytes", "0"),
+            ("checkpoint_cache_max_entries", "0"),
+        ] {
+            let yaml = format!(
+                r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 8
+    eth_rpc_url: "http://localhost:8545"
+    cache:
+      {field}: {value}
+"#
+            );
+            let err = parse(&yaml).expect_err("zero should be rejected");
+            let msg = err.to_string();
+            assert!(
+                msg.contains(field) && msg.contains("chain_key 8"),
+                "wrong error: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn cache_block_rejects_zero_block_cache_capacity() {
+        // NonZeroUsize makes serde itself reject this one.
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 8
+    eth_rpc_url: "http://localhost:8545"
+    cache:
+      block_cache_capacity: 0
+"#;
+        assert!(parse(yaml).is_err(), "zero capacity should be rejected");
+    }
+
+    #[test]
+    fn shipped_example_config_parses() {
+        // The example file is the documentation for these knobs; keep it loadable so a stray
+        // edit to the commented blocks cannot ship broken YAML.
+        let yaml = include_str!("../config.example.yaml");
+        let cfg = parse(yaml).expect("config.example.yaml should parse");
+
+        assert!(!cfg.chains.is_empty());
+        // Everything under `cache:` is commented out there, so defaults must survive.
+        for chain in &cfg.chains {
+            assert_eq!(chain.cache, ChainCacheConfig::default());
+        }
+    }
+
+    #[test]
+    fn duplicate_chain_key_is_rejected() {
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 8
+    eth_rpc_url: "http://localhost:8545"
+  - chain_key: 8
+    eth_rpc_url: "http://localhost:8546"
+"#;
+        let err = parse(yaml).expect_err("duplicate chain_key should be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("duplicate chain_key 8"), "wrong error: {msg}");
+    }
+
+    #[test]
+    fn empty_chains_list_is_rejected() {
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains: []
+"#;
+        let err = parse(yaml).expect_err("empty chains should be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("at least one entry"), "wrong error: {msg}");
     }
 }

--- a/proof-gen-api-server/src/config.rs
+++ b/proof-gen-api-server/src/config.rs
@@ -215,7 +215,8 @@ pub struct ChainConfigFile {
 pub struct ChainCacheConfigFile {
     #[serde(default)]
     pub merkle_retention_blocks: Option<u64>,
-    #[serde(default)]
+    /// Accepts a plain byte count or a human-readable size (`"768MiB"`, `"1GiB"`, `"800MB"`).
+    #[serde(default, deserialize_with = "deserialize_byte_size")]
     pub merkle_max_bytes: Option<u64>,
     #[serde(default)]
     pub block_cache_capacity: Option<NonZeroUsize>,
@@ -223,6 +224,72 @@ pub struct ChainCacheConfigFile {
     pub merkle_backfill_enabled: Option<bool>,
     #[serde(default)]
     pub checkpoint_cache_max_entries: Option<usize>,
+}
+
+/// Deserialize a byte size written either as a number or as a human-readable string.
+///
+/// A raw byte count for something like 768 MiB is 805306368, which is easy to fat-finger by a
+/// factor of 1024 and impossible to eyeball in a review. Accepting `"768MiB"` keeps the
+/// operator-facing value legible while still allowing a plain integer.
+fn deserialize_byte_size<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Raw {
+        Int(u64),
+        Str(String),
+    }
+
+    match Option::<Raw>::deserialize(deserializer)? {
+        None => Ok(None),
+        Some(Raw::Int(bytes)) => Ok(Some(bytes)),
+        Some(Raw::Str(text)) => parse_byte_size(&text)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+    }
+}
+
+/// Parse `"768MiB"` / `"800MB"` / `"1024"` into a byte count.
+///
+/// Binary units (`KiB`/`MiB`/`GiB`) are powers of 1024; decimal units (`KB`/`MB`/`GB`) are
+/// powers of 1000, matching how memory limits are usually quoted. Case-insensitive.
+fn parse_byte_size(text: &str) -> std::result::Result<u64, String> {
+    let trimmed = text.trim();
+    let split = trimmed
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    let (digits, unit) = trimmed.split_at(split);
+
+    if digits.is_empty() {
+        return Err(format!(
+            "invalid byte size {text:?}: expected a number optionally followed by \
+             B/KiB/MiB/GiB/KB/MB/GB"
+        ));
+    }
+
+    let multiplier = match unit.trim().to_ascii_lowercase().as_str() {
+        "" | "b" => 1_u64,
+        "kib" => 1 << 10,
+        "mib" => 1 << 20,
+        "gib" => 1 << 30,
+        "kb" => 1_000,
+        "mb" => 1_000_000,
+        "gb" => 1_000_000_000,
+        other => {
+            return Err(format!(
+                "invalid byte size unit {other:?} in {text:?}: expected one of \
+                 B, KiB, MiB, GiB, KB, MB, GB"
+            ))
+        }
+    };
+
+    digits
+        .parse::<u64>()
+        .map_err(|err| format!("invalid byte size {text:?}: {err}"))?
+        .checked_mul(multiplier)
+        .ok_or_else(|| format!("byte size {text:?} overflows u64"))
 }
 
 fn default_max_batch_size() -> NonZeroUsize {
@@ -598,6 +665,85 @@ chains:
       block_cache_capacity: 0
 "#;
         assert!(parse(yaml).is_err(), "zero capacity should be rejected");
+    }
+
+    #[test]
+    fn byte_sizes_accept_units_and_plain_numbers() {
+        for (text, expected) in [
+            ("1024", 1024_u64),
+            ("512B", 512),
+            ("768MiB", 768 * 1024 * 1024),
+            ("1GiB", 1024 * 1024 * 1024),
+            ("4KiB", 4096),
+            ("800MB", 800_000_000),
+            ("2gb", 2_000_000_000),
+            (" 768 MiB ", 768 * 1024 * 1024),
+        ] {
+            assert_eq!(
+                parse_byte_size(text),
+                Ok(expected),
+                "parsing {text:?} should give {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn byte_sizes_reject_nonsense() {
+        for text in ["", "MiB", "768 mib mib", "12 furlongs", "-5"] {
+            assert!(
+                parse_byte_size(text).is_err(),
+                "{text:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn merkle_max_bytes_accepts_a_readable_unit_in_yaml() {
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 8
+    eth_rpc_url: "http://localhost:8545"
+    cache:
+      merkle_max_bytes: "768MiB"
+"#;
+        let cfg = parse(yaml).expect("yaml should parse");
+        assert_eq!(
+            cfg.chains[0].cache.merkle_max_bytes,
+            Some(768 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn merkle_max_bytes_still_accepts_a_plain_integer() {
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 8
+    eth_rpc_url: "http://localhost:8545"
+    cache:
+      merkle_max_bytes: 805306368
+"#;
+        let cfg = parse(yaml).expect("yaml should parse");
+        assert_eq!(cfg.chains[0].cache.merkle_max_bytes, Some(805_306_368));
+    }
+
+    #[test]
+    fn merkle_max_bytes_rejects_a_bad_unit() {
+        let yaml = r#"
+bind_host: "0.0.0.0"
+bind_port: 3100
+chains:
+  - chain_key: 8
+    eth_rpc_url: "http://localhost:8545"
+    cache:
+      merkle_max_bytes: "768 gigglebytes"
+"#;
+        let err = parse(yaml).expect_err("bad unit should be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("invalid byte size unit"), "wrong error: {msg}");
     }
 
     #[test]

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -35,6 +35,10 @@ pub struct Server {
     cc3_client: CcClient,
     /// One continuity builder per configured source chain.
     builders: Vec<Arc<ContinuityBuilder>>,
+    /// Per-chain handle to the raw block cache, so its occupancy can be reported. Each entry
+    /// holds a whole block's decoded txs and receipts, which is the largest per-chain
+    /// allocation on a high-throughput chain -- and the one with no other way to observe it.
+    block_caches: HashMap<u64, Arc<eth::mem_block_cache::MemBlockCache>>,
     checkpoint_intervals: events::CheckpointIntervalMap,
     last_checkpoint_blocks: events::LastCheckpointBlockMap,
     prom_metrics: Arc<ProofGenMetrics>,
@@ -66,6 +70,8 @@ impl Server {
         debug!("🚀 ✅ [startup] Creditcoin3 client connected");
 
         let mut builders: Vec<Arc<ContinuityBuilder>> = Vec::with_capacity(config.chains.len());
+        let mut block_caches: HashMap<u64, Arc<eth::mem_block_cache::MemBlockCache>> =
+            HashMap::with_capacity(config.chains.len());
         let checkpoint_intervals = Arc::new(RwLock::new(HashMap::new()));
         let last_checkpoint_blocks = Arc::new(RwLock::new(HashMap::new()));
 
@@ -87,7 +93,7 @@ impl Server {
                     "[startup] eth_rpc fallback registered"
                 );
             }
-            let builder = Self::build_continuity_for_chain(
+            let (builder, block_cache) = Self::build_continuity_for_chain(
                 &config,
                 cc3_client.clone(),
                 chain,
@@ -96,12 +102,16 @@ impl Server {
             )
             .await?;
             builders.push(builder);
+            if let Some(block_cache) = block_cache {
+                block_caches.insert(chain.chain_key, block_cache);
+            }
         }
 
         Ok(Server {
             config,
             cc3_client,
             builders,
+            block_caches,
             checkpoint_intervals,
             last_checkpoint_blocks,
             prom_metrics,
@@ -114,7 +124,10 @@ impl Server {
         chain: &ChainConfig,
         checkpoint_intervals: &Arc<RwLock<HashMap<u64, u64>>>,
         last_checkpoint_blocks: &Arc<RwLock<HashMap<u64, u64>>>,
-    ) -> Result<Arc<ContinuityBuilder>> {
+    ) -> Result<(
+        Arc<ContinuityBuilder>,
+        Option<Arc<eth::mem_block_cache::MemBlockCache>>,
+    )> {
         let chain_key = chain.chain_key;
 
         debug!(
@@ -214,6 +227,10 @@ impl Server {
                 // which holds the same recent blocks in encoded form. Hence the per-chain knob.
                 .with_block_cache(chain.cache.block_cache_capacity)
         };
+
+        // Grab the cache handle before the client is moved into the RPC providers; going back
+        // through the provider traits later would mean widening them for a metrics read.
+        let block_cache = eth_client.block_cache();
 
         let chain_id = eth_client.chain_id();
         if supported_chain_id != chain_id {
@@ -319,7 +336,7 @@ impl Server {
             .await
             .insert(chain_key, checkpoint_interval);
 
-        Ok(builder)
+        Ok((builder, block_cache))
     }
 
     pub async fn run(&self) -> Result<()> {
@@ -344,7 +361,7 @@ impl Server {
         let service = Arc::new(service);
 
         ProofGenMetrics::spawn_hardware_updater(self.prom_metrics.clone());
-        ContinuityService::spawn_cache_metrics_updater(service.clone());
+        ContinuityService::spawn_cache_metrics_updater(service.clone(), self.block_caches.clone());
         ContinuityService::spawn_merkle_backfill(service.clone());
 
         let allowed: std::collections::HashSet<u64> = self.config.chain_keys();

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tokio::sync::{oneshot::channel, RwLock};
 use tokio::{select, signal};
@@ -30,14 +29,6 @@ pub use services::errors::ErrorResponse;
 /// crate keep working unchanged. The eth-side helper redacts both `?query`
 /// strings *and* secret-looking path segments (Chainstack/Alchemy style).
 use eth::redact_url_query;
-
-/// Max finalized source blocks held in the per-chain in-process block cache. Sized to comfortably
-/// cover a continuity range (last checkpoint → query height) plus recent inclusion-proof blocks,
-/// while bounding memory (each entry is one block's txs+receipts).
-const BLOCK_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(512) {
-    Some(n) => n,
-    None => panic!("512 is non-zero"),
-};
 
 pub struct Server {
     config: Config,
@@ -217,7 +208,11 @@ impl Server {
                 // In-process cache of finalized source blocks. Overlapping continuity ranges and
                 // batched requests re-fetch the same low blocks every time; caching them removes
                 // the repeat RPC + merkle work. Finalized blocks are immutable, so no invalidation.
-                .with_block_cache(BLOCK_CACHE_CAPACITY)
+                //
+                // Each entry holds one block's *decoded* txs+receipts, so on a high-tx chain this
+                // is the largest single per-chain allocation - and it overlaps the merkle cache,
+                // which holds the same recent blocks in encoded form. Hence the per-chain knob.
+                .with_block_cache(chain.cache.block_cache_capacity)
         };
 
         let chain_id = eth_client.chain_id();
@@ -330,8 +325,16 @@ impl Server {
     pub async fn run(&self) -> Result<()> {
         let metrics: Metrics = self.prom_metrics.clone() as Metrics;
 
-        let service = services::continuity_service::ContinuityService::new(
+        let cache_configs = self
+            .config
+            .chains
+            .iter()
+            .map(|chain| (chain.chain_key, chain.cache.clone()))
+            .collect();
+
+        let service = services::continuity_service::ContinuityService::new_with_cache_configs(
             self.builders.clone(),
+            cache_configs,
             metrics.clone(),
             self.config.max_batch_size.get(),
             self.config.max_batch_span,
@@ -341,6 +344,7 @@ impl Server {
         let service = Arc::new(service);
 
         ProofGenMetrics::spawn_hardware_updater(self.prom_metrics.clone());
+        ContinuityService::spawn_cache_metrics_updater(service.clone());
         ContinuityService::spawn_merkle_backfill(service.clone());
 
         let allowed: std::collections::HashSet<u64> = self.config.chain_keys();

--- a/proof-gen-api-server/src/prom/mod.rs
+++ b/proof-gen-api-server/src/prom/mod.rs
@@ -27,6 +27,25 @@ pub trait GetErrorType {
 
 /// Trait defining the metrics interface.
 /// Implemented by both `ProofGenMetrics` (real metrics) and `NoopMetrics` (no-op for testing).
+/// Occupancy of one chain's in-process caches, as reported to Prometheus.
+///
+/// Bundled into one struct so the sampler makes a single call per chain and the gauges can
+/// never be updated half-way to a new snapshot.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CacheOccupancy {
+    /// Blocks currently held in the merkle-proof cache.
+    pub merkle_blocks: u64,
+    /// Transactions indexed across those blocks.
+    pub merkle_txs: u64,
+    /// Approximate heap bytes held by those blocks.
+    pub merkle_bytes: u64,
+    /// Effective retention window in source blocks, after any byte-budget clamp. Compare with
+    /// the configured/derived value to see whether the budget is engaging.
+    pub merkle_retention_blocks: u64,
+    /// Retained checkpoint-digest entries.
+    pub checkpoint_entries: u64,
+}
+
 pub trait MetricsTrait: Send + Sync + Debug {
     // Request metrics
     fn inc_request(&self, endpoint: Endpoint, status: Status);
@@ -46,6 +65,7 @@ pub trait MetricsTrait: Send + Sync + Debug {
     fn observe_block_range(&self, block: u64);
     fn set_last_attested_height(&self, chain_key: u64, height: Option<u64>);
     fn set_last_checkpoint_height(&self, chain_key: u64, height: Option<u64>);
+    fn set_cache_occupancy(&self, chain_key: u64, occupancy: CacheOccupancy);
 }
 
 /// Metrics type alias for use throughout the codebase.
@@ -81,6 +101,7 @@ impl MetricsTrait for NoopMetrics {
     fn observe_block_range(&self, _block: u64) {}
     fn set_last_attested_height(&self, _chain_key: u64, _height: Option<u64>) {}
     fn set_last_checkpoint_height(&self, _chain_key: u64, _height: Option<u64>) {}
+    fn set_cache_occupancy(&self, _chain_key: u64, _occupancy: CacheOccupancy) {}
 }
 
 /// Comprehensive metrics for the proof-gen-api-server.
@@ -106,6 +127,14 @@ pub struct ProofGenMetrics {
     block_range: Histogram,
     last_attested_height: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
     last_checkpoint_height: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
+
+    // Cache occupancy metrics. Without these there is no way to see a cache approaching the
+    // process memory limit before it OOMs.
+    merkle_cache_blocks: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
+    merkle_cache_txs: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
+    merkle_cache_bytes: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
+    merkle_cache_retention_blocks: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
+    checkpoint_cache_entries: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
     /// Server start time as Unix timestamp (seconds since epoch).
     /// Use PromQL `time() - proof_gen_start_time_seconds` to calculate uptime.
     /// This field is registered with Prometheus registry and accessed during encoding,
@@ -194,6 +223,43 @@ impl ProofGenMetrics {
             last_checkpoint_height.clone(),
         );
 
+        let merkle_cache_blocks = Family::<labels::LabelChain, Gauge<u64, AtomicU64>>::default();
+        registry.register(
+            "proof_gen_merkle_cache_blocks",
+            "Source blocks currently held in the merkle proof cache",
+            merkle_cache_blocks.clone(),
+        );
+
+        let merkle_cache_txs = Family::<labels::LabelChain, Gauge<u64, AtomicU64>>::default();
+        registry.register(
+            "proof_gen_merkle_cache_txs",
+            "Transactions indexed in the merkle proof cache",
+            merkle_cache_txs.clone(),
+        );
+
+        let merkle_cache_bytes = Family::<labels::LabelChain, Gauge<u64, AtomicU64>>::default();
+        registry.register(
+            "proof_gen_merkle_cache_bytes",
+            "Approximate heap bytes held by the merkle proof cache",
+            merkle_cache_bytes.clone(),
+        );
+
+        let merkle_cache_retention_blocks =
+            Family::<labels::LabelChain, Gauge<u64, AtomicU64>>::default();
+        registry.register(
+            "proof_gen_merkle_cache_retention_blocks",
+            "Effective merkle proof cache retention window in source blocks, after any byte-budget clamp",
+            merkle_cache_retention_blocks.clone(),
+        );
+
+        let checkpoint_cache_entries =
+            Family::<labels::LabelChain, Gauge<u64, AtomicU64>>::default();
+        registry.register(
+            "proof_gen_checkpoint_cache_entries",
+            "Checkpoint digests retained in the in-process checkpoint cache",
+            checkpoint_cache_entries.clone(),
+        );
+
         let start_time_seconds = Gauge::default();
         // Set start time once at initialization (Unix timestamp)
         let now = SystemTime::now()
@@ -254,6 +320,11 @@ impl ProofGenMetrics {
             block_range,
             last_attested_height,
             last_checkpoint_height,
+            merkle_cache_blocks,
+            merkle_cache_txs,
+            merkle_cache_bytes,
+            merkle_cache_retention_blocks,
+            checkpoint_cache_entries,
             start_time_seconds,
             cpu_usage_percent,
             memory_usage_bytes,
@@ -417,6 +488,26 @@ impl MetricsTrait for ProofGenMetrics {
         } else {
             let _ = self.last_checkpoint_height.remove(&labels);
         }
+    }
+
+    fn set_cache_occupancy(&self, chain_key: u64, occupancy: CacheOccupancy) {
+        let labels = labels::LabelChain { chain_key };
+
+        self.merkle_cache_blocks
+            .get_or_create(&labels)
+            .set(occupancy.merkle_blocks);
+        self.merkle_cache_txs
+            .get_or_create(&labels)
+            .set(occupancy.merkle_txs);
+        self.merkle_cache_bytes
+            .get_or_create(&labels)
+            .set(occupancy.merkle_bytes);
+        self.merkle_cache_retention_blocks
+            .get_or_create(&labels)
+            .set(occupancy.merkle_retention_blocks);
+        self.checkpoint_cache_entries
+            .get_or_create(&labels)
+            .set(occupancy.checkpoint_entries);
     }
 }
 

--- a/proof-gen-api-server/src/prom/mod.rs
+++ b/proof-gen-api-server/src/prom/mod.rs
@@ -44,6 +44,14 @@ pub struct CacheOccupancy {
     pub merkle_retention_blocks: u64,
     /// Retained checkpoint-digest entries.
     pub checkpoint_entries: u64,
+    /// Blocks held in the raw (decoded) block cache.
+    pub block_cache_blocks: u64,
+    /// Transactions across those blocks.
+    pub block_cache_txs: u64,
+    /// Configured capacity of the raw block cache. Compare with `block_cache_blocks` to see
+    /// saturation -- this cache holds fully decoded transactions and receipts, so it is
+    /// typically the largest per-chain allocation in the process.
+    pub block_cache_capacity: u64,
 }
 
 pub trait MetricsTrait: Send + Sync + Debug {
@@ -135,6 +143,9 @@ pub struct ProofGenMetrics {
     merkle_cache_bytes: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
     merkle_cache_retention_blocks: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
     checkpoint_cache_entries: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
+    block_cache_blocks: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
+    block_cache_txs: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
+    block_cache_capacity: Family<labels::LabelChain, Gauge<u64, AtomicU64>>,
     /// Server start time as Unix timestamp (seconds since epoch).
     /// Use PromQL `time() - proof_gen_start_time_seconds` to calculate uptime.
     /// This field is registered with Prometheus registry and accessed during encoding,
@@ -260,6 +271,27 @@ impl ProofGenMetrics {
             checkpoint_cache_entries.clone(),
         );
 
+        let block_cache_blocks = Family::<labels::LabelChain, Gauge<u64, AtomicU64>>::default();
+        registry.register(
+            "proof_gen_block_cache_blocks",
+            "Source blocks held in the raw (decoded) block cache",
+            block_cache_blocks.clone(),
+        );
+
+        let block_cache_txs = Family::<labels::LabelChain, Gauge<u64, AtomicU64>>::default();
+        registry.register(
+            "proof_gen_block_cache_txs",
+            "Transactions held in the raw (decoded) block cache",
+            block_cache_txs.clone(),
+        );
+
+        let block_cache_capacity = Family::<labels::LabelChain, Gauge<u64, AtomicU64>>::default();
+        registry.register(
+            "proof_gen_block_cache_capacity",
+            "Configured capacity, in blocks, of the raw (decoded) block cache",
+            block_cache_capacity.clone(),
+        );
+
         let start_time_seconds = Gauge::default();
         // Set start time once at initialization (Unix timestamp)
         let now = SystemTime::now()
@@ -325,6 +357,9 @@ impl ProofGenMetrics {
             merkle_cache_bytes,
             merkle_cache_retention_blocks,
             checkpoint_cache_entries,
+            block_cache_blocks,
+            block_cache_txs,
+            block_cache_capacity,
             start_time_seconds,
             cpu_usage_percent,
             memory_usage_bytes,
@@ -508,6 +543,15 @@ impl MetricsTrait for ProofGenMetrics {
         self.checkpoint_cache_entries
             .get_or_create(&labels)
             .set(occupancy.checkpoint_entries);
+        self.block_cache_blocks
+            .get_or_create(&labels)
+            .set(occupancy.block_cache_blocks);
+        self.block_cache_txs
+            .get_or_create(&labels)
+            .set(occupancy.block_cache_txs);
+        self.block_cache_capacity
+            .get_or_create(&labels)
+            .set(occupancy.block_cache_capacity);
     }
 }
 

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -556,6 +556,50 @@ mod tests {
         }
     }
 
+    /// Regression: a warm cache must still shed blocks outside the retained window.
+    ///
+    /// A byte-budget clamp narrows the window into exactly this state -- every remaining height
+    /// already processed, so there is no fill work -- and the backfill tick used to return early
+    /// before pruning. The excluded blocks then stayed resident until the next checkpoint, or
+    /// indefinitely if attestations stalled and `cache_tip` stopped advancing.
+    #[tokio::test]
+    async fn backfill_prunes_outside_the_window_even_with_no_fill_work() {
+        let svc = make_service_with_cache_config(ChainCacheConfig {
+            merkle_retention_blocks: Some(10),
+            ..ChainCacheConfig::default()
+        })
+        .await;
+        let chain = svc.chain_state(2).expect("chain should exist");
+
+        // FoundEthProvider reports tip 1000 at depth 0, so cache_tip == 1000 and the retained
+        // window is [990, 1000]. Mark all of it processed so the tick finds nothing to fill.
+        {
+            let mut att = chain.attestation_cache.write().await;
+            att.clear();
+            att.insert(1000, H256::from_low_u64_be(1000));
+        }
+        for height in 990..=1000 {
+            chain.merkle_proof_cache.mark_processed_empty(height).await;
+        }
+
+        // Stale blocks far below the window, as a previously wider window would have left.
+        fill_merkle_cache(&svc, 2, 5, 20, 1_024).await;
+        assert_eq!(chain.merkle_proof_cache.size_stats().await.blocks, 5);
+
+        let chain = chain.clone();
+        svc.backfill_merkle_cache_for_chain(chain.clone())
+            .await
+            .expect("backfill tick should succeed");
+
+        assert_eq!(
+            chain.merkle_proof_cache.size_stats().await,
+            MerkleCacheStats::default(),
+            "blocks outside the retained window should be pruned on the warm path"
+        );
+        // The window itself is untouched.
+        assert!(chain.merkle_proof_cache.is_processed(1000).await);
+    }
+
     #[tokio::test]
     async fn retention_defaults_to_the_derived_window() {
         // mock_config uses attestation_interval 10 * checkpoint_interval 10 * multiplier 4.

--- a/proof-gen-api-server/src/services/continuity_service/helpers.rs
+++ b/proof-gen-api-server/src/services/continuity_service/helpers.rs
@@ -510,6 +510,137 @@ mod tests {
             .expect("service init should succeed with mocks")
     }
 
+    async fn make_service_with_cache_config(cache: ChainCacheConfig) -> ContinuityService {
+        let chain_key = 2;
+        let (cc_provider, _) = make_mock_providers(chain_key);
+        let builder = Arc::new(ContinuityBuilder::new_with_providers(
+            mock_config(chain_key),
+            cc_provider,
+            Arc::new(FoundEthProvider),
+        ));
+        ContinuityService::new_with_cache_configs(
+            vec![builder],
+            HashMap::from([(chain_key, cache)]),
+            NoopMetrics::new(),
+            10,
+            1_000,
+        )
+        .await
+        .expect("service init should succeed with mocks")
+    }
+
+    /// Fill a chain's merkle cache with `blocks` blocks of `txs_per_block` transactions each,
+    /// so the retention clamp has a real measured density to work from.
+    async fn fill_merkle_cache(
+        svc: &ContinuityService,
+        chain_key: u64,
+        blocks: u64,
+        txs_per_block: u64,
+        tx_len: usize,
+    ) {
+        let chain = svc.chain_state(chain_key).expect("chain should exist");
+        for height in 1..=blocks {
+            let txs = (0..txs_per_block)
+                .map(|n| {
+                    (
+                        H256::from_low_u64_be(height * 1_000 + n),
+                        vec![n as u8; tx_len],
+                    )
+                })
+                .collect();
+            chain
+                .merkle_proof_cache
+                .insert_block(height, txs)
+                .await
+                .expect("insert should succeed");
+        }
+    }
+
+    #[tokio::test]
+    async fn retention_defaults_to_the_derived_window() {
+        // mock_config uses attestation_interval 10 * checkpoint_interval 10 * multiplier 4.
+        let svc = make_service_with_cache_config(ChainCacheConfig::default()).await;
+        let chain = svc.chain_state(2).expect("chain should exist");
+
+        assert_eq!(svc.merkle_cache_retention_blocks(chain).await, 400);
+    }
+
+    #[tokio::test]
+    async fn configured_retention_overrides_the_derived_window() {
+        // The point of the knob: decouple cache size from attestation cadence.
+        let svc = make_service_with_cache_config(ChainCacheConfig {
+            merkle_retention_blocks: Some(1_000),
+            ..ChainCacheConfig::default()
+        })
+        .await;
+        let chain = svc.chain_state(2).expect("chain should exist");
+
+        assert_eq!(svc.merkle_cache_retention_blocks(chain).await, 1_000);
+    }
+
+    #[tokio::test]
+    async fn budget_does_not_clamp_while_the_cache_is_cold() {
+        let svc = make_service_with_cache_config(ChainCacheConfig {
+            merkle_retention_blocks: Some(1_000),
+            merkle_max_bytes: Some(1),
+            ..ChainCacheConfig::default()
+        })
+        .await;
+        let chain = svc.chain_state(2).expect("chain should exist");
+
+        // No density measured yet, so nothing to clamp against.
+        assert_eq!(svc.merkle_cache_retention_blocks(chain).await, 1_000);
+    }
+
+    #[tokio::test]
+    async fn budget_clamps_the_window_using_measured_density() {
+        let svc = make_service_with_cache_config(ChainCacheConfig {
+            merkle_retention_blocks: Some(4_000),
+            // Room for roughly 10 blocks at the density we are about to establish.
+            merkle_max_bytes: Some(10 * 20 * 1_024),
+            ..ChainCacheConfig::default()
+        })
+        .await;
+        fill_merkle_cache(&svc, 2, 4, 20, 1_024).await;
+        let chain = svc.chain_state(2).expect("chain should exist");
+
+        let effective = svc.merkle_cache_retention_blocks(chain).await;
+        assert!(
+            (5..=20).contains(&effective),
+            "budget should clamp 4000 to roughly 10 blocks, got {effective}"
+        );
+    }
+
+    #[tokio::test]
+    async fn budget_never_clamps_below_one_attestation_interval() {
+        // A tiny budget must still leave the current attestation bracket cached.
+        let svc = make_service_with_cache_config(ChainCacheConfig {
+            merkle_retention_blocks: Some(4_000),
+            merkle_max_bytes: Some(1),
+            ..ChainCacheConfig::default()
+        })
+        .await;
+        fill_merkle_cache(&svc, 2, 2, 50, 4_096).await;
+        let chain = svc.chain_state(2).expect("chain should exist");
+
+        // mock_config sets attestation_interval = 10.
+        assert_eq!(svc.merkle_cache_retention_blocks(chain).await, 10);
+    }
+
+    #[tokio::test]
+    async fn budget_leaves_a_comfortable_window_alone() {
+        let svc = make_service_with_cache_config(ChainCacheConfig {
+            merkle_retention_blocks: Some(400),
+            merkle_max_bytes: Some(8 * 1_024 * 1_024 * 1_024),
+            ..ChainCacheConfig::default()
+        })
+        .await;
+        fill_merkle_cache(&svc, 2, 4, 10, 256).await;
+        let chain = svc.chain_state(2).expect("chain should exist");
+
+        assert_eq!(svc.merkle_cache_retention_blocks(chain).await, 400);
+    }
+
     #[tokio::test]
     async fn tx_hash_found_returns_position() {
         let svc = make_service(Arc::new(FoundEthProvider)).await;

--- a/proof-gen-api-server/src/services/continuity_service/merkle_cache.rs
+++ b/proof-gen-api-server/src/services/continuity_service/merkle_cache.rs
@@ -7,6 +7,15 @@ use tokio::sync::RwLock;
 
 use super::MerkleProofItem;
 
+/// Per-transaction cost of the cache-level tx-hash index, charged to the block that owns the
+/// transaction so a block's measured size covers everything caching it allocates.
+///
+/// Each transaction adds one `by_tx_hash` entry: a 32-byte `H256` key plus a `(u64, usize)`
+/// value, in a hashbrown table that holds spare capacity and a control byte per slot. Rounded up
+/// rather than derived exactly -- the true figure moves with the table's load factor, and a
+/// budget that understates its own cost is worse than one that is slightly conservative.
+const PER_TX_INDEX_OVERHEAD_BYTES: usize = 64;
+
 #[derive(Debug)]
 struct CachedMerkleBlock {
     header_number: u64,
@@ -51,9 +60,11 @@ impl CachedMerkleBlock {
             acc.saturating_add(tx.len())
                 .saturating_add(std::mem::size_of::<Vec<u8>>())
         });
+        let index = PER_TX_INDEX_OVERHEAD_BYTES.saturating_mul(tx_hashes.len());
 
         hashes
             .saturating_add(payloads)
+            .saturating_add(index)
             .saturating_add(tree.heap_bytes()) as u64
     }
 

--- a/proof-gen-api-server/src/services/continuity_service/merkle_cache.rs
+++ b/proof-gen-api-server/src/services/continuity_service/merkle_cache.rs
@@ -13,19 +13,48 @@ struct CachedMerkleBlock {
     tx_hashes: Vec<H256>,
     tx_bytes: Vec<Vec<u8>>,
     tree: KeccakMerkleTree,
+    /// Approximate heap footprint, measured once at construction.
+    ///
+    /// Precomputed rather than derived on demand so that the running total in
+    /// [`ChainMerkleCache::cached_bytes`] adds and subtracts the exact same number for a given
+    /// block. Recomputing it at removal time would let the total drift.
+    heap_bytes: u64,
 }
 
 impl CachedMerkleBlock {
     fn new(header_number: u64, txs: Vec<(H256, Vec<u8>)>) -> Self {
         let (tx_hashes, tx_bytes): (Vec<_>, Vec<_>) = txs.into_iter().unzip();
         let tree = KeccakMerkleTree::new(&tx_bytes);
+        let heap_bytes = Self::measure_heap_bytes(&tx_hashes, &tx_bytes, &tree);
 
         Self {
             header_number,
             tx_hashes,
             tx_bytes,
             tree,
+            heap_bytes,
         }
+    }
+
+    /// Approximate heap bytes held by one cached block.
+    ///
+    /// The dominant term is the raw transaction payloads; the hash vector and the merkle tree
+    /// are both `O(tx_count)` in 32-byte words. Exact allocator overhead is not modelled -- this
+    /// feeds a budget, so a consistent underestimate is fine as long as it tracks tx density.
+    fn measure_heap_bytes(
+        tx_hashes: &[H256],
+        tx_bytes: &[Vec<u8>],
+        tree: &KeccakMerkleTree,
+    ) -> u64 {
+        let hashes = std::mem::size_of::<H256>().saturating_mul(tx_hashes.len());
+        let payloads = tx_bytes.iter().fold(0usize, |acc, tx| {
+            acc.saturating_add(tx.len())
+                .saturating_add(std::mem::size_of::<Vec<u8>>())
+        });
+
+        hashes
+            .saturating_add(payloads)
+            .saturating_add(tree.heap_bytes()) as u64
     }
 
     async fn build(header_number: u64, txs: Vec<(H256, Vec<u8>)>) -> Result<Self, String> {
@@ -56,6 +85,53 @@ struct ChainMerkleCache {
     by_block: BTreeMap<u64, Arc<CachedMerkleBlock>>,
     by_tx_hash: HashMap<H256, (u64, usize)>,
     processed_blocks: BTreeSet<u64>,
+    /// Running sum of [`CachedMerkleBlock::heap_bytes`] over `by_block`.
+    ///
+    /// Maintained incrementally because the whole point is to read it cheaply on every backfill
+    /// tick; summing the map each time would be `O(blocks)` on the hot path.
+    cached_bytes: u64,
+}
+
+impl ChainMerkleCache {
+    /// Drop a cached block and everything indexing it, keeping `cached_bytes` in step.
+    ///
+    /// Note this deliberately leaves `processed_blocks` alone: a height can be "processed" with
+    /// no cached block (an empty source block), and the backfill worker uses that set to decide
+    /// what still needs fetching.
+    fn drop_block(&mut self, header_number: u64) -> bool {
+        let Some(old) = self.by_block.remove(&header_number) else {
+            return false;
+        };
+
+        self.cached_bytes = self.cached_bytes.saturating_sub(old.heap_bytes);
+        for tx_hash in &old.tx_hashes {
+            self.by_tx_hash.remove(tx_hash);
+        }
+
+        true
+    }
+}
+
+/// Snapshot of a chain's merkle cache occupancy.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MerkleCacheStats {
+    pub blocks: u64,
+    pub txs: u64,
+    pub bytes: u64,
+}
+
+impl MerkleCacheStats {
+    /// Mean heap bytes per cached block, or `None` while the cache is still cold.
+    ///
+    /// This is the measured density that lets a byte budget be translated into a block count
+    /// without assuming anything about the chain.
+    pub fn mean_bytes_per_block(&self) -> Option<u64> {
+        if self.blocks == 0 || self.bytes == 0 {
+            return None;
+        }
+
+        Some((self.bytes / self.blocks).max(1))
+    }
 }
 
 /// In-memory cache of finalized source-chain merkle data.
@@ -118,27 +194,33 @@ impl MerkleProofCache {
 
     async fn insert_cached_block(&self, header_number: u64, block: Arc<CachedMerkleBlock>) {
         let mut cache = self.inner.write().await;
-        if let Some(old) = cache.by_block.remove(&header_number) {
-            for tx_hash in &old.tx_hashes {
-                cache.by_tx_hash.remove(tx_hash);
-            }
-        }
+        // Re-inserting a height already cached is normal (an on-demand fill can race a
+        // backfill), so the old block's bytes must come off before the new block's go on.
+        cache.drop_block(header_number);
 
         for (tx_index, tx_hash) in block.tx_hashes.iter().copied().enumerate() {
             cache.by_tx_hash.insert(tx_hash, (header_number, tx_index));
         }
         cache.processed_blocks.insert(header_number);
+        cache.cached_bytes = cache.cached_bytes.saturating_add(block.heap_bytes);
         cache.by_block.insert(header_number, block);
     }
 
     pub async fn mark_processed_empty(&self, header_number: u64) {
         let mut cache = self.inner.write().await;
-        if let Some(old) = cache.by_block.remove(&header_number) {
-            for tx_hash in &old.tx_hashes {
-                cache.by_tx_hash.remove(tx_hash);
-            }
-        }
+        cache.drop_block(header_number);
         cache.processed_blocks.insert(header_number);
+    }
+
+    /// Current occupancy of this chain's cache.
+    pub async fn size_stats(&self) -> MerkleCacheStats {
+        let cache = self.inner.read().await;
+
+        MerkleCacheStats {
+            blocks: cache.by_block.len() as u64,
+            txs: cache.by_tx_hash.len() as u64,
+            bytes: cache.cached_bytes,
+        }
     }
 
     pub async fn is_processed(&self, header_number: u64) -> bool {
@@ -180,6 +262,7 @@ impl MerkleProofCache {
 
         let removed = removed_blocks.len();
         for block in removed_blocks.into_values() {
+            cache.cached_bytes = cache.cached_bytes.saturating_sub(block.heap_bytes);
             for tx_hash in &block.tx_hashes {
                 cache.by_tx_hash.remove(tx_hash);
             }
@@ -195,11 +278,8 @@ impl MerkleProofCache {
         cache.processed_blocks.split_off(&split_key);
 
         let removed = removed_blocks.len();
-        if removed == 0 {
-            return 0;
-        }
-
         for block in removed_blocks.into_values() {
+            cache.cached_bytes = cache.cached_bytes.saturating_sub(block.heap_bytes);
             for tx_hash in &block.tx_hashes {
                 cache.by_tx_hash.remove(tx_hash);
             }
@@ -337,5 +417,144 @@ mod tests {
             cache.unprocessed_heights_desc(10, 14, 3).await,
             vec![13, 12, 10]
         );
+    }
+
+    /// Variable-size payload: the default `tx` helper makes 1-byte payloads, which are too
+    /// small to tell a real byte total from a per-entry constant.
+    fn sized_tx(n: u64, len: usize) -> (H256, Vec<u8>) {
+        (H256::from_low_u64_be(n), vec![n as u8; len])
+    }
+
+    #[tokio::test]
+    async fn byte_accounting_returns_to_zero_after_pruning_everything() {
+        let cache = MerkleProofCache::default();
+        cache
+            .insert_block(10, vec![sized_tx(1, 512), sized_tx(2, 512)])
+            .await
+            .expect("insert should succeed");
+        cache
+            .insert_block(11, vec![sized_tx(3, 512)])
+            .await
+            .expect("insert should succeed");
+
+        let filled = cache.size_stats().await;
+        assert_eq!(filled.blocks, 2);
+        assert_eq!(filled.txs, 3);
+        assert!(
+            filled.bytes >= 3 * 512,
+            "payloads should dominate: {filled:?}"
+        );
+
+        cache.prune_below(100).await;
+
+        assert_eq!(cache.size_stats().await, MerkleCacheStats::default());
+    }
+
+    #[tokio::test]
+    async fn reinserting_same_height_does_not_drift_byte_total() {
+        // An on-demand fill can re-cache a height a backfill already cached. If the old block's
+        // bytes were not subtracted first, the total would grow on every re-insert.
+        let cache = MerkleProofCache::default();
+        cache
+            .insert_block(10, vec![sized_tx(1, 1024)])
+            .await
+            .expect("insert should succeed");
+        let first = cache.size_stats().await;
+
+        for _ in 0..5 {
+            cache
+                .insert_block(10, vec![sized_tx(1, 1024)])
+                .await
+                .expect("insert should succeed");
+        }
+
+        assert_eq!(cache.size_stats().await, first);
+    }
+
+    #[tokio::test]
+    async fn marking_a_cached_height_empty_releases_its_bytes() {
+        let cache = MerkleProofCache::default();
+        cache
+            .insert_block(10, vec![sized_tx(1, 1024)])
+            .await
+            .expect("insert should succeed");
+        assert!(cache.size_stats().await.bytes > 0);
+
+        cache.mark_processed_empty(10).await;
+
+        let stats = cache.size_stats().await;
+        assert_eq!(stats.bytes, 0);
+        assert_eq!(stats.blocks, 0);
+        assert_eq!(stats.txs, 0);
+        // Still processed: an empty block needs no refetch.
+        assert!(cache.is_processed(10).await);
+    }
+
+    #[tokio::test]
+    async fn prune_above_releases_bytes_for_reverted_blocks() {
+        let cache = MerkleProofCache::default();
+        for height in 10..=12 {
+            cache
+                .insert_block(height, vec![sized_tx(height, 1024)])
+                .await
+                .expect("insert should succeed");
+        }
+        let all_three = cache.size_stats().await.bytes;
+
+        cache.prune_above(10).await;
+
+        let stats = cache.size_stats().await;
+        assert_eq!(stats.blocks, 1);
+        assert!(
+            stats.bytes > 0 && stats.bytes < all_three,
+            "one of three blocks should remain: {stats:?} vs {all_three}"
+        );
+
+        cache.prune_above(9).await;
+        assert_eq!(cache.size_stats().await, MerkleCacheStats::default());
+    }
+
+    #[tokio::test]
+    async fn byte_total_tracks_transaction_density() {
+        // The whole point of the budget: two chains with the same block count but different tx
+        // density must report very different totals.
+        let sparse = MerkleProofCache::default();
+        sparse
+            .insert_block(1, vec![sized_tx(1, 256)])
+            .await
+            .expect("insert should succeed");
+
+        let dense = MerkleProofCache::default();
+        dense
+            .insert_block(1, (0..100).map(|n| sized_tx(n, 256)).collect())
+            .await
+            .expect("insert should succeed");
+
+        let sparse_stats = sparse.size_stats().await;
+        let dense_stats = dense.size_stats().await;
+
+        assert_eq!(sparse_stats.blocks, dense_stats.blocks);
+        assert!(
+            dense_stats.bytes > sparse_stats.bytes * 50,
+            "dense={dense_stats:?} sparse={sparse_stats:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mean_bytes_per_block_is_none_while_cold() {
+        let cache = MerkleProofCache::default();
+        assert_eq!(cache.size_stats().await.mean_bytes_per_block(), None);
+
+        cache
+            .insert_block(1, vec![sized_tx(1, 1024)])
+            .await
+            .expect("insert should succeed");
+
+        let mean = cache
+            .size_stats()
+            .await
+            .mean_bytes_per_block()
+            .expect("warm cache should report a mean");
+        assert!(mean >= 1024, "mean should cover the payload: {mean}");
     }
 }

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -392,12 +392,24 @@ impl ContinuityService {
     /// Sampled rather than updated at each mutation site: these are observability gauges, the
     /// reads are cheap, and driving them from a single place keeps metric updates out of the
     /// cache write paths.
-    pub fn spawn_cache_metrics_updater(service: Arc<Self>) {
+    pub fn spawn_cache_metrics_updater(
+        service: Arc<Self>,
+        block_caches: HashMap<u64, Arc<eth::mem_block_cache::MemBlockCache>>,
+    ) {
         tokio::spawn(async move {
             loop {
                 for (chain_key, chain) in service.chains.iter() {
                     let (merkle, checkpoint_entries) = Self::cache_occupancy(chain.as_ref()).await;
-                    let retention = service.merkle_cache_retention_blocks(chain.as_ref()).await;
+                    // One snapshot feeds both the gauges and the clamp.
+                    let retention = Self::retention_blocks_for(chain.as_ref(), merkle);
+                    let (block_cache_blocks, block_cache_txs, block_cache_capacity) =
+                        match block_caches.get(chain_key) {
+                            Some(cache) => {
+                                let (blocks, txs) = cache.occupancy();
+                                (blocks as u64, txs as u64, cache.capacity() as u64)
+                            }
+                            None => (0, 0, 0),
+                        };
 
                     service.metrics.set_cache_occupancy(
                         *chain_key,
@@ -407,6 +419,9 @@ impl ContinuityService {
                             merkle_bytes: merkle.bytes,
                             merkle_retention_blocks: retention,
                             checkpoint_entries,
+                            block_cache_blocks,
+                            block_cache_txs,
+                            block_cache_capacity,
                         },
                     );
                 }
@@ -669,6 +684,14 @@ impl ContinuityService {
     /// the window — a fill/evict thrash loop. Narrowing the window instead keeps
     /// height-ordered `prune_below` as the single eviction path and makes thrash impossible.
     async fn merkle_cache_retention_blocks(&self, chain: &ChainState) -> u64 {
+        let stats = chain.merkle_proof_cache.size_stats().await;
+
+        Self::retention_blocks_for(chain, stats)
+    }
+
+    /// [`Self::merkle_cache_retention_blocks`] against an already-taken occupancy snapshot, so a
+    /// caller that needs both does not read the cache twice.
+    fn retention_blocks_for(chain: &ChainState, stats: MerkleCacheStats) -> u64 {
         let configured = chain
             .cache_config
             .merkle_retention_blocks
@@ -679,12 +702,7 @@ impl ContinuityService {
         };
 
         // A cold cache has no density to measure yet; the clamp engages after the first tick.
-        let Some(mean_bytes) = chain
-            .merkle_proof_cache
-            .size_stats()
-            .await
-            .mean_bytes_per_block()
-        else {
+        let Some(mean_bytes) = stats.mean_bytes_per_block() else {
             return configured;
         };
 
@@ -1034,11 +1052,7 @@ impl ContinuityService {
                 // miss, so dropping old checkpoints caps how far back proofs can be served.
                 if let Some(max_entries) = chain.cache_config.checkpoint_cache_max_entries {
                     let mut dropped = 0usize;
-                    while cp.len() > max_entries {
-                        let Some(oldest) = cp.keys().next().copied() else {
-                            break;
-                        };
-                        cp.remove(&oldest);
+                    while cp.len() > max_entries && cp.pop_first().is_some() {
                         dropped += 1;
                     }
                     if dropped > 0 {

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -470,11 +470,28 @@ impl ContinuityService {
             return Ok(());
         }
 
+        // Shed everything below the retained window *before* deciding whether there is fill
+        // work. A byte-budget clamp narrows the window precisely into the state where every
+        // remaining height is already processed, so pruning only on the fill path would leave
+        // the blocks the budget just excluded resident until the next checkpoint -- or
+        // indefinitely, if attestations stall and `cache_tip` stops advancing. Filling only
+        // ever adds heights inside the window, so one prune per tick is enough.
+        let removed = chain.merkle_proof_cache.prune_below(start).await;
+        if removed > 0 {
+            tracing::info!(
+                chain_key,
+                min_retained = start,
+                removed,
+                "pruned old merkle proof cache blocks outside the retained window"
+            );
+        }
+
         let heights = chain
             .merkle_proof_cache
             .unprocessed_heights_desc(start, cache_tip, MERKLE_BACKFILL_MAX_BLOCKS_PER_TICK)
             .await;
         if heights.is_empty() {
+            let (merkle_stats, checkpoint_entries) = Self::cache_occupancy(chain.as_ref()).await;
             tracing::info!(
                 chain_key,
                 confirmed_tip,
@@ -482,6 +499,10 @@ impl ContinuityService {
                 cache_tip,
                 retained_from = start,
                 retention_blocks,
+                total_cached_blocks = merkle_stats.blocks,
+                total_cached_txs = merkle_stats.txs,
+                total_cached_bytes = merkle_stats.bytes,
+                checkpoint_cache_entries = checkpoint_entries,
                 "merkle proof cache backfill already warm for retained range"
             );
             return Ok(());
@@ -533,17 +554,6 @@ impl ContinuityService {
                     );
                 }
             }
-        }
-
-        let min_retained = cache_tip.saturating_sub(retention_blocks).max(genesis);
-        let removed = chain.merkle_proof_cache.prune_below(min_retained).await;
-        if removed > 0 {
-            tracing::info!(
-                chain_key,
-                min_retained,
-                removed,
-                "pruned old merkle proof cache blocks after backfill"
-            );
         }
 
         let (merkle_stats, checkpoint_entries) = Self::cache_occupancy(chain.as_ref()).await;

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -10,12 +10,13 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 
-use crate::prom::Metrics;
+use crate::config::ChainCacheConfig;
+use crate::prom::{CacheOccupancy, Metrics};
 use crate::services::continuity_service::helpers::*;
 use attestor_primitives::block::ContinuityProof;
 use continuity::ContinuityBuilder;
 use merkle::proof::TransactionMerkleProof;
-use merkle_cache::MerkleProofCache;
+use merkle_cache::{MerkleCacheStats, MerkleProofCache};
 
 pub mod helpers;
 mod merkle_cache;
@@ -38,6 +39,8 @@ pub struct ChainState {
     /// pod counts as healthy until real events land (same convention as the attestor's
     /// liveness watchdog).
     pub last_cache_advance: std::sync::Mutex<Instant>,
+    /// Per-chain cache sizing. Defaults reproduce the pre-configuration behavior.
+    pub cache_config: ChainCacheConfig,
 }
 
 impl ChainState {
@@ -209,6 +212,8 @@ pub struct CacheFreshness {
     pub stale_chains: Vec<u64>,
 }
 
+/// How often cache-occupancy gauges are refreshed.
+const CACHE_METRICS_POLL_INTERVAL: Duration = Duration::from_secs(15);
 const MERKLE_BACKFILL_POLL_INTERVAL: Duration = Duration::from_secs(15);
 const MERKLE_BACKFILL_MAX_BLOCKS_PER_TICK: usize = 50;
 const MERKLE_BACKFILL_MAX_CONCURRENCY: usize = 8;
@@ -221,6 +226,32 @@ impl ContinuityService {
     /// Returns an error if the attestation genesis block cannot be fetched from RPC.
     pub async fn new(
         builders: Vec<Arc<ContinuityBuilder>>,
+        metrics: Metrics,
+        max_batch_size: usize,
+        max_batch_span: u64,
+    ) -> anyhow::Result<Self> {
+        Self::new_with_cache_configs(
+            builders,
+            HashMap::new(),
+            metrics,
+            max_batch_size,
+            max_batch_span,
+        )
+        .await
+    }
+
+    /// Like [`Self::new`], but with per-chain cache sizing.
+    ///
+    /// Cache tuning is deliberately routed here rather than through [`continuity::ContinuityConfig`]:
+    /// that type lives in a crate shared with the attestors, and how this process budgets its own
+    /// caches is none of their business. Chains absent from `cache_configs` get
+    /// [`ChainCacheConfig::default`], i.e. the historical behavior.
+    ///
+    /// # Errors
+    /// Returns an error if the attestation genesis block cannot be fetched from RPC.
+    pub async fn new_with_cache_configs(
+        builders: Vec<Arc<ContinuityBuilder>>,
+        cache_configs: HashMap<u64, ChainCacheConfig>,
         metrics: Metrics,
         max_batch_size: usize,
         max_batch_span: u64,
@@ -315,6 +346,7 @@ impl ContinuityService {
             metrics.set_last_attested_height(chain_key, latest_attested_height);
             let checkpoint_interval = builder.config.checkpoint_interval;
             let attestation_interval = builder.config.attestation_interval;
+            let cache_config = cache_configs.get(&chain_key).cloned().unwrap_or_default();
 
             chains.insert(
                 chain_key,
@@ -327,6 +359,7 @@ impl ContinuityService {
                     checkpoint_interval: AtomicU64::new(checkpoint_interval),
                     attestation_interval: AtomicU64::new(attestation_interval),
                     last_cache_advance: std::sync::Mutex::new(Instant::now()),
+                    cache_config,
                 }),
             );
         }
@@ -354,9 +387,46 @@ impl ContinuityService {
         self.chains.keys().copied().collect()
     }
 
+    /// Sample every chain's cache occupancy into Prometheus on a fixed tick.
+    ///
+    /// Sampled rather than updated at each mutation site: these are observability gauges, the
+    /// reads are cheap, and driving them from a single place keeps metric updates out of the
+    /// cache write paths.
+    pub fn spawn_cache_metrics_updater(service: Arc<Self>) {
+        tokio::spawn(async move {
+            loop {
+                for (chain_key, chain) in service.chains.iter() {
+                    let (merkle, checkpoint_entries) = Self::cache_occupancy(chain.as_ref()).await;
+                    let retention = service.merkle_cache_retention_blocks(chain.as_ref()).await;
+
+                    service.metrics.set_cache_occupancy(
+                        *chain_key,
+                        CacheOccupancy {
+                            merkle_blocks: merkle.blocks,
+                            merkle_txs: merkle.txs,
+                            merkle_bytes: merkle.bytes,
+                            merkle_retention_blocks: retention,
+                            checkpoint_entries,
+                        },
+                    );
+                }
+                tokio::time::sleep(CACHE_METRICS_POLL_INTERVAL).await;
+            }
+        });
+    }
+
     pub fn spawn_merkle_backfill(service: Arc<Self>) {
         for chain in service.chains.values().cloned().collect::<Vec<_>>() {
             let service = service.clone();
+            if !chain.cache_config.merkle_backfill_enabled {
+                // Pruning still happens on every checkpoint, so skipping the worker cannot let
+                // the cache grow without bound - it just fills on demand instead of eagerly.
+                tracing::info!(
+                    chain_key = chain.builder.config.chain_key,
+                    "merkle proof cache backfill disabled by config; filling on demand only"
+                );
+                continue;
+            }
             tokio::spawn(async move {
                 tracing::info!(
                     chain_key = chain.builder.config.chain_key,
@@ -392,7 +462,7 @@ impl ContinuityService {
             return Ok(());
         };
         let cache_tip = latest_attested_height.min(confirmed_tip);
-        let retention_blocks = self.merkle_cache_retention_blocks(chain.as_ref());
+        let retention_blocks = self.merkle_cache_retention_blocks(chain.as_ref()).await;
         let genesis = chain.attestation_genesis_block.load(Ordering::Relaxed);
         let start = cache_tip.saturating_sub(retention_blocks).max(genesis);
 
@@ -465,20 +535,6 @@ impl ContinuityService {
             }
         }
 
-        tracing::info!(
-            chain_key,
-            confirmed_tip,
-            latest_attested_height,
-            cache_tip,
-            retained_from = start,
-            min_height,
-            max_height,
-            cached_blocks,
-            cached_txs,
-            failed_blocks,
-            "merkle proof cache backfill tick completed"
-        );
-
         let min_retained = cache_tip.saturating_sub(retention_blocks).max(genesis);
         let removed = chain.merkle_proof_cache.prune_below(min_retained).await;
         if removed > 0 {
@@ -489,6 +545,26 @@ impl ContinuityService {
                 "pruned old merkle proof cache blocks after backfill"
             );
         }
+
+        let (merkle_stats, checkpoint_entries) = Self::cache_occupancy(chain.as_ref()).await;
+        tracing::info!(
+            chain_key,
+            confirmed_tip,
+            latest_attested_height,
+            cache_tip,
+            retained_from = start,
+            retention_blocks,
+            min_height,
+            max_height,
+            cached_blocks,
+            cached_txs,
+            failed_blocks,
+            total_cached_blocks = merkle_stats.blocks,
+            total_cached_txs = merkle_stats.txs,
+            total_cached_bytes = merkle_stats.bytes,
+            checkpoint_cache_entries = checkpoint_entries,
+            "merkle proof cache backfill tick completed"
+        );
 
         Ok(())
     }
@@ -557,12 +633,65 @@ impl ContinuityService {
         Ok(item)
     }
 
-    fn merkle_cache_retention_blocks(&self, chain: &ChainState) -> u64 {
+    /// Retention window derived from the chain's live on-chain attestation cadence.
+    ///
+    /// Note what this couples: raising `attestation_interval` to *reduce* attestation load on a
+    /// fast chain multiplies this window by the same factor. That is why it can be overridden
+    /// per chain via `cache.merkle_retention_blocks`.
+    fn derived_retention_blocks(chain: &ChainState) -> u64 {
         let checkpoint_interval = chain.checkpoint_interval.load(Ordering::Relaxed);
         let attestation_interval = chain.attestation_interval.load(Ordering::Relaxed);
         attestation_interval
             .saturating_mul(checkpoint_interval)
             .saturating_mul(MERKLE_PROOF_CACHE_CHECKPOINT_RETENTION_MULTIPLIER)
+    }
+
+    /// Effective retention window for a chain's merkle cache, in source blocks.
+    ///
+    /// Starts from the configured or derived window, then — when a byte budget is set — narrows
+    /// it using the cache's own measured bytes-per-block so the resident set stays inside the
+    /// budget however many transactions the chain puts in a block.
+    ///
+    /// The budget deliberately moves this window rather than evicting blocks directly.
+    /// [`MerkleProofCache::unprocessed_heights_desc`] drives the backfill worker off
+    /// `processed_blocks`, so a block evicted purely for size would either be treated as
+    /// still-cached (and never refilled) or be refilled immediately because it remains inside
+    /// the window — a fill/evict thrash loop. Narrowing the window instead keeps
+    /// height-ordered `prune_below` as the single eviction path and makes thrash impossible.
+    async fn merkle_cache_retention_blocks(&self, chain: &ChainState) -> u64 {
+        let configured = chain
+            .cache_config
+            .merkle_retention_blocks
+            .unwrap_or_else(|| Self::derived_retention_blocks(chain));
+
+        let Some(budget) = chain.cache_config.merkle_max_bytes else {
+            return configured;
+        };
+
+        // A cold cache has no density to measure yet; the clamp engages after the first tick.
+        let Some(mean_bytes) = chain
+            .merkle_proof_cache
+            .size_stats()
+            .await
+            .mean_bytes_per_block()
+        else {
+            return configured;
+        };
+
+        // Never shrink below one attestation bracket, so the window a proof is most likely to
+        // need stays resident even under a tight budget.
+        let floor = chain.attestation_interval.load(Ordering::Relaxed).max(1);
+        let affordable = (budget / mean_bytes).max(floor);
+
+        configured.min(affordable)
+    }
+
+    /// Occupancy of a chain's caches, for metrics and logging.
+    async fn cache_occupancy(chain: &ChainState) -> (MerkleCacheStats, u64) {
+        let merkle = chain.merkle_proof_cache.size_stats().await;
+        let checkpoints = chain.checkpoint_cache.read().await.len() as u64;
+
+        (merkle, checkpoints)
     }
 
     /// Update the continuity builder's last-checkpoint hint (from on-chain events).
@@ -887,11 +1016,31 @@ impl ContinuityService {
     pub async fn insert_checkpoint(&self, chain_key: u64, block_number: u64, digest: H256) {
         if let Some(chain) = self.chains.get(&chain_key) {
             {
-                chain
-                    .checkpoint_cache
-                    .write()
-                    .await
-                    .insert(block_number, digest);
+                let mut cp = chain.checkpoint_cache.write().await;
+                cp.insert(block_number, digest);
+
+                // Optional cap. Off by default: proof serving resolves a query against the
+                // checkpoint immediately *below* it and has no fallback to chain state on a
+                // miss, so dropping old checkpoints caps how far back proofs can be served.
+                if let Some(max_entries) = chain.cache_config.checkpoint_cache_max_entries {
+                    let mut dropped = 0usize;
+                    while cp.len() > max_entries {
+                        let Some(oldest) = cp.keys().next().copied() else {
+                            break;
+                        };
+                        cp.remove(&oldest);
+                        dropped += 1;
+                    }
+                    if dropped > 0 {
+                        tracing::debug!(
+                            chain_key,
+                            dropped,
+                            max_entries,
+                            oldest_retained = ?cp.keys().next(),
+                            "🔧 🧹 dropped oldest checkpoints to honor checkpoint_cache_max_entries"
+                        );
+                    }
+                }
             }
             chain.touch_cache();
             tracing::debug!(
@@ -905,8 +1054,9 @@ impl ContinuityService {
                 Self::cached_checkpoint_height(chain.as_ref()).await,
             );
 
-            let retention_blocks = self.merkle_cache_retention_blocks(chain.as_ref());
-            let min_retained = block_number.saturating_sub(retention_blocks);
+            let retention_blocks = self.merkle_cache_retention_blocks(chain.as_ref()).await;
+            let genesis = chain.attestation_genesis_block.load(Ordering::Relaxed);
+            let min_retained = block_number.saturating_sub(retention_blocks).max(genesis);
             let removed = chain.merkle_proof_cache.prune_below(min_retained).await;
             if removed > 0 {
                 tracing::debug!(


### PR DESCRIPTION
## Why

The merkle-proof cache retention window is **derived, not configurable** — `attestation_interval * checkpoint_interval * 4`, both intervals read from chain. That couples cache memory to attestation cadence, so raising `attestation_interval` to *reduce* attestation load on a fast chain multiplies this cache by the same factor.

On cc3-devnet, BSC (`chain_key` 8) runs `attestation_interval = 100` — 10x the default, chosen deliberately for ~1s blocks — giving it a **4000-block window vs 400** for the Ethereum chains. At ~100 tx/block that is ~402k cached transactions against ~33k for both ETH chains combined — **92% of all cached transactions**. The pods were `OOMKilled` every 4–8h (41 and 43 restarts in 2.5 days) on a 4Gi limit.

> **Correction (thanks @DylanVerstraete):** an earlier revision of this description called that "93% of the process", which wrongly implied 93% of *memory*. It is the share of cached *transactions*. By bytes the merkle cache is only a few hundred MiB; the **decoded block cache is the heavyweight** — mainnet-usc holds ~100k cached txs (~120 MiB of merkle data) yet sits at 1.3 GiB resident. `block_cache_capacity` is therefore the more consequential knob here, not a secondary one, and this PR now exposes gauges for it. Note also that both caches plateau within minutes, so they do **not** explain devnet's slow climb from ~2.8 GiB to 4 GiB over ~15h — allocator fragmentation is the likely remainder. This PR cuts churn and steady-state, but may not by itself stop that climb; the plan is to deploy and compare the new gauges against `container_memory_working_set_bytes` before reaching for more knobs.

The same 4Gi limit is comfortable everywhere else, which isolates the cause:

| deployment | chains | retention | memory | restarts |
|---|---|---|---|---|
| `cc3-main-usc-proof-gen-api` | 1 @400 | 400 | 1.3GB | 0 in 39d |
| `cc3-test-proof-gen-api` | 2 @400 | 400 | 2.5GB | 0 in 5.5d |
| `cc3-dev-proof-gen-api` | 3, one @4000 | 400/400/**4000** | 4.0GB | **41–43 in 2.5d** |

BSC's `attestation_interval` stays at 100 — that call is right for attestation load. So the fix belongs here: **make cache size a function of configuration rather than of the chain.**

## What

New optional per-chain `cache:` block. Omitting it reproduces the previous behavior exactly (test-guarded).

```yaml
chains:
  - chain_key: 8
    eth_rpc_url: "..."
    cache:
      merkle_retention_blocks: 1000    # decouple cache size from attestation cadence
      merkle_max_bytes: 805306368      # backstop; 768 MiB
      block_cache_capacity: 96         # was a hard-coded 512
      merkle_backfill_enabled: true
      checkpoint_cache_max_entries: null
```

- **`merkle_max_bytes` narrows the effective retention window** using the cache's own measured bytes-per-block, rather than evicting blocks directly. See the design note below.
- **`block_cache_capacity`** replaces the hard-coded `512`. Each entry holds a whole block's *decoded* txs and receipts, and it overlaps the merkle cache — recent blocks were resident twice.
- `MerkleProofCache` tracks `cached_bytes` incrementally; adds `KeccakMerkleTree::heap_bytes()` since `levels` is private.
- **Five per-chain cache gauges** plus a 15s sampler, and the backfill tick log now carries `retention_blocks`, `total_cached_{blocks,txs,bytes}`, `checkpoint_cache_entries`. There was previously no cache visibility on `/metrics` at all — nothing to alert on or tune against.

## Design note: why the budget moves the window instead of evicting

The obvious implementation — evict oldest blocks on insert when over budget — is a trap. `unprocessed_heights_desc` selects backfill work from `processed_blocks`, so a block evicted purely for size must either stay in `processed_blocks` (and never be refilled) or leave it (and be refilled immediately, since it is still inside the window) — a fill/evict thrash loop burning RPC and keccak.

Narrowing the window instead keeps height-ordered `prune_below` as the **single** eviction path: no new invariant to maintain, no thrash, and the window self-tunes as tx density changes. Floored at one attestation interval so the bracket a proof is most likely to need stays resident.

## Deliberately conservative

`checkpoint_cache_max_entries` **defaults to unbounded**. `get_checkpoint_boundaries` resolves a proof against the checkpoint immediately *below* the queried block and has **no fallback to chain state** — a miss returns `AttestationsMissing` → 404. So capping it trades how far back proofs can be served for tens of MB/year. Shipped opt-in, documented as such, and set nowhere.

## Also

Fixes stale docs in `config.example.yaml` / `.env.example` claiming `block_confirmation_depth` defaults to `0` (untrue since it became derived from `MaturityStrategy` in #1313), and marks the unused `REDIS_*` env vars as ignored — no Redis code remains in the crate.

## Testing

- `cargo fmt --all -- --check` clean; `cargo clippy -p proof-gen-api-server -p merkle --all-targets -- -D warnings` zero findings
- **71 lib + 27 route + 11 merkle** tests pass; `cargo check --workspace --all-targets` exit 0
- New coverage: defaults survive an omitted `cache:` block; zero values rejected; byte-counter drift on re-insert / `prune_above` / `mark_processed_empty`; clamp behavior (cold cache, density-based, interval floor); and that `config.example.yaml` itself still parses

## Follow-up (not in this PR)

`cc-networks-iac` needs the chart to render the `cache:` block before devnet can set these. Suggested chain-8 values: `merkle_retention_blocks: 1000`, `merkle_max_bytes: 768MiB`, `block_cache_capacity: 96` — expected to take BSC from ~402k cached txs to ~100k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

