### PR TITLE
feat(usc-messaging): generic per-chain usc-dev deploy scripts (register chain, dest stack, source stack with RelayerContractLite)

### DIFF
--- a/usc-messaging/scripts/deploy-dest-chain-devnet.mts
+++ b/usc-messaging/scripts/deploy-dest-chain-devnet.mts
@@ -1,0 +1,159 @@
+// usc-dev: deploy the DESTINATION-chain write-ability stack for a newly registered chain key
+// (e.g. Base Sepolia, chain id 84532) — AttestorRegistry, EOAValidator, MockDestination, Inbox.
+//
+// Step 2 of 3 when adding a destination chain to usc-devnet (Creditcoin EVM chain id 42):
+//   1. register-chain-devnet.mjs        — pallet side, assigns CHAIN_KEY
+//   2. deploy-dest-chain-devnet.mts     (this)
+//   3. deploy-source-chain-devnet.mts   — Creditcoin: per-chain Outbox / vault / RelayerContractLite,
+//                                         then allowlists that Outbox on the Inbox deployed here.
+//
+// On-chain calls (destination chain, DEPLOYER_KEY):
+//   AttestorRegistry(owner, INITIAL_ATTESTORS)
+//   EOAValidator(owner, registry, MIN_ATTESTOR_COUNT, THRESHOLD_NUMERATOR, THRESHOLD_ADDITION)
+//   MockDestination()                                        // Inbox needs a dispatcher WITH code
+//   Inbox(bytes32(CHAIN_KEY), 42, validator, mockDestination, owner, [] /* initialOutboxes */)
+//   AttestorRegistry.setUpdater(validator, true)             // lets submitAttestorSetUpdate rotate the set
+//
+// The registry cannot start empty: EOAValidator's constructor reverts "below minimum" unless the
+// registry already holds >= MIN_ATTESTOR_COUNT attestors, so INITIAL_ATTESTORS defaults to the
+// three placeholder addresses the anvil e2e uses. The owner must replace them with the real
+// attestor EVM addresses (AttestorRegistry.updateAttestorSet) before any delivery is attempted.
+//
+// Records chains.<CHAIN_KEY>.dest in the deploy JSON (rpc stored WITHOUT path/query, i.e. no API key).
+//
+// Env:
+//   CHAIN_KEY             chain key assigned by register-chain-devnet.mjs   (required)
+//   DEST_RPC              destination-chain JSON-RPC URL                     (required)
+//   DEST_CHAIN_ID         destination EVM chain id, e.g. 84532               (required)
+//   DEPLOYER_KEY          destination-chain deployer, needs native gas       (required)
+//   INITIAL_ATTESTORS     comma-separated EVM addresses (default: 3 placeholders, see above)
+//   MIN_ATTESTOR_COUNT / THRESHOLD_NUMERATOR / THRESHOLD_ADDITION   default 3 / 20 / 1
+//   ASC_CONTRACTS_DIR     compiled asc-contracts checkout (main c83b3372+)
+//   DEPLOY_OUT            default ../usc-dev-deploy.json
+//
+// Keys used here are DEVNET-ONLY. Never point this at testnet/mainnet.
+import { ethers } from "ethers";
+import { readFileSync, writeFileSync } from "node:fs";
+
+function ascContractsDir(): string {
+  const dir = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR;
+  if (!dir) throw new Error("set ASC_CONTRACTS_DIR to a compiled asc-contracts checkout (main c83b3372+, `npx hardhat compile`)");
+  return dir;
+}
+const UC = ascContractsDir();
+const ART = (p: string, n: string) => JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
+const OUT = process.env.DEPLOY_OUT ?? new URL("../usc-dev-deploy.json", import.meta.url).pathname;
+
+const need = (k: string): string => {
+  const v = process.env[k];
+  if (!v) throw new Error(`missing ${k}`);
+  return v;
+};
+const uint = (k: string, dflt?: number): number => {
+  const v = process.env[k] ?? (dflt !== undefined ? String(dflt) : undefined);
+  if (v === undefined) throw new Error(`missing ${k}`);
+  if (!/^\d+$/.test(v)) throw new Error(`${k} must be a non-negative integer, got "${v}"`);
+  return Number(v);
+};
+
+const CHAIN_KEY = uint("CHAIN_KEY");
+const DEST_CHAIN_ID = uint("DEST_CHAIN_ID");
+const DEST_RPC = need("DEST_RPC");
+const DEPLOYER_KEY = need("DEPLOYER_KEY");
+const MIN_ATTESTOR_COUNT = uint("MIN_ATTESTOR_COUNT", 3);
+const THRESHOLD_NUMERATOR = uint("THRESHOLD_NUMERATOR", 20);
+const THRESHOLD_ADDITION = uint("THRESHOLD_ADDITION", 1);
+const CREDITCOIN_CHAIN_ID = 42;
+const MIN_NATIVE = ethers.parseEther("0.02");
+if (CHAIN_KEY === 0) throw new Error("CHAIN_KEY must be > 0 (Inbox rejects bytes32(0))");
+
+// Same placeholders as deploy-dest-ethers.mts; wiped by the owner via updateAttestorSet later.
+const INITIAL_ATTESTORS = (process.env.INITIAL_ATTESTORS
+  ? process.env.INITIAL_ATTESTORS.split(",").map((a) => a.trim()).filter(Boolean)
+  : ["0x0000000000000000000000000000000000000001", "0x0000000000000000000000000000000000000002", "0x0000000000000000000000000000000000000003"]
+).map((a) => ethers.getAddress(a));
+if (new Set(INITIAL_ATTESTORS.map((a) => a.toLowerCase())).size !== INITIAL_ATTESTORS.length) throw new Error("INITIAL_ATTESTORS has duplicates");
+if (INITIAL_ATTESTORS.length < MIN_ATTESTOR_COUNT) {
+  throw new Error(`INITIAL_ATTESTORS has ${INITIAL_ATTESTORS.length} entries; EOAValidator needs >= MIN_ATTESTOR_COUNT (${MIN_ATTESTOR_COUNT}) in the registry at construction`);
+}
+
+// localChainKey = chain_key_to_bytes32(CHAIN_KEY): value in the low 8 bytes (matches the Rust encoder).
+const LOCAL_CHAIN_KEY = ethers.zeroPadValue(ethers.toBeHex(CHAIN_KEY), 32);
+// Persist the RPC without path/query so an embedded provider API key never lands in git.
+const rpcForRecord = new URL(DEST_RPC).origin;
+
+const deployJson = JSON.parse(readFileSync(OUT, "utf8"));
+deployJson.chains ??= {};
+const entry = deployJson.chains[String(CHAIN_KEY)];
+if (!entry) throw new Error(`no chains.${CHAIN_KEY} in ${OUT} — run register-chain-devnet.mjs first`);
+if (entry.destChainId !== undefined && Number(entry.destChainId) !== DEST_CHAIN_ID) {
+  throw new Error(`chains.${CHAIN_KEY}.destChainId is ${entry.destChainId}, but DEST_CHAIN_ID=${DEST_CHAIN_ID}`);
+}
+if (entry.dest?.inbox) {
+  throw new Error(`chains.${CHAIN_KEY}.dest.inbox is already ${entry.dest.inbox}; refusing to redeploy (remove the entry to force)`);
+}
+
+const provider = new ethers.JsonRpcProvider(DEST_RPC, DEST_CHAIN_ID, { staticNetwork: true });
+const wallet = new ethers.Wallet(DEPLOYER_KEY, provider);
+const owner = wallet.address;
+
+// staticNetwork skips the handshake, so confirm we are really on DEST_CHAIN_ID before spending gas.
+const liveChainId = Number(BigInt(await provider.send("eth_chainId", [])));
+if (liveChainId !== DEST_CHAIN_ID) throw new Error(`${rpcForRecord} reports chain id ${liveChainId}, expected DEST_CHAIN_ID=${DEST_CHAIN_ID}`);
+
+const balance: bigint = await provider.getBalance(owner);
+console.log(`deployer ${owner}  balance ${ethers.formatEther(balance)} native  nonce ${await wallet.getNonce()}  chain ${DEST_CHAIN_ID} (${rpcForRecord})`);
+if (balance < MIN_NATIVE) throw new Error(`deployer has ${ethers.formatEther(balance)} native, needs at least ${ethers.formatEther(MIN_NATIVE)}`);
+console.log(`chain key ${CHAIN_KEY} → localChainKey ${LOCAL_CHAIN_KEY}; initial attestors: ${INITIAL_ATTESTORS.join(", ")}`);
+
+async function deploy(name: string, art: any, args: any[] = []) {
+  const c = await new ethers.ContractFactory(art.abi, art.bytecode, wallet).deploy(...args);
+  await c.waitForDeployment();
+  console.log(`  ${name} → ${await c.getAddress()}`);
+  return c;
+}
+
+const registry = await deploy("AttestorRegistry", ART("write-ability/AttestorRegistry.sol", "AttestorRegistry"), [owner, INITIAL_ATTESTORS]);
+const registryAddr = await registry.getAddress();
+// 2/3 + 1 quorum (numerator 20 / THRESHOLD_DENOMINATOR 30, addition 1), minAttestorCount at the floor.
+const validator = await deploy("EOAValidator", ART("write-ability/EOAValidator.sol", "EOAValidator"),
+  [owner, registryAddr, MIN_ATTESTOR_COUNT, THRESHOLD_NUMERATOR, THRESHOLD_ADDITION]);
+const validatorAddr = await validator.getAddress();
+// Inbox requires messageDispatcher to already have code, so the dApp goes first.
+const dapp = await deploy("MockDestination", ART("mocks/TestMocks.sol", "MockDestination"));
+const dappAddr = await dapp.getAddress();
+// asc-contracts #48: six-arg constructor; initialOutboxes stays empty — the Outbox only exists after
+// deploy-source-chain-devnet, which allowlists it via setSupportedOutbox.
+const inbox = await deploy("Inbox", ART("write-ability/Inbox.sol", "Inbox"),
+  [LOCAL_CHAIN_KEY, CREDITCOIN_CHAIN_ID, validatorAddr, dappAddr, owner, []]);
+const inboxAddr = await inbox.getAddress();
+
+// Same as asc-contracts scripts/hardhat/deployWriteAbility.ts: the validator's
+// submitAttestorSetUpdate writes through to the registry, so it must be an authorised updater.
+const registryC = registry as unknown as ethers.Contract;
+if (!(await registryC.isUpdater(validatorAddr))) {
+  await (await registryC.setUpdater(validatorAddr, true)).wait();
+  console.log("  AttestorRegistry.setUpdater(EOAValidator, true)");
+} else console.log("  AttestorRegistry already has EOAValidator as updater");
+
+// Read-back sanity.
+const inboxC = inbox as unknown as ethers.Contract;
+if ((await inboxC.localChainKey()).toLowerCase() !== LOCAL_CHAIN_KEY.toLowerCase()) throw new Error("Inbox.localChainKey() mismatch");
+if (Number(await inboxC.creditcoinChainId()) !== CREDITCOIN_CHAIN_ID) throw new Error("Inbox.creditcoinChainId() != 42");
+if ((await inboxC.defaultVoteValidator()).toLowerCase() !== validatorAddr.toLowerCase()) throw new Error("Inbox.defaultVoteValidator() mismatch");
+
+deployJson.chains[String(CHAIN_KEY)] = {
+  ...entry,
+  dest: {
+    chainId: DEST_CHAIN_ID, rpc: rpcForRecord, chainKey: CHAIN_KEY,
+    creditcoinChainId: CREDITCOIN_CHAIN_ID, localChainKey: LOCAL_CHAIN_KEY,
+    voteValidator: validatorAddr, attestorRegistry: registryAddr,
+    inbox: inboxAddr, dapp: dappAddr, admin: owner,
+    initialAttestors: INITIAL_ATTESTORS, deployedAt: new Date().toISOString(),
+  },
+};
+writeFileSync(OUT, JSON.stringify(deployJson, null, 2) + "\n");
+console.log(`✅ dest stack for chain key ${CHAIN_KEY} deployed → chains.${CHAIN_KEY}.dest in ${OUT}`);
+console.log(`   Inbox ${inboxAddr} has NO supported Outbox yet; deploy-source-chain-devnet.mts allowlists it.`);
+console.log(`   Replace the placeholder attestors: AttestorRegistry(${registryAddr}).updateAttestorSet([...]) as ${owner}.`);
+process.exit(0);

