### PR TITLE
chore(usc-messaging): redeploy the Sepolia RelayerContractLite under the deployer

### DIFF
--- a/usc-messaging/scripts/redeploy-lite-devnet.mts
+++ b/usc-messaging/scripts/redeploy-lite-devnet.mts
@@ -1,0 +1,112 @@
+// Redeploy the RelayerContractLite (+ its RelayerFeeVault) for an EXISTING source-chain stack on
+// usc-devnet, owned by the deployer, and wire it to the existing Outbox, proof verifier, decoder.
+//
+// Why: the Sepolia (chain key 8) Lite 0x6bEC0843… is owned by a third-party EOA we cannot reach, and
+// it still points at the pre-#48 decoder, so relay-fee claims revert. Everything else on the route
+// (Outbox, AttestorVault, ack validator, Inbox) is unaffected: the Lite only fronts fee collection
+// and payout, so a fresh one can take over. Fees already deposited on the old Lite stay in its vault.
+//
+// Sequence (nonce-predicted, same pattern as deploy-source-chain-devnet):
+//   RelayerFeeVault(attest, predictedLite)                           nonce n
+//   RelayerContractLite(owner, attest, outbox, proofVerifier, decoder) nonce n+1
+//   outbox.setTrustedForwarder(lite, true)   (Outbox owner = deployer)
+//   lite.setRelayerFeeVault(feeVault); lite.setDestinationEvmChainId(CHAIN_KEY, DEST_CHAIN_ID)
+//   lite.setAuthorizedQuoter(QUOTER_EOA, true)
+//   decoder.setTrustedInbox(DEST_CHAIN_ID, destInbox)  (idempotent)
+// Then: relayer IaC route relayerContractAddress -> new Lite; every emitter re-runs
+// Outbox.approveForwarder(newLite, true) (publish-lite-devnet.mts does this itself).
+//
+// Env: DEPLOYER_KEY, ASC_CONTRACTS_DIR, QUOTER_EOA (dedicated quoter, never the deployer),
+//      optional CHAIN_KEY (default 8), CC_RPC, DEPLOY_OUT, DRY_RUN=true (predict only).
+// Keys used here are DEVNET-ONLY. Never point this at testnet/mainnet.
+import { ethers } from "ethers";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const UC = process.env.ASC_CONTRACTS_DIR ?? process.env.USC_CONTRACTS_DIR;
+if (!UC) throw new Error("set ASC_CONTRACTS_DIR to a compiled asc-contracts checkout (main c83b3372+)");
+const ART = (p: string, n: string) => JSON.parse(readFileSync(`${UC}/artifacts/contracts/${p}/${n}.json`, "utf8"));
+const OUT = process.env.DEPLOY_OUT ?? new URL("../usc-dev-deploy.json", import.meta.url).pathname;
+const CC_CHAIN_ID = 42;
+const need = (k: string): string => { const v = process.env[k]; if (!v) throw new Error(`missing ${k}`); return v; };
+const CHAIN_KEY = Number(process.env.CHAIN_KEY ?? 8);
+const DEPLOYER_KEY = need("DEPLOYER_KEY");
+const QUOTER_EOA = ethers.getAddress(need("QUOTER_EOA"));
+const DRY_RUN = (process.env.DRY_RUN ?? "false") === "true";
+
+const deployJson = JSON.parse(readFileSync(OUT, "utf8"));
+// Chain key 8 lives in source/dest; other chains under chains.<K>.
+const src = CHAIN_KEY === 8 ? deployJson.source : deployJson.chains?.[String(CHAIN_KEY)]?.source;
+const dst = CHAIN_KEY === 8 ? deployJson.dest : deployJson.chains?.[String(CHAIN_KEY)]?.dest;
+if (!src?.outbox || !dst?.inbox) throw new Error(`no source.outbox / dest.inbox recorded for chain key ${CHAIN_KEY} in ${OUT}`);
+const DEST_CHAIN_ID = Number(process.env.DEST_CHAIN_ID ?? dst.chainId ?? (CHAIN_KEY === 8 ? 11155111 : undefined));
+if (!Number.isInteger(DEST_CHAIN_ID) || DEST_CHAIN_ID <= 0) throw new Error("DEST_CHAIN_ID unknown");
+const shared = deployJson.source;
+for (const k of ["attest", "proofVerifier", "deliveryDecoder"]) if (!shared[k]) throw new Error(`source.${k} missing`);
+if (QUOTER_EOA.toLowerCase() === new ethers.Wallet(DEPLOYER_KEY).address.toLowerCase()) throw new Error("QUOTER_EOA must not be the deployer");
+
+const provider = new ethers.JsonRpcProvider(process.env.CC_RPC ?? shared.rpc, CC_CHAIN_ID, { staticNetwork: true, polling: true });
+provider.pollingInterval = 1000;
+const wallet = new ethers.Wallet(DEPLOYER_KEY, provider);
+const owner = wallet.address;
+const lc = (a: string) => a.toLowerCase();
+const same = (a: string, b: string) => lc(a) === lc(b);
+const at = (addr: string, art: any) => new ethers.Contract(addr, art.abi, wallet);
+
+const feeVaultArt = ART("write-ability/RelayerFeeVault.sol", "RelayerFeeVault");
+const liteArt = ART("write-ability/RelayerContractLite.sol", "RelayerContractLite");
+const outboxArt = ART("write-ability/Outbox.sol", "Outbox");
+const decoderArt = ART("write-ability/common/EVMDeliveryDecoder.sol", "EVMDeliveryDecoder");
+
+const outbox = at(src.outbox, outboxArt);
+const decoder = at(shared.deliveryDecoder, decoderArt);
+console.log(`chain key ${CHAIN_KEY} → EVM ${DEST_CHAIN_ID}; deployer ${owner} balance ${ethers.formatEther(await provider.getBalance(owner))} CTC`);
+console.log(`  outbox ${src.outbox} (owner ${await outbox.owner()})  decoder ${shared.deliveryDecoder}  old Lite ${src.relayerContract}`);
+if (!same(await outbox.owner(), owner)) throw new Error("Outbox owner is not the deployer; cannot trust a new forwarder");
+
+const n = await wallet.getNonce();
+const predictedFeeVault = ethers.getCreateAddress({ from: owner, nonce: n });
+const predictedLite = ethers.getCreateAddress({ from: owner, nonce: n + 1 });
+console.log(`  predicted: feeVault ${predictedFeeVault}  lite ${predictedLite}`);
+if (DRY_RUN) { console.log("DRY_RUN — stopping before any transaction"); process.exit(0); }
+
+async function deploy(name: string, art: any, args: any[]) {
+  const c = await new ethers.ContractFactory(art.abi, art.bytecode, wallet).deploy(...args);
+  await c.waitForDeployment();
+  console.log(`  ${name} → ${await c.getAddress()}`);
+  return c;
+}
+const feeVault = await deploy("RelayerFeeVault", feeVaultArt, [shared.attest, predictedLite]);
+const lite = await deploy("RelayerContractLite", liteArt, [owner, shared.attest, src.outbox, shared.proofVerifier, shared.deliveryDecoder]);
+if (!same(await feeVault.getAddress(), predictedFeeVault) || !same(await lite.getAddress(), predictedLite)) {
+  throw new Error("nonce prediction mismatch — the vault is bound to the wrong Lite; do NOT wire, redeploy");
+}
+const liteAddr = predictedLite, feeVaultAddr = predictedFeeVault;
+
+async function ensure(label: string, isDone: () => Promise<boolean>, act: () => Promise<ethers.ContractTransactionResponse>) {
+  if (await isDone()) { console.log(`  ✓ ${label} (already)`); return; }
+  await (await act()).wait();
+  if (!(await isDone())) throw new Error(`${label} landed but the getter still disagrees`);
+  console.log(`  ✓ ${label}`);
+}
+await ensure(`Outbox.setTrustedForwarder(${liteAddr}, true)`,
+  () => outbox.isTrustedForwarder(liteAddr), () => outbox.setTrustedForwarder(liteAddr, true));
+await ensure(`Lite.setRelayerFeeVault(${feeVaultAddr})`,
+  async () => same(await lite.relayerFeeVault(), feeVaultAddr), () => lite.setRelayerFeeVault(feeVaultAddr));
+await ensure(`Lite.setDestinationEvmChainId(${CHAIN_KEY}, ${DEST_CHAIN_ID})`,
+  async () => Number(await lite.destinationEvmChainIds(CHAIN_KEY)) === DEST_CHAIN_ID, () => lite.setDestinationEvmChainId(CHAIN_KEY, DEST_CHAIN_ID));
+await ensure(`Lite.setAuthorizedQuoter(${QUOTER_EOA}, true)`,
+  () => lite.authorizedQuoters(QUOTER_EOA), () => lite.setAuthorizedQuoter(QUOTER_EOA, true));
+await ensure(`Decoder.setTrustedInbox(${DEST_CHAIN_ID}, ${dst.inbox})`,
+  async () => same(await decoder.trustedInboxes(DEST_CHAIN_ID), dst.inbox), () => decoder.setTrustedInbox(DEST_CHAIN_ID, dst.inbox));
+
+if (src.relayerContract && !same(src.relayerContract, liteAddr)) src.oldRelayerContract = src.relayerContract;
+if (src.relayerFeeVault && !same(src.relayerFeeVault, feeVaultAddr)) src.oldRelayerFeeVault = src.relayerFeeVault;
+src.relayerContract = liteAddr;
+src.relayerContractKind = "RelayerContractLite";
+src.relayerFeeVault = feeVaultAddr;
+src.quoterEOA = QUOTER_EOA;
+src.liteRedeployedAt = new Date().toISOString();
+writeFileSync(OUT, JSON.stringify(deployJson, null, 2) + "\n");
+console.log(`✅ chain key ${CHAIN_KEY}: RelayerContractLite ${liteAddr}  RelayerFeeVault ${feeVaultAddr}  (owner ${owner}). Written to ${OUT}.`);
+console.log("Next: relayer IaC route relayerContractAddress → new Lite, rollout; emitters approveForwarder(newLite).");
+provider.destroy();

