### PR TITLE
test(archiver): stop the sled reopen tests failing on a lock we already dropped

### DIFF
--- a/archiver/src/store.rs
+++ b/archiver/src/store.rs
@@ -306,6 +306,64 @@ mod tests {
         (height, root, H256::random())
     }
 
+    /// Reopen a store at `path`, tolerating a lock the previous handle has not released yet.
+    ///
+    /// Dropping a `sled::Db` does not synchronously release its file lock: the context is shared
+    /// with a background flusher thread, so the `flock` can outlive the `Drop` that closed our
+    /// handle. Under CI load — the whole workspace in release under `llvm-cov`, where that thread
+    /// is starved of CPU — the gap is wide enough that an immediate reopen fails with
+    /// `WouldBlock`, which read as `count_recovers_from_missing_meta` failing rather than as the
+    /// scheduling artefact it is.
+    ///
+    /// Bounded deliberately tight: a genuine open failure (a corrupt database, a bad path) still
+    /// surfaces in about a second rather than being buried under a long backoff.
+    fn open_after_close(path: &Path) -> RootStore {
+        const ATTEMPTS: usize = 20;
+        const WAIT: std::time::Duration = std::time::Duration::from_millis(50);
+
+        let mut last = None;
+        for _ in 0..ATTEMPTS {
+            match RootStore::open(path) {
+                Ok(store) => return store,
+                Err(e) => {
+                    last = Some(e);
+                    std::thread::sleep(WAIT);
+                }
+            }
+        }
+        panic!(
+            "could not reopen {} after {ATTEMPTS} attempts over {:?}: {:?}",
+            path.display(),
+            WAIT * ATTEMPTS as u32,
+            last.expect("at least one attempt failed"),
+        )
+    }
+
+    /// Covers the helper above, since the condition it exists for only appears under CI load.
+    /// Also asserts its premise: if sled ever stops locking per handle, this fails and tells us the
+    /// retry is now pointless, rather than passing silently and leaving dead scaffolding behind.
+    #[test]
+    fn open_after_close_waits_for_a_held_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.sled");
+        let holder = RootStore::open(&path).unwrap();
+
+        assert!(
+            RootStore::open(&path).is_err(),
+            "sled no longer refuses a second handle — open_after_close has nothing left to ride out"
+        );
+
+        let releaser = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(250));
+            drop(holder);
+        });
+
+        // Would fail immediately without the retry; must succeed once the holder lets go.
+        let reopened = open_after_close(&path);
+        assert_eq!(reopened.count(), 0);
+        releaser.join().expect("releaser thread panicked");
+    }
+
     #[test]
     fn roundtrip_put_get() {
         let dir = tempfile::tempdir().unwrap();
@@ -366,7 +424,7 @@ mod tests {
             // Drop the store, closing the database.
         }
 
-        let reopened = RootStore::open(&path).unwrap();
+        let reopened = open_after_close(&path);
         // Count must be restored from the meta tree without a full scan.
         assert_eq!(reopened.count(), 7);
 
@@ -392,7 +450,7 @@ mod tests {
             store.db.flush().unwrap();
         }
 
-        let reopened = RootStore::open(&path).unwrap();
+        let reopened = open_after_close(&path);
         // The one-time fallback scan should have recovered the count.
         assert_eq!(reopened.count(), 5);
         // And persisted it for next time.


### PR DESCRIPTION
## Why

`cargo-test` on usc-dev PRs intermittently fails on the archiver test `store::tests::count_recovers_from_missing_meta` (and its sibling `count_persists_across_reopen` is equally exposed):

```
failed to open sled database at "/tmp/.tmpXXXX/test.sled"
IO error: could not acquire lock on ".../test.sled/db": Os { code: 11, kind: WouldBlock, ... }
```

Seen on #1320 (2026-09-07) and on an unrelated branch on 2026-08-28. Both tests drop a `sled::Db` and immediately reopen the same path. Dropping the handle does not synchronously release sled's file lock: the context is shared with a background flusher thread, so the `flock` can outlive our `Drop`. Under CI load (whole workspace, release, `llvm-cov`) the gap is wide enough to lose the race.

## What

Port of #1295, which fixed this on `writeability-off-usc-dev` only. `archiver/src/store.rs` ends up **byte-identical** to the writeability copy, so the trunks reconcile without conflict.

- `open_after_close(path)` test helper: retries `RootStore::open` up to 20 × 50 ms on any error, then panics with the last error. Bounded tight so a genuine open failure (corrupt DB, bad path) still surfaces in about a second.
- Both reopen tests use it.
- `open_after_close_waits_for_a_held_lock`: holds a handle in another thread, asserts sled still refuses a second handle (the premise), releases after 250 ms, and asserts the helper rides it out. If sled ever stops locking per handle this test fails and tells us the retry is dead scaffolding.

## Verification

- `cargo test -p archiver`: 19 passed (incl. the new lock test)
- `cargo clippy -p archiver --all-targets -- -D warnings`, `cargo fmt --check`: clean
