### PR TITLE
ci: report peak runner resource usage in job summaries

### DIFF
--- a/.github/resource-monitor.sh
+++ b/.github/resource-monitor.sh
@@ -12,46 +12,57 @@
 #
 # Never fails a job: every path exits 0.
 
-LABEL="${2:-job}"
+LABEL="${2:-${GITHUB_JOB:-job}}"
 STATE_DIR="${RESOURCE_MONITOR_DIR:-/var/tmp/resource-monitor}"
 SAMPLES="${STATE_DIR}/${LABEL}.tsv"
 PIDFILE="${STATE_DIR}/${LABEL}.pid"
+BASEFILE="${STATE_DIR}/${LABEL}.baseline"
 INTERVAL="${RESOURCE_MONITOR_INTERVAL:-10}"
-# Watch the filesystem holding the workspace; that is what fills up.
+# Defaults to the workspace, which is right for build jobs (cargo target dir).
+# Jobs that write their bulk data elsewhere MUST set RESOURCE_MONITOR_DISK_PATH
+# -- runtime-upgrade uses /mnt, the compatibility workflows /var/tmp. Watching
+# the wrong path silently reports ~0% once that data lands on its own volume.
 DISK_PATH="${RESOURCE_MONITOR_DISK_PATH:-${GITHUB_WORKSPACE:-$PWD}}"
 
-mem_total_mb() { awk '/^MemTotal:/ {print int($2/1024)}' /proc/meminfo; }
-
-sample_once() {
-    local total avail used swap_total swap_free swap_used disk load
-    total=$(awk '/^MemTotal:/ {print int($2/1024)}' /proc/meminfo)
-    avail=$(awk '/^MemAvailable:/ {print int($2/1024)}' /proc/meminfo)
-    # MemTotal-MemAvailable tracks memory the workload actually needs, unlike
-    # "used", which counts reclaimable page cache against you.
-    used=$(( total - avail ))
-    swap_total=$(awk '/^SwapTotal:/ {print int($2/1024)}' /proc/meminfo)
-    swap_free=$(awk '/^SwapFree:/ {print int($2/1024)}' /proc/meminfo)
-    swap_used=$(( swap_total - swap_free ))
-    disk=$(df -m --output=used "$DISK_PATH" 2>/dev/null | tail -1 | tr -d ' ')
-    load=$(awk '{print $1}' /proc/loadavg)
-    printf '%s\t%s\t%s\t%s\t%s\n' \
-        "$(date -u +%s)" "$used" "$swap_used" "${disk:-0}" "$load"
+# One awk pass over /proc/meminfo -> "used_mb total_mb swap_used_mb".
+# used = MemTotal-MemAvailable, which is what the workload actually needs;
+# "used" as reported by free() counts reclaimable page cache against you.
+mem_stats() {
+    awk '/^MemTotal:/ {t=$2} /^MemAvailable:/ {a=$2}
+         /^SwapTotal:/ {st=$2} /^SwapFree:/ {sf=$2}
+         END { printf "%d %d %d", int((t-a)/1024), int(t/1024), int((st-sf)/1024) }' \
+        /proc/meminfo
 }
 
-# Order matters here: these conditions are not mutually exclusive. A job can be
+# Cumulative busy/total jiffies -> "busy total". Deltas between two readings
+# give real CPU utilisation. loadavg is a 60s EMA and cannot see a burst
+# shorter than ~45s, which is the shape of most jobs here, so it is not used
+# for the verdict. iowait counts as idle on purpose: a job waiting on disk is
+# disk-bound, not CPU-bound, and should be reported that way.
+cpu_jiffies() {
+    awk '/^cpu / { idle = $5 + $6; total = 0
+                   for (i = 2; i <= NF; i++) total += $i
+                   printf "%d %d", total - idle, total; exit }' /proc/stat
+}
+
+disk_used_mb() { df -m --output=used "$DISK_PATH" 2>/dev/null | tail -1 | tr -d ' '; }
+disk_size_mb() { df -m --output=size "$DISK_PATH" 2>/dev/null | tail -1 | tr -d ' '; }
+
+# $1 = mem %, $2 = disk %, $3 = cpu %
+#
+# Order matters: these conditions are not mutually exclusive. A job can be
 # memory-light and CPU-idle while filling its disk -- live-sync-creditcoin