--- a/usc-messaging/scripts/deploy-source-chain-devnet.mts
+++ b/usc-messaging/scripts/deploy-source-chain-devnet.mts
@@ -1,0 +1,262 @@
+// usc-dev: deploy the CREDITCOIN-side per-chain write-ability stack for a newly registered chain
+// key (Outbox, AttestorVault, RelayerFeeVault, RelayerContractLite, AcknowledgmentValidator) and
+// wire it into the SHARED contracts already recorded under `source.*` of usc-dev-deploy.json.
+//
+// Step 3 of 3 when adding a destination chain to usc-devnet (Creditcoin EVM chain id 42):
+//   1. register-chain-devnet.mjs        — pallet side, assigns CHAIN_KEY
+//   2. deploy-dest-chain-devnet.mts     — destination chain: AttestorRegistry, EOAValidator, Inbox
+//   3. deploy-source-chain-devnet.mts   (this)
+//
+// Shared (reused, from source.*): attest, proofVerifier, deliveryDecoder, factory (OutboxFactory),
+// feeRegistry, attestorRegistry, chainRegistry, outboxDiscovery. NOT deployed: legacy
+// RelayerContract, TWAPReader, ASCRelayingQuoter (the quoter is off-chain since 2026-09-04).
+//
+// On-chain calls (Creditcoin, DEPLOYER_KEY = owner of the shared contracts):
+//   predict: vault = CREATE(nonce n), feeVault = n+1, lite = n+2,
+//            outbox = factory.computeOutboxAddressFor(owner, CHAIN_KEY, owner, owner, 0, vault, feeRegistry, attest)
+//   AttestorVault(owner, attest, outbox, lite, owner /*validationContract placeholder*/, attestorRegistry, DEAD, 0)
+//   RelayerFeeVault(attest, lite)
+//   RelayerContractLite(owner, attest, outbox, proofVerifier, deliveryDecoder)
+//   factory.deployOutbox(CHAIN_KEY, owner, owner, 0, vault, feeRegistry, attest)   → OutboxCreated
+//   outbox.setTrustedForwarder(lite, true)
+//   AcknowledgmentValidator(CHAIN_KEY, owner, proofVerifier, attest)
+//   outbox.setValidator(ack); ack.setOutbox(outbox); ack.updateTrustedInbox(destInbox, true)
+//   lite.setRelayerFeeVault(feeVault); lite.setDestinationEvmChainId(CHAIN_KEY, DEST_CHAIN_ID)
+//   lite.setAuthorizedQuoter(QUOTER_EOA, true)                       (only when QUOTER_EOA is set)
+//   deliveryDecoder.setTrustedInbox(DEST_CHAIN_ID, destInbox)
+//   chainRegistry.setChain(CHAIN_KEY, DEST_CHAIN_ID)
+//   outboxDiscovery.registerOutbox(CHAIN_KEY, outbox)                → defaultOutbox(CHAIN_KEY)
+// then on the destination chain (DEST_RPC, DEST_ADMIN_KEY = Inbox owner):
+//   Inbox.setSupportedOutbox(outbox, true)                           → isSupportedOutbox
+// Every wiring step reads its getter first and is skipped when already in place. If
+// chains.<CHAIN_KEY>.source.outbox already exists, nothing is redeployed and only the wiring is
+// re-checked, so the script can be re-run after a partial failure.
+//
+// Env:
+//   CHAIN_KEY          chain key from register-chain-devnet.mjs                   (required)
+//   DEST_CHAIN_ID      destination EVM chain id (default: chains.<CHAIN_KEY>.dest.chainId)
+//   DEPLOYER_KEY       Creditcoin deployer / owner of the shared contracts         (required)
+//   DEST_RPC           destination-chain JSON-RPC URL                              (required)
+//   DEST_ADMIN_KEY     owner of the destination Inbox (chains.<CHAIN_KEY>.dest.admin) (required)
+//   QUOTER_EOA         optional; unset = no quoter authorised on the new Lite
+//   CC_RPC             default source.rpc / https://rpc.usc-devnet.creditcoin.network
+//   ASC_CONTRACTS_DIR  compiled asc-contracts checkout (main c83b3372+)
+//   DEPLOY_OUT         default ../usc-dev-deploy.json
+//
+// Keys used here are DEVNET-ONLY. Never point this at testnet/mainnet.
+import { ethers } from "ethers";
+import { readFileSync, writeFileSync } from "node:fs";
+
+function ascContractsDir(): string {
+  const dir = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR;
+  if (!dir) throw new Error("set ASC_CONTRACTS_DIR to a compiled asc-contracts checkout (main c83b3372+, `npx hardhat compile`)");
+  return dir;
+}
+const UC = ascContractsDir();
+const ART = (p: string, n: string) => JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
+const OUT = process.env.DEPLOY_OUT ?? new URL("../usc-dev-deploy.json", import.meta.url).pathname;
+const DEAD = "0x000000000000000000000000000000000000dEaD";
+const CC_CHAIN_ID = 42;
+const RATE = 0n; // Outbox defaultRateLimit (uint128)
+
+const need = (k: string): string => {
+  const v = process.env[k];
+  if (!v) throw new Error(`missing ${k}`);
+  return v;
+};
+const CHAIN_KEY = Number(need("CHAIN_KEY"));
+if (!Number.isInteger(CHAIN_KEY) || CHAIN_KEY <= 0 || CHAIN_KEY > 0xffff) throw new Error("CHAIN_KEY must be an integer in 1..65535 (ChainRegistry limit)");
+const DEPLOYER_KEY = need("DEPLOYER_KEY");
+const DEST_RPC = need("DEST_RPC");
+const DEST_ADMIN_KEY = need("DEST_ADMIN_KEY");
+const QUOTER_EOA = process.env.QUOTER_EOA ? ethers.getAddress(process.env.QUOTER_EOA) : null;
+
+const deployJson = JSON.parse(readFileSync(OUT, "utf8"));
+const s = deployJson.source ?? {};
+for (const k of ["attest", "proofVerifier", "deliveryDecoder", "factory", "feeRegistry", "attestorRegistry", "chainRegistry", "outboxDiscovery"]) {
+  if (!s[k]) throw new Error(`source.${k} missing in ${OUT} — the shared stack must be deployed first (deploy-source-devnet / deploy-discovery-devnet)`);
+}
+deployJson.chains ??= {};
+const entry = deployJson.chains[String(CHAIN_KEY)];
+if (!entry?.dest?.inbox) throw new Error(`no chains.${CHAIN_KEY}.dest.inbox in ${OUT} — run deploy-dest-chain-devnet first`);
+const destInbox: string = ethers.getAddress(entry.dest.inbox);
+const DEST_CHAIN_ID = Number(process.env.DEST_CHAIN_ID ?? entry.dest.chainId ?? entry.destChainId);
+if (!Number.isInteger(DEST_CHAIN_ID) || DEST_CHAIN_ID <= 0) throw new Error("DEST_CHAIN_ID unset and not recorded under chains.<CHAIN_KEY>.dest");
+if (entry.dest.chainId !== undefined && Number(entry.dest.chainId) !== DEST_CHAIN_ID) {
+  throw new Error(`chains.${CHAIN_KEY}.dest.chainId is ${entry.dest.chainId}, but DEST_CHAIN_ID=${DEST_CHAIN_ID}`);
+}
+const existing = entry.source ?? null;
+
+const rpc = process.env.CC_RPC ?? s.rpc ?? "https://rpc.usc-devnet.creditcoin.network";
+const provider = new ethers.JsonRpcProvider(rpc, CC_CHAIN_ID, { staticNetwork: true, polling: true });
+provider.pollingInterval = 1000;
+const wallet = new ethers.Wallet(DEPLOYER_KEY, provider);
+const owner = wallet.address;
+const lc = (a: string) => a.toLowerCase();
+const same = (a: string, b: string) => lc(a) === lc(b);
+
+async function deploy(name: string, art: any, args: any[] = []) {
+  const c = await new ethers.ContractFactory(art.abi, art.bytecode, wallet).deploy(...args);
+  await c.waitForDeployment();
+  console.log(`  ${name} → ${await c.getAddress()}`);
+  return c;
+}
+const at = (addr: string, art: any, signer: ethers.Signer | ethers.Provider = wallet) => new ethers.Contract(addr, art.abi, signer);
+
+const factoryArt = ART("write-ability/deployer/OutboxFactory.sol", "OutboxFactory");
+const outboxArt = ART("write-ability/Outbox.sol", "Outbox");
+const vaultArt = ART("write-ability/AttestorVault.sol", "AttestorVault");
+const feeVaultArt = ART("write-ability/RelayerFeeVault.sol", "RelayerFeeVault");
+const liteArt = ART("write-ability/RelayerContractLite.sol", "RelayerContractLite");
+const ackArt = ART("write-ability/AcknowledgementValidator.sol", "AcknowledgmentValidator"); // file vs contract spelling differ
+const decoderArt = ART("write-ability/common/EVMDeliveryDecoder.sol", "EVMDeliveryDecoder");
+const chainRegistryArt = ART("write-ability/deployer/ChainRegistry.sol", "ChainRegistry");
+const discoveryArt = ART("write-ability/deployer/OutboxDiscovery.sol", "OutboxDiscovery");
+const inboxArt = ART("write-ability/Inbox.sol", "Inbox");
+
+const factory = at(s.factory, factoryArt);
+const decoder = at(s.deliveryDecoder, decoderArt);
+const chainRegistry = at(s.chainRegistry, chainRegistryArt);
+const discovery = at(s.outboxDiscovery, discoveryArt);
+
+console.log(`deployer ${owner}  balance ${ethers.formatEther(await provider.getBalance(owner))} CTC  nonce ${await wallet.getNonce()}`);
+console.log(`chain key ${CHAIN_KEY} → dest chain ${DEST_CHAIN_ID}, Inbox ${destInbox}${existing ? " (source stack already recorded — wiring only)" : ""}`);
+
+// The shared contracts we mutate must be ours or every setter below reverts.
+for (const [name, c] of [["EVMDeliveryDecoder", decoder], ["ChainRegistry", chainRegistry], ["OutboxDiscovery", discovery]] as const) {
+  const o: string = await c.owner();
+  if (!same(o, owner)) throw new Error(`${name} owner is ${o}, not the deployer ${owner}`);
+}
+// A different chain key already mapped to this destination chain id would be silently unmapped by setChain.
+const priorKey = Number(await chainRegistry.chainKeyOf(DEST_CHAIN_ID));
+if (priorKey !== 0 && priorKey !== CHAIN_KEY) throw new Error(`ChainRegistry already maps chain id ${DEST_CHAIN_ID} to chain key ${priorKey}; refusing to steal it for ${CHAIN_KEY}`);
+
+// ---------------------------------------------------------------------------------------------
+// 1. Per-chain deploy (skipped when chains.<CHAIN_KEY>.source is recorded).
+// ---------------------------------------------------------------------------------------------
+let vaultAddr: string, feeVaultAddr: string, liteAddr: string, outboxAddr: string, ackAddr: string;
+if (existing) {
+  ({ attestorVault: vaultAddr, relayerFeeVault: feeVaultAddr, relayerContract: liteAddr, outbox: outboxAddr, ackValidator: ackAddr } = existing);
+  for (const [k, v] of Object.entries({ vaultAddr, feeVaultAddr, liteAddr, outboxAddr, ackAddr })) if (!v) throw new Error(`chains.${CHAIN_KEY}.source is incomplete (${k}); delete it to redeploy`);
+  if ((existing.relayerContractKind ?? "RelayerContractLite") !== "RelayerContractLite") throw new Error(`chains.${CHAIN_KEY}.source.relayerContractKind is ${existing.relayerContractKind}; this script only wires RelayerContractLite`);
+} else {
+  // vault (nonce n), feeVault (n+1), lite (n+2); Outbox via CREATE2 — resolves the ctor circularity.
+  const n = await wallet.getNonce();
+  const predict = (k: number) => ethers.getCreateAddress({ from: owner, nonce: n + k });
+  [vaultAddr, feeVaultAddr, liteAddr] = [predict(0), predict(1), predict(2)];
+  outboxAddr = await factory.computeOutboxAddressFor(owner, CHAIN_KEY, owner, owner, RATE, vaultAddr, s.feeRegistry, s.attest);
+  if ((await provider.getCode(outboxAddr)) !== "0x") {
+    throw new Error(`predicted Outbox ${outboxAddr} already has code (same salt inputs deployed before) but chains.${CHAIN_KEY}.source is not recorded; record it by hand or change the inputs`);
+  }
+  const curDefault: string = await discovery.defaultOutbox(CHAIN_KEY);
+  if (curDefault !== ethers.ZeroAddress) throw new Error(`OutboxDiscovery.defaultOutbox(${CHAIN_KEY}) is already ${curDefault}; a rotation needs setDefaultOutbox + timelock, not this script`);
+  console.log(`  predicted: vault ${vaultAddr}  feeVault ${feeVaultAddr}  lite ${liteAddr}  outbox ${outboxAddr}`);
+
+  const vault = await deploy("AttestorVault", vaultArt, [owner, s.attest, outboxAddr, liteAddr, owner, s.attestorRegistry, DEAD, 0]);
+  const feeVault = await deploy("RelayerFeeVault", feeVaultArt, [s.attest, liteAddr]);
+  const lite = await deploy("RelayerContractLite", liteArt, [owner, s.attest, outboxAddr, s.proofVerifier, s.deliveryDecoder]);
+  for (const [name, c, want] of [["AttestorVault", vault, vaultAddr], ["RelayerFeeVault", feeVault, feeVaultAddr], ["RelayerContractLite", lite, liteAddr]] as const) {
+    if (!same(await c.getAddress(), want)) throw new Error(`${name} precompute mismatch: got ${await c.getAddress()}, predicted ${want}`);
+  }
+
+  console.log("  deployOutbox via factory…");
+  const rcpt = await (await factory.deployOutbox(CHAIN_KEY, owner, owner, RATE, vaultAddr, s.feeRegistry, s.attest)).wait();
+  const created = rcpt!.logs.map((l: any) => { try { return factory.interface.parseLog(l); } catch { return null; } }).find((e: any) => e?.name === "OutboxCreated");
+  if (!created) throw new Error("deployOutbox receipt has no OutboxCreated event");
+  if (!same(created.args.outbox, outboxAddr)) throw new Error(`Outbox CREATE2 mismatch: event ${created.args.outbox}, predicted ${outboxAddr}`);
+  console.log(`  Outbox → ${outboxAddr} (chainKey ${created.args.chainKey}, version ${created.args.version})`);
+
+  const ack = await deploy("AcknowledgmentValidator", ackArt, [BigInt(CHAIN_KEY) /* uint64 destinationChainKey */, owner, s.proofVerifier, s.attest]);
+  ackAddr = await ack.getAddress();
+
+  // Record immediately so a wiring failure below can be resumed instead of redeploying.
+  deployJson.chains[String(CHAIN_KEY)] = {
+    ...entry,
+    source: {
+      outbox: outboxAddr, attestorVault: vaultAddr, relayerFeeVault: feeVaultAddr,
+      relayerContract: liteAddr, relayerContractKind: "RelayerContractLite", ackValidator: ackAddr,
+      quoterEOA: QUOTER_EOA, deployedAt: new Date().toISOString(),
+    },
+  };
+  writeFileSync(OUT, JSON.stringify(deployJson, null, 2) + "\n");
+}
+
+const outbox = at(outboxAddr, outboxArt);
+const lite = at(liteAddr, liteArt);
+const ack = at(ackAddr, ackArt);
+if (Number(await outbox.chainKey()) !== CHAIN_KEY) throw new Error(`Outbox.chainKey() is ${await outbox.chainKey()}, expected ${CHAIN_KEY}`);
+if (Number(await ack.destinationChainKey()) !== CHAIN_KEY) throw new Error("AcknowledgmentValidator.destinationChainKey() mismatch");
+
+// ---------------------------------------------------------------------------------------------
+// 2. Wiring on Creditcoin — each step: read getter, act only if needed.
+// ---------------------------------------------------------------------------------------------
+async function ensure(label: string, isDone: () => Promise<boolean>, act: () => Promise<ethers.ContractTransactionResponse>) {
+  if (await isDone()) { console.log(`  ✓ ${label} (already)`); return; }
+  await (await act()).wait();
+  if (!(await isDone())) throw new Error(`${label} landed but the getter still disagrees`);
+  console.log(`  ✓ ${label}`);
+}
+
+await ensure(`Outbox.setTrustedForwarder(${liteAddr}, true)`,
+  () => outbox.isTrustedForwarder(liteAddr), () => outbox.setTrustedForwarder(liteAddr, true));
+await ensure(`Outbox.setValidator(${ackAddr})`,
+  async () => same(await outbox.validator(), ackAddr), () => outbox.setValidator(ackAddr));
+await ensure(`AcknowledgmentValidator.setOutbox(${outboxAddr})`,
+  async () => same(await ack.outbox(), outboxAddr), () => ack.setOutbox(outboxAddr));
+await ensure(`AcknowledgmentValidator.updateTrustedInbox(${destInbox}, true)`,
+  () => ack.trustedInboxes(destInbox), () => ack.updateTrustedInbox(destInbox, true));
+await ensure(`RelayerContractLite.setRelayerFeeVault(${feeVaultAddr})`,
+  async () => same(await lite.relayerFeeVault(), feeVaultAddr), () => lite.setRelayerFeeVault(feeVaultAddr));
+await ensure(`RelayerContractLite.setDestinationEvmChainId(${CHAIN_KEY}, ${DEST_CHAIN_ID})`,
+  async () => Number(await lite.destinationEvmChainIds(CHAIN_KEY)) === DEST_CHAIN_ID, () => lite.setDestinationEvmChainId(CHAIN_KEY, DEST_CHAIN_ID));
+if (QUOTER_EOA) {
+  await ensure(`RelayerContractLite.setAuthorizedQuoter(${QUOTER_EOA}, true)`,
+    () => lite.authorizedQuoters(QUOTER_EOA), () => lite.setAuthorizedQuoter(QUOTER_EOA, true));
+} else console.log("  - QUOTER_EOA unset: no quoter authorised on the new RelayerContractLite (use add-quoter.mts later)");
+await ensure(`EVMDeliveryDecoder.setTrustedInbox(${DEST_CHAIN_ID}, ${destInbox})`,
+  async () => same(await decoder.trustedInboxes(DEST_CHAIN_ID), destInbox), () => decoder.setTrustedInbox(DEST_CHAIN_ID, destInbox));
+// registerOutbox reverts UnknownChainKey unless the ChainRegistry mapping exists, so setChain goes first.
+await ensure(`ChainRegistry.setChain(${CHAIN_KEY}, ${DEST_CHAIN_ID})`,
+  async () => Number(await chainRegistry.chainIdOf(CHAIN_KEY)) === DEST_CHAIN_ID, () => chainRegistry.setChain(CHAIN_KEY, DEST_CHAIN_ID));
+{
+  const cur: string = await discovery.defaultOutbox(CHAIN_KEY);
+  if (cur !== ethers.ZeroAddress && !same(cur, outboxAddr)) throw new Error(`OutboxDiscovery.defaultOutbox(${CHAIN_KEY}) is ${cur}, not our ${outboxAddr}; rotation needs setDefaultOutbox + timelock`);
+  // First registration for a key becomes the default immediately (no timelock).
+  await ensure(`OutboxDiscovery.registerOutbox(${CHAIN_KEY}, ${outboxAddr})`,
+    async () => same(await discovery.defaultOutbox(CHAIN_KEY), outboxAddr), () => discovery.registerOutbox(CHAIN_KEY, outboxAddr));
+}
+
+// ---------------------------------------------------------------------------------------------
+// 3. Destination chain: allowlist the Outbox on the Inbox (or the relayer's first delivery reverts
+//    UnsupportedOutbox).
+// ---------------------------------------------------------------------------------------------
+{
+  const destProvider = new ethers.JsonRpcProvider(DEST_RPC, DEST_CHAIN_ID, { staticNetwork: true });
+  const liveChainId = Number(BigInt(await destProvider.send("eth_chainId", [])));
+  if (liveChainId !== DEST_CHAIN_ID) throw new Error(`DEST_RPC reports chain id ${liveChainId}, expected ${DEST_CHAIN_ID}`);
+  const destAdmin = new ethers.Wallet(DEST_ADMIN_KEY, destProvider);
+  const inbox = at(destInbox, inboxArt, destAdmin);
+  const inboxOwner: string = await inbox.owner();
+  if (!same(inboxOwner, destAdmin.address)) throw new Error(`Inbox ${destInbox} owner is ${inboxOwner}, but DEST_ADMIN_KEY is ${destAdmin.address}`);
+  if ((await inbox.localChainKey()).toLowerCase() !== ethers.zeroPadValue(ethers.toBeHex(CHAIN_KEY), 32).toLowerCase()) throw new Error(`Inbox.localChainKey() is not bytes32(${CHAIN_KEY})`);
+  console.log(`dest admin ${destAdmin.address}  balance ${ethers.formatEther(await destProvider.getBalance(destAdmin.address))} native`);
+  await ensure(`Inbox.setSupportedOutbox(${outboxAddr}, true) on chain ${DEST_CHAIN_ID}`,
+    () => inbox.isSupportedOutbox(outboxAddr), () => inbox.setSupportedOutbox(outboxAddr, true));
+  destProvider.destroy();
+}
+
+deployJson.chains[String(CHAIN_KEY)] = {
+  ...deployJson.chains[String(CHAIN_KEY)],
+  source: {
+    ...(deployJson.chains[String(CHAIN_KEY)].source ?? {}),
+    outbox: outboxAddr, attestorVault: vaultAddr, relayerFeeVault: feeVaultAddr,
+    relayerContract: liteAddr, relayerContractKind: "RelayerContractLite", ackValidator: ackAddr,
+    quoterEOA: QUOTER_EOA ?? existing?.quoterEOA ?? null,
+    deployedAt: existing?.deployedAt ?? deployJson.chains[String(CHAIN_KEY)].source?.deployedAt ?? new Date().toISOString(),
+    wiredAt: new Date().toISOString(),
+  },
+};
+writeFileSync(OUT, JSON.stringify(deployJson, null, 2) + "\n");
+console.log(`✅ chain key ${CHAIN_KEY} source stack ready. Outbox ${outboxAddr}  RelayerContractLite ${liteAddr}  ack ${ackAddr}`);
+console.log(`   recorded chains.${CHAIN_KEY}.source in ${OUT}. Next: point attestors/relayer at chain key ${CHAIN_KEY} and replace the placeholder attestor set on the destination registry.`);
+process.exit(0);

