### PR TITLE
feat(archiver): write and flush every block once within a flush window of the head

### DIFF
--- a/archiver/README.md
+++ b/archiver/README.md
@@ -39,7 +39,7 @@ All flags can also be set via environment variables (see below).
 | `--stream-timeout-secs` | `STREAM_TIMEOUT_SECS` | `120` | Seconds before treating a stream as stalled |
 | `--sled-db-path` | `SLED_DB_PATH` | `./data/roots.sled` | Path to the sled database directory |
 | `--api-bind` | `API_BIND` | `0.0.0.0:8080` | HTTP API bind address |
-| `--flush-every` | `FLUSH_EVERY` | `10000` | Flush database to disk every N blocks |
+| `--flush-every` | `FLUSH_EVERY` | `10000` | Write and flush roots every N blocks while catching up; within N blocks of the head the archiver writes and flushes every block automatically |
 | `--backfill` | — | `false` | Scan for gaps and fill them before resuming |
 | `--finalization_lag_override` | - | *(none)* | Configurable finalization lag override |
 

--- a/archiver/src/config.rs
+++ b/archiver/src/config.rs
@@ -62,7 +62,9 @@ pub struct Config {
     #[arg(long, env = "API_BIND", default_value = "0.0.0.0:8080")]
     pub api_bind: SocketAddr,
 
-    /// How often to flush the sled database to disk (every N blocks).
+    /// How often to write and flush roots while catching up (every N blocks). Once the archiver
+    /// is within N blocks of the chain head it writes and flushes every block automatically, so
+    /// this only needs tuning for backfill throughput; tip-following never needs `1`.
     #[arg(long, env = "FLUSH_EVERY", default_value = "10000")]
     pub flush_every: NonZeroU64,
 

--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -384,9 +384,16 @@ async fn main() -> Result<()> {
         count += 1;
 
         let end_reached = cfg.end_height.is_some_and(|end| height >= end);
+        let target = cfg
+            .end_height
+            .unwrap_or_else(|| chain_head.load(Ordering::Acquire));
+        let remaining = target.saturating_sub(height);
+        let at_tip = at_tip(remaining, cfg.flush_every);
 
-        // Flush batch when full or at end.
-        if batch_buf.len() >= flush_size || end_reached {
+        // Write the batch when full, at the end, or whenever we are at the tip: batching there
+        // only delays when the API can serve a root that is already mature, which is what
+        // proof-gen and the attestors are waiting on. Deep catch-up keeps the batched writes.
+        if batch_buf.len() >= flush_size || end_reached || at_tip {
             store.put_roots(&batch_buf)?;
             batch_buf.clear();
         }
@@ -397,8 +404,8 @@ async fn main() -> Result<()> {
             break;
         }
 
-        // Periodic flush + logging
-        let is_flush = height % cfg.flush_every.get() == 0;
+        // Durability flush + logging: every block at the tip, every `flush_every` otherwise.
+        let is_flush = at_tip || height % cfg.flush_every.get() == 0;
         let is_log = is_flush || count % cfg.flush_every.get() == 0;
 
         if is_flush {
@@ -412,10 +419,6 @@ async fn main() -> Result<()> {
             } else {
                 0.0
             };
-            let target = cfg
-                .end_height
-                .unwrap_or_else(|| chain_head.load(Ordering::Acquire));
-            let remaining = target.saturating_sub(height);
             let label = if is_flush { "flushed" } else { "✓" };
             tracing::info!(
                 height,
@@ -445,6 +448,16 @@ async fn main() -> Result<()> {
     );
 
     Ok(())
+}
+
+/// True when the archiver is close enough to the chain head that batching would delay the
+/// visibility of mature roots: within one `flush_every` window of the target. At the tip
+/// `remaining` settles at the finalization lag (plus a little head-tracker latency), which is
+/// far below any sane `flush_every`, so tip-following writes and flushes every block without
+/// operators having to set `FLUSH_EVERY=1`. If the head tracker has no value yet (`0`),
+/// `remaining` is `0` and we err on the side of flushing.
+fn at_tip(remaining: u64, flush_every: std::num::NonZeroU64) -> bool {
+    remaining < flush_every.get()
 }
 
 fn format_eta(remaining: u64, rate: f64) -> String {
@@ -503,6 +516,35 @@ fn resolve_finalization_lag(override_lag: Option<u64>, on_chain_lag: Option<u64>
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn at_tip_within_one_flush_window_of_the_head() {
+        let every = std::num::NonZeroU64::new(10_000).unwrap();
+        // Deep catch-up keeps batching.
+        assert!(!at_tip(45_000_000, every));
+        assert!(!at_tip(10_000, every));
+        // Inside the last window, and at the head itself (remaining == finalization lag).
+        assert!(at_tip(9_999, every));
+        assert!(at_tip(10, every));
+        assert!(at_tip(0, every));
+    }
+
+    #[test]
+    fn at_tip_with_flush_every_one_keeps_the_old_meaning() {
+        let one = std::num::NonZeroU64::new(1).unwrap();
+        assert!(at_tip(0, one));
+        assert!(!at_tip(1, one));
+    }
+
+    #[test]
+    fn missing_head_tracker_value_flushes_conservatively() {
+        // chain_head defaults to 0 when the HTTP head fetch fails; remaining saturates to 0.
+        let remaining = 0u64.saturating_sub(123_456);
+        assert!(at_tip(
+            remaining,
+            std::num::NonZeroU64::new(10_000).unwrap()
+        ));
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
## Why

`FLUSH_EVERY` gates both the sled write (which is what makes a root visible to `/roots`) and the durability flush. A tip-following archiver therefore had to run with `flushEvery: 1`, otherwise mature roots stayed invisible for up to N blocks: with the default 10000 that is ~33 hours on Ethereum mainnet and ~75 minutes on BSC. The devnet BSC archiver carries `flushEvery: 1` for exactly this reason, and every new chain deployment was one forgotten value away from an archiver that looks healthy but serves nothing recent.

## What

- The main loop already tracks `remaining = target − height` for the ETA. It now also derives `at_tip = remaining < flush_every`. At the tip the batch is written and a flush is requested on **every** block; during deep catch-up the batched behaviour is unchanged.
- `target` is `end_height` when set, else the polled chain head (12 s poll), so the window is wide enough that head-tracker latency cannot flap it.
- If the head fetch failed and `chain_head` is still 0, `remaining` saturates to 0 and we flush: the failure mode is more flushing, never less.
- `FLUSH_EVERY=1` keeps its old meaning. Config doc and README row updated.

Operational effect: the `flushEvery: 1` override on `cc3-devnet/bsc-mainnet/archiver.yaml` becomes unnecessary (and can be dropped so backfills on that deployment batch again).

## Verification

- Unit tests for `at_tip`: deep catch-up batches, inside the last window flushes, `remaining == lag` flushes, `FLUSH_EVERY=1` semantics preserved, missing head value flushes.
- `cargo test -p archiver` 18 passed; `cargo clippy -p archiver --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