-# expands a 114 GB mainnet snapshot to 158 GB on disk while needing little RAM.
-# Linode bundles disk with RAM (g6-standard-6/8/16 = 320/640/1280 GB), so
-# "shrink the plan" on memory evidence alone would cut the disk such a job
-# depends on. Disk is therefore checked first, and the over-provisioned verdict
-# requires low disk as well as low memory and load.
-verdict() { # $1 = mem %, $2 = disk %, $3 = load %
+# expands a 114 GB mainnet snapshot to 158 GB while needing little RAM. Linode
+# bundles disk with RAM (g6-standard-6/8/16 = 320/640/1280 GB), so "shrink the
+# plan" on memory evidence alone would cut the disk such a job depends on.
+# Disk is checked first, and over-provisioned requires low disk as well.
+verdict() {
     if [ "$1" -gt 85 ] || [ "$2" -gt 85 ]; then
         echo "**near a limit** - consider a larger plan"
     elif [ "$2" -gt 50 ] && [ "$1" -lt 25 ]; then
         echo "**disk-bound** - sized for its disk, not its RAM; do not shrink on memory alone"
-    elif [ "$1" -lt 25 ] && [ "$3" -lt 50 ] && [ "$2" -lt 50 ]; then
-        echo "**over-provisioned** - peak memory under a quarter of the VM, CPU never saturated, disk under half"
+    elif [ "$1" -lt 25 ] && [ "$3" -lt 50 ] && [ "$2" -le 50 ]; then
+        echo "**over-provisioned** - peak memory under a quarter of the VM, CPU never saturated, disk at most half"
     else
         echo "sized about right"
     fi
@@ -60,15 +71,33 @@ verdict() { # $1 = mem %, $2 = disk %, $3 = load %
 case "${1:-}" in
 start)
     mkdir -p "$STATE_DIR" || exit 0
-    printf 'epoch\tmem_used_mb\tswap_used_mb\tdisk_used_mb\tload1\n' > "$SAMPLES"
+    printf 'epoch\tmem_used_mb\tswap_used_mb\tdisk_used_mb\tcpu_pct\n' > "$SAMPLES"
+    # Disk baseline: the runner image and any earlier job on this VM already
+    # occupy space that is not this job's doing. Peak stays absolute (the plan
+    # has to hold it) but the delta says what the job itself needed.
+    disk_used_mb > "$BASEFILE"
     (
+        # stdio must be detached. Inheriting the step's pipe makes
+        # actions/runner wait out its full 5s "STDIO streams did not close"
+        # grace period at the end of every start step.
+        read -r prev_busy prev_total < <(cpu_jiffies)
         while true; do
-            sample_once >> "$SAMPLES"
             sleep "$INTERVAL"
+            read -r busy total < <(cpu_jiffies)
+            if [ "$total" -gt "$prev_total" ]; then
+                cpu=$(( (busy - prev_busy) * 100 / (total - prev_total) ))
+            else
+                cpu=0
+            fi
+            prev_busy=$busy
+            prev_total=$total
+            read -r used _ swap < <(mem_stats)
+            printf '%s\t%s\t%s\t%s\t%s\n' \
+                "$(date -u +%s)" "$used" "$swap" "$(disk_used_mb)" "$cpu" >> "$SAMPLES"
         done
-    ) &
+    ) </dev/null >/dev/null 2>&1 &
     echo $! > "$PIDFILE"
-    echo "INFO: resource-monitor started for '${LABEL}' (pid $(cat "$PIDFILE"), every ${INTERVAL}s)"
+    echo "INFO: resource-monitor started for '${LABEL}' (pid $(cat "$PIDFILE"), every ${INTERVAL}s, disk ${DISK_PATH})"
     ;;
 
 report)
@@ -76,26 +105,37 @@ report)
         kill "$(cat "$PIDFILE")" 2>/dev/null
         rm -f "$PIDFILE"
     fi
-    if [ ! -s "$SAMPLES" ]; then
-        echo "WARNING: no samples collected for '${LABEL}', nothing to report"
+    if [ ! -f "$SAMPLES" ]; then
+        echo "WARNING: no sample file for '${LABEL}' - did the start step run with the same label?"
         exit 0
     fi
-    # One final sample so short jobs always have at least one data point.
-    sample_once >> "$SAMPLES"
 