--- a/usc-messaging/scripts/run-redeploy-lite.sh
+++ b/usc-messaging/scripts/run-redeploy-lite.sh
@@ -1,0 +1,8 @@
+#!/bin/zsh
+# One-shot wrapper: redeploy the Sepolia (chain key 8) RelayerContractLite on usc-devnet.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+set -a; . ~/.usc-dev-deployer.env; set +a
+export QUOTER_EOA=0x7CC15788445190C8EaADa403b010196f96A0f28d
+export ASC_CONTRACTS_DIR=/private/tmp/claude-501/-Users-dylan-Projects-creditcoin3/7ea76496-06e9-4b09-97b2-3d23c97d60bc/scratchpad/asc-contracts-c83b337
+exec npx tsx scripts/redeploy-lite-devnet.mts

--- a/usc-messaging/scripts/run-redeploy-lite.sh
+++ b/usc-messaging/scripts/run-redeploy-lite.sh
@@ -1,8 +1,13 @@
-#!/bin/zsh
+#!/usr/bin/env bash
 # One-shot wrapper: redeploy the Sepolia (chain key 8) RelayerContractLite on usc-devnet.
+# Exists because the full command wraps in a terminal. Devnet-only keys.
+#   ASC_CONTRACTS_DIR  compiled asc-contracts checkout (main c83b3372+); required
+#   QUOTER_EOA         dedicated devnet quoter (default: the usc-dev test quoter)
 set -euo pipefail
 cd "$(dirname "$0")/.."
