### PR TITLE
feat(usc-audit): add BSC (chain key 8) liveness sanities on devnet

### DIFF
--- a/.github/workflows/audit-automation.yml
+++ b/.github/workflows/audit-automation.yml
@@ -51,7 +51,6 @@ jobs:
           USC_NOTI_SLACK_CHANNEL_ID: ${{ matrix.slack_channel_id }}
           USC_SLACK_ALERT_GROUP: ${{ secrets.USC_SLACK_ALERT_GROUP }}
           SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
-          BSC_RPC_URL: ${{ secrets.BSC_RPC_URL }}
           BSC_MAINNET_RPC_URL: ${{ secrets.BSC_MAINNET_RPC_URL }}
           MAINNET_RPC_URL: ${{ secrets.USC_SANITY_ETHEREUM_RPC_URL }}
         run: |

--- a/.github/workflows/audit-automation.yml
+++ b/.github/workflows/audit-automation.yml
@@ -52,6 +52,7 @@ jobs:
           USC_SLACK_ALERT_GROUP: ${{ secrets.USC_SLACK_ALERT_GROUP }}
           SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
           BSC_RPC_URL: ${{ secrets.BSC_RPC_URL }}
+          BSC_MAINNET_RPC_URL: ${{ secrets.BSC_MAINNET_RPC_URL }}
           MAINNET_RPC_URL: ${{ secrets.USC_SANITY_ETHEREUM_RPC_URL }}
         run: |
           deno task start -- --config config-${{ matrix.config }}.json

--- a/scripts/usc-audit-automation/README.md
+++ b/scripts/usc-audit-automation/README.md
@@ -71,6 +71,9 @@ variables.
 `BSC_RPC_URL` for chainId 97, `BSC_MAINNET_RPC_URL` for chainId 56 and
 `MAINNET_RPC_URL` for chainId 1.
 
+Devnet's chainId 56 entry ships a public BSC endpoint, so `BSC_MAINNET_RPC_URL`
+is optional; set it to move that check onto a private provider.
+
 Relative config paths (e.g. `config-devnet.json`) are resolved from the script
 directory, so it works regardless of current working directory.
 

--- a/scripts/usc-audit-automation/README.md
+++ b/scripts/usc-audit-automation/README.md
@@ -5,7 +5,8 @@ A Deno-based TypeScript tool that runs attestation sanity checks on USC
 
 All configuration is loaded from a single JSON file. For CI, env overrides:
 `USC_NOTI_SLACK_BOT_TOKEN`, `USC_NOTI_SLACK_CHANNEL_ID`,
-`USC_SLACK_ALERT_GROUP`, `SEPOLIA_RPC_URL`, `BSC_RPC_URL`, `MAINNET_RPC_URL`
+`USC_SLACK_ALERT_GROUP`, `SEPOLIA_RPC_URL`, `BSC_RPC_URL`,
+`BSC_MAINNET_RPC_URL`, `MAINNET_RPC_URL`
 
 ## Features
 
@@ -48,7 +49,8 @@ variables.
       "chainKey": 2,
       "url": "wss://ethereum-sepolia.publicnode.com"
     },
-    { "chainId": 97, "chainKey": 3, "url": "wss://bsc-testnet.publicnode.com" }
+    { "chainId": 97, "chainKey": 3, "url": "wss://bsc-testnet.publicnode.com" },
+    { "chainId": 56, "chainKey": 8, "url": "wss://bsc-rpc.publicnode.com" }
   ],
   "slackBotToken": "xxxx-xxxxxxxxxx-xx...",
   "slackChannelId": "C09DC0AAD..",
@@ -66,7 +68,8 @@ variables.
   only when not using `--no-slack`
 
 **Env overrides (CI)**: `SEPOLIA_RPC_URL` overrides url for chainId 11155111;
-`BSC_RPC_URL` for chainId 97 and `MAINNET_RPC_URL` for chainId 1.
+`BSC_RPC_URL` for chainId 97, `BSC_MAINNET_RPC_URL` for chainId 56 and
+`MAINNET_RPC_URL` for chainId 1.
 
 Relative config paths (e.g. `config-devnet.json`) are resolved from the script
 directory, so it works regardless of current working directory.