--- a/usc-messaging/scripts/register-chain-devnet.mjs
+++ b/usc-messaging/scripts/register-chain-devnet.mjs
@@ -1,0 +1,220 @@
+// usc-dev: register a NEW destination chain for write-ability in the Creditcoin runtime (sudo).
+//
+// Step 1 of 3 when adding a destination chain to usc-devnet (chain id 42):
+//   1. register-chain-devnet.mjs        (this)  — pallet side, assigns the chain key
+//   2. deploy-dest-chain-devnet.mts     — destination EVM chain: AttestorRegistry, EOAValidator, Inbox
+//   3. deploy-source-chain-devnet.mts   — Creditcoin: per-chain Outbox / vault / RelayerContractLite
+//
+// What it does, every step idempotent (storage is read first):
+//   a. supportedChains.registerChain(chainId, name, …) unless chainIdAndNameToUniqKey(chainId, name)
+//      already holds a key — then that key is reused. The live extrinsic shape is checked against
+//      `api.tx.supportedChains.registerChain.meta.args` before submitting.
+//   b. supportedChains.setOutboxFactoryAddr(chainKey, factory)     (factory = source.factory)
+//   c. supportedChains.setWriteAbilityConfig(chainKey, bytes32(chainKey), true)
+//   d. supportedChains.setCoreFee(chainKey, CORE_FEE_WEI)          (only when CORE_FEE_WEI is set)
+//   e. supportedChains.setOutboxDiscoveryAddr(chainKey, source.outboxDiscovery) when the runtime
+//      exposes it (#1292) and the deploy JSON has the address; otherwise skipped with a message.
+// Finally the chain key is printed and written to usc-dev-deploy.json under
+// chains.<chainKey>.{chainKey,destChainId,destChainName,registeredAt}; `source` / `dest` untouched.
+//
+// Env:
+//   SUDO_URI                      seed/uri of the devnet sudo account            (required)
+//   DEST_CHAIN_ID                 destination EVM chain id, e.g. 84532            (required)
+//   DEST_CHAIN_NAME               e.g. "Base Sepolia"                             (required)
+//   TARGET_SAMPLE_SIZE            attestors sampled per attestation               (required)
+//   ATTESTATION_INTERVAL          blocks between attestations                     (required)
+//   CHECKPOINT_INTERVAL           attestations per checkpoint                     (required)
+//   MAX_ATTESTORS                 max attestors for the chain                     (required)
+//   GENESIS_BLOCK                 first attested block, multiple of ATTESTATION_INTERVAL (required)
+//   MATURITY                      e.g. "FixedDelay: 20", "EvmSafe", "EvmFinalized", "EvmLatest" (required)
+//   CORE_FEE_WEI                  optional, attestcoin wei; unset = left as is
+//   FACTORY_ADDR                  optional, default source.factory from the deploy JSON
+//   CREDITCOIN_SUBSTRATE_WS_URL   default wss://rpc.usc-devnet.creditcoin.network
+//   DEPLOY_OUT                    default ../usc-dev-deploy.json
+//
+// Keys used here are DEVNET-ONLY. Never point this at testnet/mainnet.
+import { ApiPromise, WsProvider, Keyring } from "@polkadot/api";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { stringToU8a } from "@polkadot/util";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const WS = process.env.CREDITCOIN_SUBSTRATE_WS_URL || "wss://rpc.usc-devnet.creditcoin.network";
+const OUT = process.env.DEPLOY_OUT ?? new URL("../usc-dev-deploy.json", import.meta.url).pathname;
+
+const need = (k) => {
+  if (!process.env[k]) throw new Error(`missing ${k}`);
+  return process.env[k];
+};
+const uint = (k) => {
+  const v = need(k);
+  if (!/^\d+$/.test(v)) throw new Error(`${k} must be a non-negative integer, got "${v}"`);
+  return BigInt(v);
+};
+
+const SUDO_URI = need("SUDO_URI");
+const DEST_CHAIN_ID = uint("DEST_CHAIN_ID");
+const DEST_CHAIN_NAME = need("DEST_CHAIN_NAME");
+const TARGET_SAMPLE_SIZE = uint("TARGET_SAMPLE_SIZE");
+const ATTESTATION_INTERVAL = uint("ATTESTATION_INTERVAL");
+const CHECKPOINT_INTERVAL = uint("CHECKPOINT_INTERVAL");
+const MAX_ATTESTORS = uint("MAX_ATTESTORS");
+const GENESIS_BLOCK = uint("GENESIS_BLOCK");
+const MATURITY = need("MATURITY");
+const CORE_FEE_WEI = process.env.CORE_FEE_WEI;
+
+if (ATTESTATION_INTERVAL === 0n || CHECKPOINT_INTERVAL === 0n) {
+  throw new Error("ATTESTATION_INTERVAL and CHECKPOINT_INTERVAL must be > 0 (zero bricks commit_attestation weights)");
+}
+if (GENESIS_BLOCK % ATTESTATION_INTERVAL !== 0n) {
+  throw new Error(`GENESIS_BLOCK ${GENESIS_BLOCK} is not a multiple of ATTESTATION_INTERVAL ${ATTESTATION_INTERVAL}`);
+}
+// Same grammar as pallets/supported-chains is_valid_maturity_strategy.
+if (!/^(EvmFinalized|EvmSafe|EvmLatest|FixedDelay:\s*\d+)$/.test(MATURITY)) {
+  throw new Error(`MATURITY "${MATURITY}" is not one of EvmFinalized | EvmSafe | EvmLatest | "FixedDelay: N"`);
+}
+if (CORE_FEE_WEI !== undefined && !/^\d+$/.test(CORE_FEE_WEI)) throw new Error("CORE_FEE_WEI must be an integer (wei)");
+
+const deploy = JSON.parse(readFileSync(OUT, "utf8"));
+const source = deploy.source ?? {};
+const factory = process.env.FACTORY_ADDR ?? source.factory;
+if (!factory) throw new Error(`no source.factory in ${OUT} and FACTORY_ADDR unset`);
+const discovery = source.outboxDiscovery;
+
+const api = await ApiPromise.create({ provider: new WsProvider(WS), noInitWarn: true });
+await api.isReady;
+await cryptoWaitReady();
+const sudo = new Keyring({ type: "sr25519" }).addFromUri(SUDO_URI);
+console.log(`runtime ${api.runtimeVersion.specName.toString()}/${api.runtimeVersion.specVersion.toString()} at ${WS}`);
+console.log("sudo account:", sudo.address);
+
+const submit = (label, call) =>
+  new Promise((resolve, reject) => {
+    api.tx.sudo.sudo(call).signAndSend(sudo, ({ status, dispatchError, events }) => {
+      if (dispatchError) return reject(new Error(`${label}: ${dispatchError.toString()}`));
+      if (status.isInBlock) {
+        const failed = events.find((e) => api.events.sudo.Sudid.is(e.event) && e.event.data[0].isErr);
+        if (failed) return reject(new Error(`${label}: inner call failed: ${failed.event.data[0].asErr.toString()}`));
+        console.log(`✅ ${label} in block ${status.asInBlock.toHex()}`);
+        resolve(events);
+      }
+    });
+  });
+
+// Key 2 of ChainIdAndNameToUniqKey is Vec<u8> of the UTF-8 name; pass bytes so polkadot-js never
+// tries to interpret the name as hex.
+const nameBytes = stringToU8a(DEST_CHAIN_NAME);
+const lookupChainKey = async () => {
+  const k = await api.query.supportedChains.chainIdAndNameToUniqKey(DEST_CHAIN_ID, nameBytes);
+  return k.isSome ? BigInt(k.unwrap().toString()) : null;
+};
+
+// (a) register_chain — or reuse.
+let chainKey = await lookupChainKey();
+if (chainKey !== null) {
+  console.log(`ℹ️  (${DEST_CHAIN_ID}, "${DEST_CHAIN_NAME}") is already registered as chain key ${chainKey} — reusing it`);
+} else {
+  const tx = api.tx.supportedChains?.registerChain;
+  if (!tx) throw new Error("runtime has no supportedChains.registerChain");
+  // Guard against a runtime whose register_chain shape differs from what we encode below:
+  // exact argument names in this order, and Option-ness per argument (type names carry
+  // runtime-specific path prefixes, so they are only checked for the Option<> wrapper).
+  const EXPECTED = [
+    ["chainId", false], ["chainName", false], ["targetSampleSize", true],
+    ["chainAttestationInterval", true], ["attestationCheckpointInterval", true],
+    ["maxAttestors", true], ["maxInvulnerables", true],
+    ["attestationChainGenesisBlockNumber", true], ["encoding", false], ["maturityStrategy", true],
+  ];
+  const live = tx.meta.args.map((a) => [a.name.toString(), a.type.toString()]);
+  const shapeOk = live.length === EXPECTED.length &&
+    live.every(([n, t], i) => n === EXPECTED[i][0] && t.startsWith("Option<") === EXPECTED[i][1]);
+  if (!shapeOk) {
+    throw new Error(
+      `supportedChains.registerChain on this runtime has args\n  ${live.map((a) => a.join(": ")).join("\n  ")}\n` +
+      `but this script encodes\n  ${EXPECTED.map(([n, o]) => `${n}: ${o ? "Option<…>" : "…"}`).join("\n  ")}\nRefusing to submit; update the script.`,
+    );
+  }
+  await submit(
+    `registerChain(${DEST_CHAIN_ID}, "${DEST_CHAIN_NAME}", target=${TARGET_SAMPLE_SIZE}, interval=${ATTESTATION_INTERVAL}, checkpoint=${CHECKPOINT_INTERVAL}, maxAttestors=${MAX_ATTESTORS}, genesis=${GENESIS_BLOCK}, V1, "${MATURITY}")`,
+    tx(
+      DEST_CHAIN_ID, DEST_CHAIN_NAME,
+      TARGET_SAMPLE_SIZE, ATTESTATION_INTERVAL, CHECKPOINT_INTERVAL, MAX_ATTESTORS,
+      null /* max_invulnerables: None */, GENESIS_BLOCK, "V1", MATURITY,
+    ),
+  );
+  chainKey = await lookupChainKey();
+  if (chainKey === null) throw new Error("registerChain landed but chainIdAndNameToUniqKey has no entry for it");
+  console.log(`   assigned chain key ${chainKey}`);
+}
+
+const supported = await api.query.supportedChains.supportedChains(chainKey);
+if (!supported.isSome) throw new Error(`supportedChains(${chainKey}) is empty — registration did not stick`);
+console.log(`   supportedChains(${chainKey}) = ${JSON.stringify(supported.unwrap().toHuman())}`);
+
+// (b) OutboxFactory — the chain-info precompile's get_outbox_factory_address(chainKey).
+const curFactory = await api.query.supportedChains.outboxFactories(chainKey);
+if (curFactory.isSome && curFactory.unwrap().toString().toLowerCase() === factory.toLowerCase()) {
+  console.log(`✅ outboxFactories(${chainKey}) already ${factory}`);
+} else {
+  await submit(`setOutboxFactoryAddr(${chainKey}, ${factory})`, api.tx.supportedChains.setOutboxFactoryAddr(chainKey, factory));
+}
+
+// (c) WriteAbilityConfig — bytes32 chain key with the value in the low 8 bytes (chain_key_to_bytes32).
+const chainKeyBytes32 = "0x" + chainKey.toString(16).padStart(64, "0");
+const curWa = await api.query.supportedChains.writeAbilityConfigs(chainKey);
+const waOk = curWa.isSome &&
+  curWa.unwrap().writeAbilityChainKey.toHex().toLowerCase() === chainKeyBytes32 &&
+  curWa.unwrap().messageAttestationEnabled.isTrue;
+if (waOk) {
+  console.log(`✅ writeAbilityConfigs(${chainKey}) already {${chainKeyBytes32}, enabled}`);
+} else {
+  await submit(`setWriteAbilityConfig(${chainKey}, ${chainKeyBytes32}, true)`,
+    api.tx.supportedChains.setWriteAbilityConfig(chainKey, chainKeyBytes32, true));
+}
+
+// (d) core fee (optional).
+if (CORE_FEE_WEI !== undefined) {
+  const cur = await api.query.supportedChains.coreFees(chainKey);
+  if (cur.isSome && BigInt(cur.unwrap().amount.toString()) === BigInt(CORE_FEE_WEI)) {
+    console.log(`✅ coreFees(${chainKey}) already ${CORE_FEE_WEI}`);
+  } else {
+    await submit(`setCoreFee(${chainKey}, ${CORE_FEE_WEI})`, api.tx.supportedChains.setCoreFee(chainKey, CORE_FEE_WEI));
+  }
+} else {
+  console.log(`(core fee left unset — get_core_fee(${chainKey}) stays as is; set later with CORE_FEE_WEI)`);
+}
+
+// (e) OutboxDiscovery registry address (#1292 runtime only).
+const setDiscovery = api.tx.supportedChains?.setOutboxDiscoveryAddr;
+if (!setDiscovery) {
+  console.log(`⏭️  runtime ${api.runtimeVersion.specVersion.toString()} has no supportedChains.setOutboxDiscoveryAddr (pre-#1292) — skipped; rerun after the upgrade`);
+} else if (!discovery) {
+  console.log("⏭️  no source.outboxDiscovery in the deploy JSON — skipping setOutboxDiscoveryAddr");
+} else {
+  const cur = await api.query.supportedChains.outboxDiscoveries(chainKey);
+  if (cur.isSome && cur.unwrap().toString().toLowerCase() === discovery.toLowerCase()) {
+    console.log(`✅ outboxDiscoveries(${chainKey}) already ${discovery}`);
+  } else {
+    await submit(`setOutboxDiscoveryAddr(${chainKey}, ${discovery})`, setDiscovery(chainKey, discovery));
+  }
+}
+
+// Record. Only chains.<chainKey>; never touch source / dest.
+deploy.chains ??= {};
+const prev = deploy.chains[String(chainKey)] ?? {};
+deploy.chains[String(chainKey)] = {
+  ...prev,
+  chainKey: Number(chainKey),
+  destChainId: Number(DEST_CHAIN_ID),
+  destChainName: DEST_CHAIN_NAME,
+  registeredAt: prev.registeredAt ?? new Date().toISOString(),
+};
+writeFileSync(OUT, JSON.stringify(deploy, null, 2) + "\n");
+
+console.log("");
+console.log("==================================================");
+console.log(`  CHAIN KEY for ${DEST_CHAIN_NAME} (${DEST_CHAIN_ID}): ${chainKey}`);
+console.log("==================================================");
+console.log(`recorded chains.${chainKey} in ${OUT}`);
+console.log(`next: CHAIN_KEY=${chainKey} DEST_CHAIN_ID=${DEST_CHAIN_ID} npx tsx scripts/deploy-dest-chain-devnet.mts`);
+await api.disconnect();
+process.exit(0);