+# shellcheck disable=SC1090
 set -a; . ~/.usc-dev-deployer.env; set +a
-export QUOTER_EOA=0x7CC15788445190C8EaADa403b010196f96A0f28d
-export ASC_CONTRACTS_DIR=/private/tmp/claude-501/-Users-dylan-Projects-creditcoin3/7ea76496-06e9-4b09-97b2-3d23c97d60bc/scratchpad/asc-contracts-c83b337
+: "${ASC_CONTRACTS_DIR:?set ASC_CONTRACTS_DIR to a compiled asc-contracts checkout (npx hardhat compile)}"
+[ -d "$ASC_CONTRACTS_DIR/artifacts/contracts" ] || { echo "ASC_CONTRACTS_DIR=$ASC_CONTRACTS_DIR has no artifacts/contracts — compile it first" >&2; exit 1; }
+export QUOTER_EOA="${QUOTER_EOA:-0x7CC15788445190C8EaADa403b010196f96A0f28d}"
 exec npx tsx scripts/redeploy-lite-devnet.mts

--- a/usc-messaging/scripts/run-redeploy-lite.sh
+++ b/usc-messaging/scripts/run-redeploy-lite.sh
@@ -5,8 +5,10 @@
 #   QUOTER_EOA         dedicated devnet quoter (default: the usc-dev test quoter)
 set -euo pipefail
 cd "$(dirname "$0")/.."
-# shellcheck disable=SC1090
-set -a; . ~/.usc-dev-deployer.env; set +a
+set -a
+# shellcheck source=/dev/null
+. ~/.usc-dev-deployer.env
+set +a
 : "${ASC_CONTRACTS_DIR:?set ASC_CONTRACTS_DIR to a compiled asc-contracts checkout (npx hardhat compile)}"
 [ -d "$ASC_CONTRACTS_DIR/artifacts/contracts" ] || { echo "ASC_CONTRACTS_DIR=$ASC_CONTRACTS_DIR has no artifacts/contracts — compile it first" >&2; exit 1; }
 export QUOTER_EOA="${QUOTER_EOA:-0x7CC15788445190C8EaADa403b010196f96A0f28d}"