--- a/scripts/usc-audit-automation/README.md
+++ b/scripts/usc-audit-automation/README.md
@@ -5,8 +5,8 @@ A Deno-based TypeScript tool that runs attestation sanity checks on USC
 
 All configuration is loaded from a single JSON file. For CI, env overrides:
 `USC_NOTI_SLACK_BOT_TOKEN`, `USC_NOTI_SLACK_CHANNEL_ID`,
-`USC_SLACK_ALERT_GROUP`, `SEPOLIA_RPC_URL`, `BSC_RPC_URL`,
-`BSC_MAINNET_RPC_URL`, `MAINNET_RPC_URL`
+`USC_SLACK_ALERT_GROUP`, `SEPOLIA_RPC_URL`, `BSC_MAINNET_RPC_URL`,
+`MAINNET_RPC_URL`
 
 ## Features
 
@@ -49,8 +49,7 @@ variables.
       "chainKey": 2,
       "url": "wss://ethereum-sepolia.publicnode.com"
     },
-    { "chainId": 97, "chainKey": 3, "url": "wss://bsc-testnet.publicnode.com" },
-    { "chainId": 56, "chainKey": 8, "url": "wss://bsc-rpc.publicnode.com" }
+    { "chainId": 56, "chainKey": 8, "url": "https://bsc-rpc.publicnode.com" }
   ],
   "slackBotToken": "xxxx-xxxxxxxxxx-xx...",
   "slackChannelId": "C09DC0AAD..",
@@ -68,8 +67,7 @@ variables.
   only when not using `--no-slack`
 
 **Env overrides (CI)**: `SEPOLIA_RPC_URL` overrides url for chainId 11155111;
-`BSC_RPC_URL` for chainId 97, `BSC_MAINNET_RPC_URL` for chainId 56 and
-`MAINNET_RPC_URL` for chainId 1.
+`BSC_MAINNET_RPC_URL` for chainId 56 and `MAINNET_RPC_URL` for chainId 1.
 
 Devnet's chainId 56 entry ships a public BSC endpoint, so `BSC_MAINNET_RPC_URL`
 is optional; set it to move that check onto a private provider.