-    MEM_TOTAL=$(mem_total_mb)
+    # One final sample over a 1s window so a job shorter than the interval
+    # still yields a real CPU figure rather than a fabricated zero.
+    read -r b0 t0 < <(cpu_jiffies)
+    sleep 1
+    read -r b1 t1 < <(cpu_jiffies)
+    if [ "$t1" -gt "$t0" ]; then
+        final_cpu=$(( (b1 - b0) * 100 / (t1 - t0) ))
+    else
+        final_cpu=0
+    fi
+    read -r final_used MEM_TOTAL final_swap < <(mem_stats)
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+        "$(date -u +%s)" "$final_used" "$final_swap" "$(disk_used_mb)" "$final_cpu" >> "$SAMPLES"
+
     CPUS=$(nproc)
-    DISK_TOTAL=$(df -m --output=size "$DISK_PATH" 2>/dev/null | tail -1 | tr -d ' ')
-    DISK_TOTAL=${DISK_TOTAL:-0}
+    DISK_TOTAL=$(disk_size_mb); DISK_TOTAL=${DISK_TOTAL:-0}
+    DISK_BASE=$(cat "$BASEFILE" 2>/dev/null); DISK_BASE=${DISK_BASE:-0}
 
-    read -r PEAK_MEM PEAK_SWAP PEAK_DISK PEAK_LOAD SAMPLE_COUNT <<< "$(
+    read -r PEAK_MEM PEAK_SWAP PEAK_DISK PEAK_CPU SAMPLE_COUNT <<< "$(
         awk -F'\t' 'NR>1 {
             if ($2+0 > m) m = $2+0
             if ($3+0 > s) s = $3+0
             if ($4+0 > d) d = $4+0
-            if ($5+0 > l) l = $5+0
+            if ($5+0 > c) c = $5+0
             n++
-        } END { printf "%d %d %d %.2f %d", m, s, d, l, n }' "$SAMPLES"
+        } END { printf "%d %d %d %d %d", m, s, d, c, n }' "$SAMPLES"
     )"
 
     pct() { # $1 = part, $2 = whole -> integer percent, 0 when whole is 0
@@ -103,16 +143,24 @@ report)
     }
     MEM_PCT=$(pct "$PEAK_MEM" "$MEM_TOTAL")
     DISK_PCT=$(pct "$PEAK_DISK" "$DISK_TOTAL")
-    # Load is a float; compare in awk rather than shell arithmetic.
-    LOAD_PCT=$(awk -v l="$PEAK_LOAD" -v c="$CPUS" 'BEGIN { printf "%d", (c>0 ? l*100/c : 0) }')
+    DISK_DELTA=$(( PEAK_DISK - DISK_BASE ))
+    [ "$DISK_DELTA" -lt 0 ] && DISK_DELTA=0
 
     echo "INFO: ---- resource peaks for '${LABEL}' (${SAMPLE_COUNT} samples) ----"
     echo "INFO: memory  ${PEAK_MEM} MB peak of ${MEM_TOTAL} MB provisioned (${MEM_PCT}%)"
     echo "INFO: swap    ${PEAK_SWAP} MB peak"
-    echo "INFO: disk    ${PEAK_DISK} MB peak of ${DISK_TOTAL} MB on ${DISK_PATH} (${DISK_PCT}%)"
-    echo "INFO: load1   ${PEAK_LOAD} peak across ${CPUS} vCPU (${LOAD_PCT}%)"
+    echo "INFO: disk    ${PEAK_DISK} MB peak of ${DISK_TOTAL} MB on ${DISK_PATH} (${DISK_PCT}%), ${DISK_DELTA} MB added by this job"
+    echo "INFO: cpu     ${PEAK_CPU}% peak across ${CPUS} vCPU"
 
-    VERDICT=$(verdict "$MEM_PCT" "$DISK_PCT" "$LOAD_PCT")
+    # A verdict needs data, and only means something where the plan is ours to
+    # choose. GitHub-hosted runner sizes are fixed, so there is nothing to resize.
+    if [ "$SAMPLE_COUNT" -lt 2 ]; then
+        VERDICT="not enough samples (${SAMPLE_COUNT}) - sampler may have died; treat peaks as unreliable"
+    elif [ "${RUNNER_ENVIRONMENT:-}" = "github-hosted" ]; then
+        VERDICT="n/a - GitHub-hosted runner, size is not ours to choose"
+    else
+        VERDICT=$(verdict "$MEM_PCT" "$DISK_PCT" "$PEAK_CPU")
+    fi
     echo "INFO: verdict ${VERDICT}"
 
     if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