--- a/usc-messaging/usc-dev-deploy.json
+++ b/usc-messaging/usc-dev-deploy.json
@@ -17,7 +17,8 @@
     "oldInbox48": "0xbbF87D342102E9aCb2eb7D10D2cb363212E64422",
     "oldInbox23": "0x58D2eCdd35Fb5F4ca999087614C224a4214b90F8",
     "oldDapp": "0xC1a4a26Eeb94aB6FBF395FC99B271E6B2AA7fbc7",
-    "oldDispatcherRouter": "0x7ABc588eD63155590BFe2c58c94E52929ed2b85C"
+    "oldDispatcherRouter": "0x7ABc588eD63155590BFe2c58c94E52929ed2b85C",
+    "oldInboxRevokedAt": "2026-09-10T12:15:10.982Z"
   },
   "source": {
     "chainId": 42,
@@ -32,13 +33,13 @@
     "factory": "0xb91C2eeaA0c475115069a6ED4bc601337a22788E",
     "attestorVault": "0xD45E290062Bd0D1C640D59C350cA03CC291b37FA",
     "outbox": "0x95FE74eF5644d500379b4300344DD80d9e377B40",
-    "relayerFeeVault": "0x913eA2bDc4Dbb784279F1d222e0A2d046C9cF3A3",
-    "relayerContract": "0x6bEC08435177603e005541b449b9D13fcD360916",
+    "relayerFeeVault": "0x0018D698e6d18e2F26Fd88d9E8ef0F9EBCE06b66",
+    "relayerContract": "0xc0B8D02c193b9D03a2Bf4643F058a9184ebd9650",
     "relayerContractKind": "RelayerContractLite",
     "legacyRelayerContract": "0x115f277e8fcE437B1F513A293057D2E396Ac2EC1",
     "legacyRelayerFeeVault": "0x6eA3524AD29729b10F324fD2aF967beed9cc4E68",
     "ackValidator": "0x651D52054c8ac4b19191d7427C2633797567D39c",
-    "quoterEOA": "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac",
+    "quoterEOA": "0x7CC15788445190C8EaADa403b010196f96A0f28d",
     "coreFee": "1000000000000000000",
     "feeRegistry": "0xcCEd4FA7c35209De0a52476A8e63ba7115971876",
     "chainRegistry": "0x68A54b2826EF3f230996A8CD324a2177d7f6041E",
@@ -47,7 +48,10 @@
     "outboxDiscoveryDeployedAt": "2026-09-09T09:06:01.442Z",
     "oldDeliveryDecoder": "0x78D714e1b47Bb86FE15788B917C9CC7B77975529",
     "deliveryDecoderSelector": "0x1d36ca7b",
-    "deliveryDecoderRedeployedAt": "2026-09-10T10:45:00.982Z"
+    "deliveryDecoderRedeployedAt": "2026-09-10T10:45:00.982Z",
+    "oldRelayerContract": "0x6bEC08435177603e005541b449b9D13fcD360916",
+    "oldRelayerFeeVault": "0x913eA2bDc4Dbb784279F1d222e0A2d046C9cF3A3",
+    "liteRedeployedAt": "2026-09-10T16:29:45.958Z"
   },
   "chains": {
     "9": {


### PR DESCRIPTION
## Why

The chain-key-8 `RelayerContractLite` `0x6bEC0843…` on usc-devnet is owned by a third-party EOA (`0xd4ec4033…`) that is not reachable, and it still points at the pre-#48 `EVMDeliveryDecoder`, so every relay-fee claim on the Sepolia route reverts `UnsupportedDestinationTransaction`. The Lite only fronts fee collection and payout, so a fresh deployer-owned one can take over without touching the Outbox, AttestorVault, ack validator or Inbox.

## What

- `scripts/redeploy-lite-devnet.mts`: deploys `RelayerFeeVault` + `RelayerContractLite` for an existing source stack (nonce-predicted, same pattern as `deploy-source-chain-devnet`), trusts the Lite as an Outbox forwarder, sets vault, destination EVM chain id and the dedicated quoter EOA, confirms decoder trust, records `old*` / new addresses. `DRY_RUN=true` predicts only.
- `scripts/run-redeploy-lite.sh`: one-line wrapper (long paths wrap in the terminal).
- `usc-dev-deploy.json`: Sepolia Lite `0xc0B8D02c193b9D03a2Bf4643F058a9184ebd9650`, vault `0x0018D698e6d18e2F26Fd88d9E8ef0F9EBCE06b66`; `oldRelayerContract` / `oldRelayerFeeVault` keep the 0x6bEC… pair.

Applied on usc-devnet 10 Sep; relayer route 8 repointed in cc-networks-iac PR 9483. Emitters must `approveForwarder(newLite, true)` again (the publish script does).

https://claude.ai/code/session_01Kv6y52MHgtgkWmnJhdXbHB