### PR DESCRIPTION
Stacked on #1331. Adds three operator scripts to bring up write-ability for an additional destination chain on usc-devnet (first use: Base Sepolia, EVM 84532), parametrised by chain key, never assuming chain key 8:

- `register-chain-devnet.mjs` (sudo): `registerChain` (shape checked against live metadata), reads back the assigned key, `setOutboxFactoryAddr`, `setWriteAbilityConfig(key, bytes32(key), true)`, optional `setCoreFee`, `setOutboxDiscoveryAddr` when the runtime has it. Writes `chains.<key>` into `usc-dev-deploy.json`.
- `deploy-dest-chain-devnet.mts` (destination chain): AttestorRegistry (seeded with the three placeholder attestors, because `EOAValidator`'s constructor reverts on an empty registry), EOAValidator, MockDestination, six-arg `Inbox(bytes32(key), 42, validator, dapp, owner, [])`, `setUpdater(validator)`. Writes `chains.<key>.dest`.
- `deploy-source-chain-devnet.mts` (Creditcoin): reuses the shared `source.*` contracts (ATTEST, proof verifier, decoder, factory, fee registry, registry, ChainRegistry, OutboxDiscovery); deploys AttestorVault, RelayerFeeVault, **RelayerContractLite**, Outbox via the CREATE2 factory, AcknowledgmentValidator; wires forwarder, validator, fee vault, destination chain id, quoter, decoder trusted Inbox, `ChainRegistry.setChain`, `OutboxDiscovery.registerOutbox`; then `Inbox.setSupportedOutbox` on the destination. Resumable (JSON written after deploy; wiring steps getter-guarded). Writes `chains.<key>.source`.

Every ABI call was checked against the compiled asc-contracts main `c83b3372` artifacts. Type-checked with `tsc --strict`; `node --check` for the .mjs. Not run against any network yet; the Base runbook drives the first run.

https://claude.ai/code/session_01Kv6y52MHgtgkWmnJhdXbHB