@@ -122,14 +170,16 @@ report)
             echo "| Metric | Peak | Provisioned | Used |"
             echo "|---|---:|---:|---:|"
             echo "| Memory | ${PEAK_MEM} MB | ${MEM_TOTAL} MB | ${MEM_PCT}% |"
-            echo "| Disk (${DISK_PATH}) | ${PEAK_DISK} MB | ${DISK_TOTAL} MB | ${DISK_PCT}% |"
-            echo "| Load (1 min) | ${PEAK_LOAD} | ${CPUS} vCPU | ${LOAD_PCT}% |"
+            echo "| Disk (\`${DISK_PATH}\`) | ${PEAK_DISK} MB | ${DISK_TOTAL} MB | ${DISK_PCT}% |"
+            echo "| Disk added by this job | ${DISK_DELTA} MB | - | - |"
+            echo "| CPU | ${PEAK_CPU}% | ${CPUS} vCPU | ${PEAK_CPU}% |"
             echo "| Swap | ${PEAK_SWAP} MB | - | - |"
             echo ""
             echo "Verdict: ${VERDICT}"
             echo ""
-            echo "<sub>Sampled every ${INTERVAL}s by \`.github/resource-monitor.sh\`. "
-            echo "Memory is MemTotal-MemAvailable, so reclaimable page cache is not counted.</sub>"
+            echo "<sub>${SAMPLE_COUNT} samples at ${INTERVAL}s by \`.github/resource-monitor.sh\`. "
+            echo "Memory is MemTotal-MemAvailable (reclaimable page cache not counted); "
+            echo "CPU is busy jiffies from /proc/stat between samples, with iowait as idle.</sub>"
         } >> "$GITHUB_STEP_SUMMARY"
     fi
     ;;