--- a/scripts/usc-audit-automation/config-devnet.json
+++ b/scripts/usc-audit-automation/config-devnet.json
@@ -16,7 +16,7 @@
     {
       "chainId": 56,
       "chainKey": 8,
-      "url": ""
+      "url": "https://bsc-rpc.publicnode.com"
     }
   ],
   "balanceChecks": [

--- a/scripts/usc-audit-automation/config-devnet.json
+++ b/scripts/usc-audit-automation/config-devnet.json
@@ -12,6 +12,11 @@
       "chainId": 1,
       "chainKey": 4,
       "url": ""
+    },
+    {
+      "chainId": 56,
+      "chainKey": 8,
+      "url": ""
     }
   ],
   "balanceChecks": [

--- a/scripts/usc-audit-automation/src/config.ts
+++ b/scripts/usc-audit-automation/src/config.ts
@@ -93,11 +93,13 @@ export function loadConfig(): AuditConfig {
     | undefined;
   const sepoliaUrl = Deno.env.get("SEPOLIA_RPC_URL");
   const bscUrl = Deno.env.get("BSC_RPC_URL");
+  const bscMainnetUrl = Deno.env.get("BSC_MAINNET_RPC_URL");
   const mainnetEthUrl = Deno.env.get("MAINNET_RPC_URL");
   const ethRpc = (ethRpcRaw ?? []).map((r) => {
     let url = r.url;
     if (r.chainId === 11155111 && sepoliaUrl) url = sepoliaUrl;
     if (r.chainId === 97 && bscUrl) url = bscUrl;
+    if (r.chainId === 56 && bscMainnetUrl) url = bscMainnetUrl;
     if (r.chainId === 1 && mainnetEthUrl) url = mainnetEthUrl;
     return {
       chainId: r.chainId,
@@ -166,7 +168,8 @@ CONFIG FILE FORMAT (JSON):
     "graphqlUrl": "https://graphql-usc.cc3-devnet.creditcoin.network",
     "ethRpc": [
       { "chainId": 11155111, "chainKey": 2, "url": "wss://ethereum-sepolia.publicnode.com" },
-      { "chainId": 97, "chainKey": 3, "url": "wss://bsc-testnet.publicnode.com" }
+      { "chainId": 97, "chainKey": 3, "url": "wss://bsc-testnet.publicnode.com" },
+      { "chainId": 56, "chainKey": 8, "url": "wss://bsc-rpc.publicnode.com" }
     ],
     "slackBotToken": "xxxx-xxxxxxxxxx-xx..."
     "slackChannelId": "C09DC0AAD...",
@@ -198,8 +201,9 @@ CONFIG FILE FORMAT (JSON):
   slackBotToken, slackChannelId, slackAlertGroup: optional; required only when not using --no-slack
 
 ENV OVERRIDES (for CI):
-  SEPOLIA_RPC_URL   Override ethRpc url for chainId 11155111
-  BSC_RPC_URL       Override ethRpc url for chainId 97
-  MAINNET_RPC_URL   Override ethRpc url for chainId 1
+  SEPOLIA_RPC_URL       Override ethRpc url for chainId 11155111
+  BSC_RPC_URL           Override ethRpc url for chainId 97
+  BSC_MAINNET_RPC_URL   Override ethRpc url for chainId 56
+  MAINNET_RPC_URL       Override ethRpc url for chainId 1
 `);
 }

--- a/scripts/usc-audit-automation/src/config.ts
+++ b/scripts/usc-audit-automation/src/config.ts
@@ -92,13 +92,11 @@ export function loadConfig(): AuditConfig {
     >
     | undefined;
   const sepoliaUrl = Deno.env.get("SEPOLIA_RPC_URL");
-  const bscUrl = Deno.env.get("BSC_RPC_URL");
   const bscMainnetUrl = Deno.env.get("BSC_MAINNET_RPC_URL");
   const mainnetEthUrl = Deno.env.get("MAINNET_RPC_URL");
   const ethRpc = (ethRpcRaw ?? []).map((r) => {
     let url = r.url;
     if (r.chainId === 11155111 && sepoliaUrl) url = sepoliaUrl;
-    if (r.chainId === 97 && bscUrl) url = bscUrl;
     if (r.chainId === 56 && bscMainnetUrl) url = bscMainnetUrl;
     if (r.chainId === 1 && mainnetEthUrl) url = mainnetEthUrl;
     return {
@@ -168,8 +166,7 @@ CONFIG FILE FORMAT (JSON):
     "graphqlUrl": "https://graphql-usc.cc3-devnet.creditcoin.network",
     "ethRpc": [
       { "chainId": 11155111, "chainKey": 2, "url": "wss://ethereum-sepolia.publicnode.com" },
-      { "chainId": 97, "chainKey": 3, "url": "wss://bsc-testnet.publicnode.com" },
-      { "chainId": 56, "chainKey": 8, "url": "wss://bsc-rpc.publicnode.com" }
+      { "chainId": 56, "chainKey": 8, "url": "https://bsc-rpc.publicnode.com" }
     ],
     "slackBotToken": "xxxx-xxxxxxxxxx-xx..."
     "slackChannelId": "C09DC0AAD...",
@@ -202,8 +199,7 @@ CONFIG FILE FORMAT (JSON):
 
 ENV OVERRIDES (for CI):
   SEPOLIA_RPC_URL       Override ethRpc url for chainId 11155111
-  BSC_RPC_URL           Override ethRpc url for chainId 97
-  BSC_MAINNET_RPC_URL   Override ethRpc url for chainId 56
+  BSC_MAINNET_RPC_URL   Override ethRpc url for chainId 56 (BSC mainnet)
   MAINNET_RPC_URL       Override ethRpc url for chainId 1
 `);
 }

--- a/scripts/usc-audit-automation/src/main.ts
+++ b/scripts/usc-audit-automation/src/main.ts
@@ -422,6 +422,7 @@ function getChainName(chainId: number): string {
   const names: Record<number, string> = {
     11155111: "Sepolia",
     97: "BSC Testnet",
+    56: "BSC Mainnet",
     1: "Ethereum Mainnet",
   };
   return names[chainId] ?? `Chain ${chainId}`;


### PR DESCRIPTION
## What

Devnet now attests BSC mainnet (chainId **56**) under **chain key 8**, so the USC audit automation gets the same liveness sanities we already run for Sepolia and Ethereum.

Confirmed on-chain from devnet `getSupportedChains()` before wiring anything up:

| chain key | chainId | name | maturity | att. interval | cp. interval |
| --- | --- | --- | --- | --- | --- |
| 8 | 56 | BSC | `FixedDelay: 5` | 100 | 10 |

(Chain key 5 is the older BSC *testnet* / chainId 97 entry, which no config references. Left alone.)

## Changes

- **`config-devnet.json`**: added the `{ chainId: 56, chainKey: 8 }` `ethRpc` entry, pointing at `https://bsc-rpc.publicnode.com`.
- **`src/config.ts`**: new `BSC_MAINNET_RPC_URL` override for chainId 56. Deliberately *not* reusing the existing `BSC_RPC_URL` secret: that one is mapped to chainId 97 and almost certainly points at a BSC testnet endpoint, so a mainnet check against it would fail the header-hash comparison.
- **`src/main.ts`**: `56: "BSC Mainnet"` in `getChainName`. More than cosmetic: `getMaxBlockDiff` widens the tolerance via `chainName.includes("BSC")`, so without this chainId 56 falls back to `"Chain 56"` and uses the tight formula max (305) instead of the BSC floor of 499.
- **`.github/workflows/audit-automation.yml`**: passes `BSC_MAINNET_RPC_URL` through to the job, and drops the `BSC_RPC_URL` line.
- Removed the **unused BSC testnet override** (`BSC_RPC_URL` / chainId 97). No config referenced chainId 97, so it was dead plumbing, and dropping the workflow line stops the job consuming a stale secret aimed at a testnet endpoint. `getChainName` still maps 97, since it is a free lookup and removing it would cost a future chainId 97 entry the BSC block-diff tolerance.
- **README / `--help`**: document the new override.

## RPC endpoint

The chainId 56 entry ships a public endpoint in the config, so **no new repo secret is needed** to land this. `BSC_MAINNET_RPC_URL` remains an override for moving the check onto a private provider later, with no code change.

A public endpoint is a fine fit here: roughly 4 JSON-RPC calls per run on a 12-hour cron, and the hashed block is only ~50 blocks deep (maturity `FixedDelay: 5` plus attestation lag), so no archive node is required. `checkRpcHealthy` already retries 3x with backoff for transient public-RPC flakes. If publicnode ever rate-limits the runner IPs it surfaces as `RPC unhealthy - skipped` in Slack, and cannot produce a false green.

## Verification

Ran against **live devnet**, with `BSC_MAINNET_RPC_URL` unset so the config default is what gets exercised. `deno lint`, `deno check` and `deno fmt` all clean. All three chains plus the balance checks pass:

```
🚦 Liveness Details: BSC Mainnet - 56 - 8 - FixedDelay: 5
✅ Attestation block heights diff: 115 (120,497,215|120,497,100|499)
✅ Attestation header hash matches correct Ethereum block
✅ Last checkpoint creation is within checkpoint range
✅ Last checkpoint number found in GraphQL
✅ Last attestation header number found in GraphQL
✅ Last attestation root found in GraphQL
✅ Last attestation digest found in GraphQL
```

## Note on proofgen

There is no proofgen-specific check in this tool for *any* chain (Sepolia and Ethereum included). The indexer side is covered only by the GraphQL comparison, which chain key 8 now gets too. If you want a real proof-gen `/health` or `/roots` sanity, that is a separate change and I would need to know which endpoint devnet serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