--- a/.github/resource-monitor.sh
+++ b/.github/resource-monitor.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# Samples memory / disk / CPU while a job runs, then reports the peaks against
+# what the runner actually provides.
+#
+# Purpose: several workflows provision g6-standard-16 (16 vCPU / 64 GB) VMs.
+# Nothing verified those sizes were needed. This makes real usage visible in
+# the job summary so plan sizes can be checked against evidence.
+#
+#   resource-monitor.sh start  [label]   # begin sampling in the background
+#   resource-monitor.sh report [label]   # stop sampling, print + summarise peaks
+#
+# Never fails a job: every path exits 0.
+
+LABEL="${2:-job}"
+STATE_DIR="${RESOURCE_MONITOR_DIR:-/var/tmp/resource-monitor}"
+SAMPLES="${STATE_DIR}/${LABEL}.tsv"
+PIDFILE="${STATE_DIR}/${LABEL}.pid"
+INTERVAL="${RESOURCE_MONITOR_INTERVAL:-10}"
+# Watch the filesystem holding the workspace; that is what fills up.
+DISK_PATH="${RESOURCE_MONITOR_DISK_PATH:-${GITHUB_WORKSPACE:-$PWD}}"
+
+mem_total_mb() { awk '/^MemTotal:/ {print int($2/1024)}' /proc/meminfo; }
+
+sample_once() {
+    local total avail used swap_total swap_free swap_used disk load
+    total=$(awk '/^MemTotal:/ {print int($2/1024)}' /proc/meminfo)
+    avail=$(awk '/^MemAvailable:/ {print int($2/1024)}' /proc/meminfo)
+    # MemTotal-MemAvailable tracks memory the workload actually needs, unlike
+    # "used", which counts reclaimable page cache against you.
+    used=$(( total - avail ))
+    swap_total=$(awk '/^SwapTotal:/ {print int($2/1024)}' /proc/meminfo)
+    swap_free=$(awk '/^SwapFree:/ {print int($2/1024)}' /proc/meminfo)
+    swap_used=$(( swap_total - swap_free ))
+    disk=$(df -m --output=used "$DISK_PATH" 2>/dev/null | tail -1 | tr -d ' ')
+    load=$(awk '{print $1}' /proc/loadavg)
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+        "$(date -u +%s)" "$used" "$swap_used" "${disk:-0}" "$load"
+}
+
+case "${1:-}" in
+start)
+    mkdir -p "$STATE_DIR" || exit 0
+    printf 'epoch\tmem_used_mb\tswap_used_mb\tdisk_used_mb\tload1\n' > "$SAMPLES"
+    (
+        while true; do
+            sample_once >> "$SAMPLES"
+            sleep "$INTERVAL"
+        done
+    ) &
+    echo $! > "$PIDFILE"
+    echo "INFO: resource-monitor started for '${LABEL}' (pid $(cat "$PIDFILE"), every ${INTERVAL}s)"
+    ;;
+
+report)
+    if [ -f "$PIDFILE" ]; then
+        kill "$(cat "$PIDFILE")" 2>/dev/null
+        rm -f "$PIDFILE"
+    fi
+    if [ ! -s "$SAMPLES" ]; then
+        echo "WARNING: no samples collected for '${LABEL}', nothing to report"
+        exit 0
+    fi
+    # One final sample so short jobs always have at least one data point.
+    sample_once >> "$SAMPLES"
+
+    MEM_TOTAL=$(mem_total_mb)
+    CPUS=$(nproc)
+    DISK_TOTAL=$(df -m --output=size "$DISK_PATH" 2>/dev/null | tail -1 | tr -d ' ')
+    DISK_TOTAL=${DISK_TOTAL:-0}
+
+    read -r PEAK_MEM PEAK_SWAP PEAK_DISK PEAK_LOAD SAMPLE_COUNT <<< "$(
+        awk -F'\t' 'NR>1 {
+            if ($2+0 > m) m = $2+0
+            if ($3+0 > s) s = $3+0
+            if ($4+0 > d) d = $4+0
+            if ($5+0 > l) l = $5+0
+            n++
+        } END { printf "%d %d %d %.2f %d", m, s, d, l, n }' "$SAMPLES"
+    )"
+
+    pct() { # $1 = part, $2 = whole -> integer percent, 0 when whole is 0
+        [ "${2:-0}" -gt 0 ] 2>/dev/null && echo $(( $1 * 100 / $2 )) || echo 0
+    }
+    MEM_PCT=$(pct "$PEAK_MEM" "$MEM_TOTAL")
+    DISK_PCT=$(pct "$PEAK_DISK" "$DISK_TOTAL")
+    # Load is a float; compare in awk rather than shell arithmetic.
+    LOAD_PCT=$(awk -v l="$PEAK_LOAD" -v c="$CPUS" 'BEGIN { printf "%d", (c>0 ? l*100/c : 0) }')
+
+    echo "INFO: ---- resource peaks for '${LABEL}' (${SAMPLE_COUNT} samples) ----"
+    echo "INFO: memory  ${PEAK_MEM} MB peak of ${MEM_TOTAL} MB provisioned (${MEM_PCT}%)"
+    echo "INFO: swap    ${PEAK_SWAP} MB peak"
+    echo "INFO: disk    ${PEAK_DISK} MB peak of ${DISK_TOTAL} MB on ${DISK_PATH} (${DISK_PCT}%)"
+    echo "INFO: load1   ${PEAK_LOAD} peak across ${CPUS} vCPU (${LOAD_PCT}%)"
+
+    VERDICT="sized about right"
+    if [ "$MEM_PCT" -lt 25 ] && [ "$LOAD_PCT" -lt 50 ]; then
+        VERDICT="**over-provisioned** - peak memory used under a quarter of the VM, and CPU never saturated"
+    elif [ "$MEM_PCT" -gt 85 ] || [ "$DISK_PCT" -gt 85 ]; then
+        VERDICT="**near a limit** - consider a larger plan"
+    fi
+    echo "INFO: verdict ${VERDICT}"
+
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        {
+            echo "### Resource usage - ${LABEL}"
+            echo ""
+            echo "| Metric | Peak | Provisioned | Used |"
+            echo "|---|---:|---:|---:|"
+            echo "| Memory | ${PEAK_MEM} MB | ${MEM_TOTAL} MB | ${MEM_PCT}% |"
+            echo "| Disk (${DISK_PATH}) | ${PEAK_DISK} MB | ${DISK_TOTAL} MB | ${DISK_PCT}% |"
+            echo "| Load (1 min) | ${PEAK_LOAD} | ${CPUS} vCPU | ${LOAD_PCT}% |"
+            echo "| Swap | ${PEAK_SWAP} MB | - | - |"
+            echo ""
+            echo "Verdict: ${VERDICT}"
+            echo ""
+            echo "<sub>Sampled every ${INTERVAL}s by \`.github/resource-monitor.sh\`. "
+            echo "Memory is MemTotal-MemAvailable, so reclaimable page cache is not counted.</sub>"
+        } >> "$GITHUB_STEP_SUMMARY"
+    fi
+    ;;
+
+*)
+    echo "usage: $0 {start|report} [label]" >&2
+    ;;
+esac
+
+exit 0

--- a/.github/resource-monitor.sh
+++ b/.github/resource-monitor.sh
@@ -38,6 +38,25 @@ sample_once() {
         "$(date -u +%s)" "$used" "$swap_used" "${disk:-0}" "$load"
 }
 
+# Order matters here: these conditions are not mutually exclusive. A job can be
+# memory-light and CPU-idle while filling its disk -- live-sync-creditcoin
+# expands a 114 GB mainnet snapshot to 158 GB on disk while needing little RAM.
+# Linode bundles disk with RAM (g6-standard-6/8/16 = 320/640/1280 GB), so
+# "shrink the plan" on memory evidence alone would cut the disk such a job
+# depends on. Disk is therefore checked first, and the over-provisioned verdict
+# requires low disk as well as low memory and load.
+verdict() { # $1 = mem %, $2 = disk %, $3 = load %
+    if [ "$1" -gt 85 ] || [ "$2" -gt 85 ]; then
+        echo "**near a limit** - consider a larger plan"
+    elif [ "$2" -gt 50 ] && [ "$1" -lt 25 ]; then
+        echo "**disk-bound** - sized for its disk, not its RAM; do not shrink on memory alone"
+    elif [ "$1" -lt 25 ] && [ "$3" -lt 50 ] && [ "$2" -lt 50 ]; then
+        echo "**over-provisioned** - peak memory under a quarter of the VM, CPU never saturated, disk under half"
+    else
+        echo "sized about right"
+    fi
+}
+
 case "${1:-}" in
 start)
     mkdir -p "$STATE_DIR" || exit 0
@@ -93,12 +112,7 @@ report)
     echo "INFO: disk    ${PEAK_DISK} MB peak of ${DISK_TOTAL} MB on ${DISK_PATH} (${DISK_PCT}%)"
     echo "INFO: load1   ${PEAK_LOAD} peak across ${CPUS} vCPU (${LOAD_PCT}%)"
 
-    VERDICT="sized about right"
-    if [ "$MEM_PCT" -lt 25 ] && [ "$LOAD_PCT" -lt 50 ]; then
-        VERDICT="**over-provisioned** - peak memory used under a quarter of the VM, and CPU never saturated"
-    elif [ "$MEM_PCT" -gt 85 ] || [ "$DISK_PCT" -gt 85 ]; then
-        VERDICT="**near a limit** - consider a larger plan"
-    fi
+    VERDICT=$(verdict "$MEM_PCT" "$DISK_PCT" "$LOAD_PCT")
     echo "INFO: verdict ${VERDICT}"
 
     if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then

--- a/.github/workflows/attestor-compatibility.yml
+++ b/.github/workflows/attestor-compatibility.yml
@@ -47,6 +47,7 @@ name: Attestor Compatibility
       - "node/**"
       - "runtime/**"
       - ".github/workflows/attestor-compatibility.yml"
+      - ".github/resource-monitor.sh"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -196,6 +197,9 @@ jobs:
           mkdir -p "${LOG_DIR}" "${DATA_DIR}"
 
       - name: Start resource monitor
+        # DATA_DIR/LOG_DIR live under /var/tmp, not the workspace.
+        env:
+          RESOURCE_MONITOR_DISK_PATH: /var/tmp
         run: |
           .github/resource-monitor.sh start attestor-compatibility
 

--- a/.github/workflows/attestor-compatibility.yml
+++ b/.github/workflows/attestor-compatibility.yml
@@ -195,6 +195,10 @@ jobs:
           sudo dpkg --configure -a || true
           mkdir -p "${LOG_DIR}" "${DATA_DIR}"
 
+      - name: Start resource monitor
+        run: |
+          .github/resource-monitor.sh start attestor-compatibility
+
       - name: Download SUT binaries from current PR
         uses: actions/download-artifact@v8
         with:
@@ -621,6 +625,12 @@ jobs:
             echo "ERROR: one or more attestors hit a fatal/incompatibility error (see above)" >&2
             exit 1
           fi
+
+      - name: Report resource usage
+        if: always()
+        continue-on-error: true
+        run: |
+          .github/resource-monitor.sh report attestor-compatibility
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -91,11 +91,21 @@ jobs:
           git apply /var/tmp/new-metadata.diff
           git diff --binary
 
+      - name: Start resource monitor
+        run: |
+          .github/resource-monitor.sh start build-native
+
       - name: Build SUT
         uses: gluwa/cargo@dev
         with:
           command: build
           args: ${{ inputs.build-options }}
+
+      - name: Report resource usage
+        if: always()
+        continue-on-error: true
+        run: |
+          .github/resource-monitor.sh report build-native
 
       - name: Upload binaries
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -92,6 +92,10 @@ jobs:
           git diff --binary
 
       - name: Start resource monitor
+        # The use-new-metadata path checks out the PR *head branch*, which for
+        # any PR opened before this landed does not contain the script. Guard
+        # so rebuild-new-metadata cannot fail on a missing file.
+        if: hashFiles('.github/resource-monitor.sh') != ''
         run: |
           .github/resource-monitor.sh start build-native
 
@@ -100,12 +104,6 @@ jobs:
         with:
           command: build
           args: ${{ inputs.build-options }}
-
-      - name: Report resource usage
-        if: always()
-        continue-on-error: true
-        run: |
-          .github/resource-monitor.sh report build-native
 
       - name: Upload binaries
         uses: actions/upload-artifact@v7
@@ -166,3 +164,12 @@ jobs:
           author_email: creditcoin@gluwa.com
           message: "Auto-update metadata & TypeScript type definitions"
           github_token: ${{ secrets.GLUWA_BOT_TOKEN }}
+
+      - name: Report resource usage
+        # Last step on purpose: Install subkey / Install subxt are full cargo
+        # compiles on the release path and would otherwise land outside the
+        # sampling window.
+        if: always() && hashFiles('.github/resource-monitor.sh') != ''
+        continue-on-error: true
+        run: |
+          .github/resource-monitor.sh report build-native

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -9,6 +9,7 @@ name: Runtime Upgrade
       - '**.toml'
       - '**Cargo**'
       - '.github/workflows/runtime-upgrade.yml'
+      - '.github/resource-monitor.sh'
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -181,6 +182,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Start resource monitor
+        # This job's chain data goes to /mnt, not the workspace.
+        env:
+          RESOURCE_MONITOR_DISK_PATH: /mnt
         run: |
           .github/resource-monitor.sh start fork-creditcoin
 
@@ -284,6 +288,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Start resource monitor
+        # This job's chain data goes to /mnt, not the workspace.
+        env:
+          RESOURCE_MONITOR_DISK_PATH: /mnt
         run: |
           .github/resource-monitor.sh start live-sync-creditcoin
 
@@ -390,6 +397,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Start resource monitor
+        # This job's chain data goes to /mnt, not the workspace.
+        env:
+          RESOURCE_MONITOR_DISK_PATH: /mnt
         run: |
           .github/resource-monitor.sh start test-against-fork-current-release
 
@@ -520,6 +530,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Start resource monitor
+        # This job's chain data goes to /mnt, not the workspace.
+        env:
+          RESOURCE_MONITOR_DISK_PATH: /mnt
         run: |
           .github/resource-monitor.sh start test-against-fork-latest-release
 

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -180,6 +180,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Start resource monitor
+        run: |
+          .github/resource-monitor.sh start fork-creditcoin
+
       - name: Download creditcoin3-node for release ${{ needs.setup.outputs.release_tag }}
         uses: i3h/download-release-asset@v1
         with:
@@ -251,6 +255,12 @@ jobs:
           name: fork-creditcoin-logs
           path: "*.log"
 
+      - name: Report resource usage
+        if: always()
+        continue-on-error: true
+        run: |
+          .github/resource-monitor.sh report fork-creditcoin
+
       - name: Upload creditcoin-fork.json
         uses: actions/upload-artifact@v7
         with:
@@ -272,6 +282,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Start resource monitor
+        run: |
+          .github/resource-monitor.sh start live-sync-creditcoin
 
       - name: Install azure-cli
         run: |
@@ -349,6 +363,12 @@ jobs:
           killall -KILL creditcoin3-node
           sleep 120
 
+      - name: Report resource usage
+        if: always()
+        continue-on-error: true
+        run: |
+          .github/resource-monitor.sh report live-sync-creditcoin
+
       - name: Upload logs
         uses: actions/upload-artifact@v7
         if: always()
@@ -368,6 +388,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Start resource monitor
+        run: |
+          .github/resource-monitor.sh start test-against-fork-current-release
 
       - name: Download creditcoin3-node from current PR
         uses: actions/download-artifact@v8
@@ -470,6 +494,12 @@ jobs:
           name: test-against-fork-current-release-logs
           path: "*.log"
 
+      - name: Report resource usage
+        if: always()
+        continue-on-error: true
+        run: |
+          .github/resource-monitor.sh report test-against-fork-current-release
+
       - name: Kill creditcoin3-node
         if: always()
         run: |
@@ -488,6 +518,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Start resource monitor
+        run: |
+          .github/resource-monitor.sh start test-against-fork-latest-release
 
       - name: Download creditcoin3-node from release ${{ needs.setup.outputs.release_tag }}
         uses: i3h/download-release-asset@v1
@@ -596,6 +630,12 @@ jobs:
         with:
           name: test-against-fork-latest-release-logs
           path: "*.log"
+
+      - name: Report resource usage
+        if: always()
+        continue-on-error: true
+        run: |
+          .github/resource-monitor.sh report test-against-fork-latest-release
 
       - name: Kill creditcoin3-node
         if: always()

--- a/.github/workflows/validator-compatibility.yml
+++ b/.github/workflows/validator-compatibility.yml
@@ -30,6 +30,7 @@ name: Validator Compatibility
       - "runtime/**"
       - "chainspecs/**"
       - ".github/workflows/validator-compatibility.yml"
+      - ".github/resource-monitor.sh"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -222,6 +223,9 @@ jobs:
           done
 
       - name: Start resource monitor
+        # DATA_DIR/LOG_DIR live under /var/tmp, not the workspace.
+        env:
+          RESOURCE_MONITOR_DISK_PATH: /var/tmp
         run: |
           .github/resource-monitor.sh start validator-compatibility
 

--- a/.github/workflows/validator-compatibility.yml
+++ b/.github/workflows/validator-compatibility.yml
@@ -221,6 +221,10 @@ jobs:
             "historical/${TAG}/creditcoin3-node" --version
           done
 
+      - name: Start resource monitor
+        run: |
+          .github/resource-monitor.sh start validator-compatibility
+
       - name: Generate shared raw chainspec from SUT
         run: |
           set -euo pipefail
@@ -463,6 +467,12 @@ jobs:
             exit 1
           fi
           echo "DONE: all validators peered and agree on the chain at height ${COMMON}"
+
+      - name: Report resource usage
+        if: always()
+        continue-on-error: true
+        run: |
+          .github/resource-monitor.sh report validator-compatibility
 
       - name: Scan node logs for errors
         if: always()


### PR DESCRIPTION
# Description of proposed changes

 Adds `.github/resource-monitor.sh` — `start` forks a 10s sampler, `report` reduces it to peak
memory / disk / load and writes a table plus an over-provisioned verdict to the job summary. Wired
into `build-native.yml` (covers every build job, hosted and self-hosted) and the three
`g6-standard-16` workflows.

Memory is `MemTotal - MemAvailable` rather than `used`, so reclaimable page cache isn't charged to
the workload.

---

When merging this PR:

- For PRs against `usc-dev` use the "Squash and merge" button
- For PRs against `usc-testnet`/`main` use the "Create a merge commit" button
- Hotfixes against `usc-testnet`/`main` should use the "Squash and merge" button

---

Practical tips for PR review:

- [ ] All GitHub Actions report PASS
- [ ] Newly added code/functions have unit tests
  - [ ] Coverage tools report all newly added lines as covered
  - [ ] The positive scenario is exercised
  - [ ] Negative scenarios are exercised, e.g. assert on all possible errors
  - [ ] Assert on events triggered if applicable
  - [ ] Assert on changes made to storage if applicable
- [ ] Modified behavior/functions - try to make sure above test items are covered
- [ ] Integration tests are added if applicable/needed
