### PR TITLE
fix(archiver): pin chain identity, handle SIGTERM everywhere, decouple the tip window

### DIFF
--- a/archiver/README.md
+++ b/archiver/README.md
@@ -39,7 +39,8 @@ All flags can also be set via environment variables (see below).
 | `--stream-timeout-secs` | `STREAM_TIMEOUT_SECS` | `120` | Seconds before treating a stream as stalled |
 | `--sled-db-path` | `SLED_DB_PATH` | `./data/roots.sled` | Path to the sled database directory |
 | `--api-bind` | `API_BIND` | `0.0.0.0:8080` | HTTP API bind address |
-| `--flush-every` | `FLUSH_EVERY` | `10000` | Write and flush roots every N blocks while catching up; within N blocks of the head the archiver writes and flushes every block automatically |
+| `--flush-every` | `FLUSH_EVERY` | `10000` | Catch-up batch size: write roots (and request a flush) every N blocks |
+| `--tip-window` | `TIP_WINDOW` | `256` | Within N blocks of the head, write every root immediately; durability flushes throttled to ~1/s |
 | `--backfill` | — | `false` | Scan for gaps and fill them before resuming |
 | `--finalization_lag_override` | - | *(none)* | Configurable finalization lag override |
 

--- a/archiver/src/config.rs
+++ b/archiver/src/config.rs
@@ -62,11 +62,18 @@ pub struct Config {
     #[arg(long, env = "API_BIND", default_value = "0.0.0.0:8080")]
     pub api_bind: SocketAddr,
 
-    /// How often to write and flush roots while catching up (every N blocks). Once the archiver
-    /// is within N blocks of the chain head it writes and flushes every block automatically, so
-    /// this only needs tuning for backfill throughput; tip-following never needs `1`.
+    /// Batch size while catching up: roots are written (and a durability flush requested)
+    /// every N blocks. Only affects backfill throughput; tip-following is governed by
+    /// `--tip-window` and never needs `1`.
     #[arg(long, env = "FLUSH_EVERY", default_value = "10000")]
     pub flush_every: NonZeroU64,
+
+    /// Blocks from the target (chain head or `--end-height`) within which every root is
+    /// written as soon as it is computed, so the API can serve mature roots immediately.
+    /// Must comfortably exceed the finalization lag plus head-poll latency (12 s). Durability
+    /// flushes at the tip are throttled to about one per second regardless.
+    #[arg(long, env = "TIP_WINDOW", default_value = "256")]
+    pub tip_window: NonZeroU64,
 
     /// Finalization lag: number of blocks behind the chain tip to consider finalized.
     /// By default the archiver will use the on-chain finalization lag for this source

--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -15,6 +15,9 @@ use futures::StreamExt;
 
 /// Base delay between reconnection attempts (doubles each retry, capped at [`RECONNECT_MAX_DELAY`]).
 const RECONNECT_BASE_DELAY: Duration = Duration::from_secs(2);
+/// Minimum spacing between explicit durability flushes while following the tip. sled also
+/// flushes on its own timer (500 ms by default), so a per-block fsync buys nothing.
+const TIP_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 /// Maximum delay between reconnection attempts.
 const RECONNECT_MAX_DELAY: Duration = Duration::from_secs(60);
 
@@ -102,6 +105,13 @@ async fn main() -> Result<()> {
     }
     let source_chain_id = ws_client.chain_id();
 
+    // Pin the archive to this chain. A database that was built from another chain (or an
+    // endpoint that now serves another chain under the same name) is refused outright.
+    match store.pin_chain_id(source_chain_id)? {
+        None => tracing::info!(chain_id = source_chain_id, "pinned archive to source chain"),
+        Some(pinned) => tracing::debug!(chain_id = pinned, "archive chain pin verified"),
+    }
+
     // ── Registered chain (Creditcoin) ───────────────────────────────────
     // Previously this lookup only ran when FINALIZATION_LAG was unset, so every
     // deployment that pinned the lag skipped the chain_id verification along with it.
@@ -160,6 +170,19 @@ async fn main() -> Result<()> {
     // ── Determine finalization lag ──────────────────────────────────────
     let finaliztion_lag = resolve_finalization_lag(cfg.finalization_lag_override, on_chain_lag)?;
 
+    // ── Shutdown signal (SIGINT + SIGTERM) ──────────────────────────────
+    // A `watch` rather than a oneshot so every phase (main loop, reconnect backoff, stream
+    // construction) can select on it repeatedly. Kubernetes stops pods with SIGTERM, so
+    // it must take the same final-batch / final-flush path as Ctrl+C.
+    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+    tokio::spawn(async move {
+        wait_for_shutdown_signal().await;
+        tracing::info!("shutting down...");
+        let _ = cancel_tx.send(true);
+    });
+    let mut cancel_rx = cancel_rx;
+    let mut backfill_cancel = cancel_rx.clone();
+
     // ── Backfill gaps ────────────────────────────────────────────────────
     if cfg.backfill {
         // Pass `cfg.start_height` so the gap-finder also reports a pre-first-stored gap
@@ -194,7 +217,17 @@ async fn main() -> Result<()> {
                 let flush_size = cfg.flush_every.get() as usize;
                 let mut batch_buf = Vec::with_capacity(flush_size);
 
-                while let Some(info) = gap_stream.next().await {
+                loop {
+                    let info = tokio::select! {
+                        _ = cancelled(&mut backfill_cancel) => {
+                            tracing::info!("backfill interrupted by shutdown; writing pending batch");
+                            break;
+                        }
+                        next = gap_stream.next() => match next {
+                            Some(info) => info,
+                            None => break,
+                        },
+                    };
                     let done = info.height >= *gap_end;
                     // Store the source block hash alongside the root so canonical
                     // replacements (same root, different block) are reconciled across
@@ -221,7 +254,15 @@ async fn main() -> Result<()> {
                     }
                 }
 
+                if !batch_buf.is_empty() {
+                    store.put_roots(&batch_buf)?;
+                    batch_buf.clear();
+                }
                 store.flush().await?;
+                if *backfill_cancel.borrow() {
+                    tracing::info!(from = gap_start, filled, "backfill: stopped by shutdown");
+                    return Ok(());
+                }
                 tracing::info!(
                     from = gap_start,
                     to = gap_end,
@@ -295,14 +336,6 @@ async fn main() -> Result<()> {
             .ok();
     });
 
-    // ── Ctrl+C handler ──────────────────────────────────────────────────
-    let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel::<()>();
-    tokio::spawn(async move {
-        tokio::signal::ctrl_c().await.ok();
-        tracing::info!("shutting down...");
-        let _ = cancel_tx.send(());
-    });
-
     // ── Background flush task ───────────────────────────────────────────
     let flush_store = store.clone();
     let (flush_tx, mut flush_rx) = tokio::sync::mpsc::channel::<()>(1);
@@ -322,10 +355,12 @@ async fn main() -> Result<()> {
 
     let stream_timeout = Duration::from_secs(cfg.stream_timeout_secs);
     let mut last_height: Option<u64> = None;
+    // Stamped in the past so the first block at the tip is flushed immediately.
+    let mut last_tip_flush = Instant::now() - TIP_FLUSH_INTERVAL;
 
     loop {
         let next_item = tokio::select! {
-            _ = &mut cancel_rx => break,
+            _ = cancelled(&mut cancel_rx) => break,
             result = tokio::time::timeout(stream_timeout, root_stream.next()) => result,
         };
 
@@ -344,14 +379,34 @@ async fn main() -> Result<()> {
                     batch_buf.clear();
                 }
 
-                // Reconnect with exponential backoff.
+                // Reconnect with exponential backoff. Every wait here selects on the shutdown
+                // signal, so a SIGTERM during an outage (or a stuck stream constructor) still
+                // exits through the final-flush path instead of needing a kill.
                 let resume_from = last_height.map(|h| h + 1).unwrap_or(start_height);
                 let mut delay = RECONNECT_BASE_DELAY;
+                let mut shutting_down = false;
                 loop {
-                    tokio::time::sleep(delay).await;
+                    tokio::select! {
+                        _ = cancelled(&mut cancel_rx) => { shutting_down = true; break; }
+                        _ = tokio::time::sleep(delay) => {}
+                    }
                     tracing::info!(resume_from, "attempting stream reconnection...");
 
-                    match eth::Client::new(cfg.rpc_ws.as_str(), None).await {
+                    let connect = tokio::select! {
+                        _ = cancelled(&mut cancel_rx) => { shutting_down = true; break; }
+                        c = eth::Client::new(cfg.rpc_ws.as_str(), None) => c,
+                    };
+                    match connect {
+                        // The endpoint must still be the chain this archive is pinned to. A
+                        // DNS / load-balancer / provider flip to another chain is refused and
+                        // retried, never archived.
+                        Ok(new_ws) if new_ws.chain_id() != source_chain_id => {
+                            tracing::error!(
+                                expected = source_chain_id,
+                                got = new_ws.chain_id(),
+                                "⛔ reconnected WS endpoint serves a different chain; refusing it"
+                            );
+                        }
                         Ok(new_ws) => {
                             let new_config = stream_eth::roots::ConfigBuilder::new()
                                 .with_client(new_ws)
@@ -360,7 +415,11 @@ async fn main() -> Result<()> {
                                 .with_max_concurrency(cfg.max_fetch_tasks)
                                 .with_max_parallelism(compute_parallelism(cfg.max_fetch_tasks))
                                 .build();
-                            root_stream = stream_eth::StreamRoots::new(new_config).await;
+                            let built = tokio::select! {
+                                _ = cancelled(&mut cancel_rx) => { shutting_down = true; break; }
+                                s = stream_eth::StreamRoots::new(new_config) => s,
+                            };
+                            root_stream = built;
                             break;
                         }
                         Err(e) => {
@@ -369,6 +428,9 @@ async fn main() -> Result<()> {
                     }
 
                     delay = (delay * 2).min(RECONNECT_MAX_DELAY);
+                }
+                if shutting_down {
+                    break;
                 }
                 continue;
             }
@@ -388,7 +450,7 @@ async fn main() -> Result<()> {
             .end_height
             .unwrap_or_else(|| chain_head.load(Ordering::Acquire));
         let remaining = target.saturating_sub(height);
-        let at_tip = at_tip(remaining, cfg.flush_every);
+        let at_tip = at_tip(remaining, cfg.tip_window);
 
         // Write the batch when full, at the end, or whenever we are at the tip: batching there
         // only delays when the API can serve a root that is already mature, which is what
@@ -404,12 +466,16 @@ async fn main() -> Result<()> {
             break;
         }
 
-        // Durability flush + logging: every block at the tip, every `flush_every` otherwise.
-        let is_flush = at_tip || height % cfg.flush_every.get() == 0;
+        // Durability flush + logging: at the tip at most once per `TIP_FLUSH_INTERVAL` (the
+        // write above already made the root visible; sled's own timer flushes too), every
+        // `flush_every` blocks otherwise.
+        let is_flush =
+            should_request_flush(at_tip, height, cfg.flush_every, last_tip_flush.elapsed());
         let is_log = is_flush || count % cfg.flush_every.get() == 0;
 
         if is_flush {
             let _ = flush_tx.try_send(());
+            last_tip_flush = Instant::now();
         }
 
         if is_log {
@@ -451,13 +517,66 @@ async fn main() -> Result<()> {
 }
 
 /// True when the archiver is close enough to the chain head that batching would delay the
-/// visibility of mature roots: within one `flush_every` window of the target. At the tip
-/// `remaining` settles at the finalization lag (plus a little head-tracker latency), which is
-/// far below any sane `flush_every`, so tip-following writes and flushes every block without
-/// operators having to set `FLUSH_EVERY=1`. If the head tracker has no value yet (`0`),
-/// `remaining` is `0` and we err on the side of flushing.
-fn at_tip(remaining: u64, flush_every: std::num::NonZeroU64) -> bool {
-    remaining < flush_every.get()
+/// visibility of mature roots: within `tip_window` blocks of the target. At the tip
+/// `remaining` settles at the finalization lag (plus head-poll latency), which the default
+/// window covers with margin, so tip-following writes every block without operators having
+/// to set `FLUSH_EVERY=1`, while catch-up keeps batched writes right up to the last few
+/// hundred blocks. If the head tracker has no value yet (`0`), `remaining` is `0` and we err
+/// on the side of writing.
+fn at_tip(remaining: u64, tip_window: std::num::NonZeroU64) -> bool {
+    remaining < tip_window.get()
+}
+
+/// Whether to request a durability flush after this block. Catch-up flushes every
+/// `flush_every` blocks. At the tip, flushes are throttled to one per
+/// [`TIP_FLUSH_INTERVAL`]: the root is already visible from the write, and fsync-per-block
+/// was measured at ~9× slower for the final window of a catch-up.
+fn should_request_flush(
+    at_tip: bool,
+    height: u64,
+    flush_every: std::num::NonZeroU64,
+    since_last_tip_flush: Duration,
+) -> bool {
+    (at_tip && since_last_tip_flush >= TIP_FLUSH_INTERVAL) || height % flush_every.get() == 0
+}
+
+/// Resolves once the shutdown signal has fired. Cheap to call repeatedly from `select!`.
+async fn cancelled(rx: &mut tokio::sync::watch::Receiver<bool>) {
+    if *rx.borrow() {
+        return;
+    }
+    while rx.changed().await.is_ok() {
+        if *rx.borrow() {
+            return;
+        }
+    }
+    // Sender dropped: treat as shutdown so nothing waits forever.
+}
+
+/// SIGINT (Ctrl+C) or SIGTERM (what systemd / Kubernetes send). Either way the caller takes
+/// the graceful path: pending batch written, final flush, API drained.
+async fn wait_for_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        let mut term = match tokio::signal::unix::signal(
+            tokio::signal::unix::SignalKind::terminate(),
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!("failed to register SIGTERM handler: {e}; only Ctrl+C will shut down gracefully");
+                tokio::signal::ctrl_c().await.ok();
+                return;
+            }
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = term.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await.ok();
+    }
 }
 
 fn format_eta(remaining: u64, rate: f64) -> String {
@@ -517,22 +636,39 @@ fn resolve_finalization_lag(override_lag: Option<u64>, on_chain_lag: Option<u64>
 #[cfg(test)]
 mod tests {
     #[test]
-    fn at_tip_within_one_flush_window_of_the_head() {
-        let every = std::num::NonZeroU64::new(10_000).unwrap();
-        // Deep catch-up keeps batching.
-        assert!(!at_tip(45_000_000, every));
-        assert!(!at_tip(10_000, every));
-        // Inside the last window, and at the head itself (remaining == finalization lag).
-        assert!(at_tip(9_999, every));
-        assert!(at_tip(10, every));
-        assert!(at_tip(0, every));
+    fn at_tip_within_the_tip_window_of_the_head() {
+        let window = std::num::NonZeroU64::new(256).unwrap();
+        // Deep catch-up keeps batching, including the last FLUSH_EVERY-sized stretch.
+        assert!(!at_tip(45_000_000, window));
+        assert!(!at_tip(9_999, window));
+        assert!(!at_tip(256, window));
+        // Inside the window, and at the head itself (remaining == finalization lag).
+        assert!(at_tip(255, window));
+        assert!(at_tip(10, window));
+        assert!(at_tip(0, window));
     }
 
     #[test]
-    fn at_tip_with_flush_every_one_keeps_the_old_meaning() {
-        let one = std::num::NonZeroU64::new(1).unwrap();
-        assert!(at_tip(0, one));
-        assert!(!at_tip(1, one));
+    fn tip_flushes_are_throttled_and_catch_up_flushes_are_periodic() {
+        let every = std::num::NonZeroU64::new(10_000).unwrap();
+        // At the tip: only once the interval has elapsed since the last flush.
+        assert!(should_request_flush(true, 7, every, TIP_FLUSH_INTERVAL));
+        assert!(!should_request_flush(
+            true,
+            7,
+            every,
+            TIP_FLUSH_INTERVAL / 2
+        ));
+        // Catching up: every `flush_every` blocks regardless of timing.
+        assert!(should_request_flush(false, 20_000, every, Duration::ZERO));
+        assert!(!should_request_flush(
+            false,
+            20_001,
+            every,
+            Duration::from_secs(60)
+        ));
+        // A periodic boundary at the tip still flushes even inside the throttle window.
+        assert!(should_request_flush(true, 30_000, every, Duration::ZERO));
     }
 
     #[test]

--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -105,13 +105,6 @@ async fn main() -> Result<()> {
     }
     let source_chain_id = ws_client.chain_id();
 
-    // Pin the archive to this chain. A database that was built from another chain (or an
-    // endpoint that now serves another chain under the same name) is refused outright.
-    match store.pin_chain_id(source_chain_id)? {
-        None => tracing::info!(chain_id = source_chain_id, "pinned archive to source chain"),
-        Some(pinned) => tracing::debug!(chain_id = pinned, "archive chain pin verified"),
-    }
-
     // ── Registered chain (Creditcoin) ───────────────────────────────────
     // Previously this lookup only ran when FINALIZATION_LAG was unset, so every
     // deployment that pinned the lag skipped the chain_id verification along with it.
@@ -167,6 +160,15 @@ async fn main() -> Result<()> {
         }
     };
 
+    // Pin the archive to this chain, only now that the endpoint has passed every identity
+    // check above (ws/http agreement and, when `CHAIN_KEY` is set, the Creditcoin
+    // registration). Pinning earlier would record a wrong RPC's chain id on a first start
+    // that then exits on the registry mismatch, bricking an archive that never stored a root.
+    match store.pin_chain_id(source_chain_id)? {
+        None => tracing::info!(chain_id = source_chain_id, "pinned archive to source chain"),
+        Some(pinned) => tracing::debug!(chain_id = pinned, "archive chain pin verified"),
+    }
+
     // ── Determine finalization lag ──────────────────────────────────────
     let finaliztion_lag = resolve_finalization_lag(cfg.finalization_lag_override, on_chain_lag)?;
 
@@ -204,6 +206,17 @@ async fn main() -> Result<()> {
                 tracing::info!(from = gap_start, to = gap_end, "backfill: filling gap");
 
                 let ws_client = eth::Client::new(cfg.rpc_ws.as_str(), None).await?;
+                // Same identity rule as startup and reconnect: a fresh dial that lands on
+                // another chain must not fill gaps with foreign roots (the reorg guard only
+                // fires for heights that already exist, so gaps have no second line of
+                // defence).
+                if ws_client.chain_id() != source_chain_id {
+                    return Err(anyhow!(
+                        "backfill: WS endpoint serves chain_id {} but this archive is pinned to {}; aborting",
+                        ws_client.chain_id(),
+                        source_chain_id
+                    ));
+                }
                 let gap_config = stream_eth::roots::ConfigBuilder::new()
                     .with_client(ws_client)
                     .with_start_height(*gap_start)

--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -205,7 +205,16 @@ async fn main() -> Result<()> {
             for (gap_start, gap_end) in &gaps {
                 tracing::info!(from = gap_start, to = gap_end, "backfill: filling gap");
 
-                let ws_client = eth::Client::new(cfg.rpc_ws.as_str(), None).await?;
+                // Both the dial and `StreamRoots::new` (which retries the initial subscribe
+                // without bound) must yield to SIGTERM, or a shutdown during a source outage
+                // never reaches the final flush below.
+                let ws_client = tokio::select! {
+                    _ = cancelled(&mut backfill_cancel) => {
+                        tracing::info!("backfill interrupted by shutdown before dialing");
+                        return Ok(());
+                    }
+                    c = eth::Client::new(cfg.rpc_ws.as_str(), None) => c?,
+                };
                 // Same identity rule as startup and reconnect: a fresh dial that lands on
                 // another chain must not fill gaps with foreign roots (the reorg guard only
                 // fires for heights that already exist, so gaps have no second line of
@@ -225,7 +234,13 @@ async fn main() -> Result<()> {
                     .with_max_parallelism(compute_parallelism(cfg.max_fetch_tasks))
                     .build();
 
-                let mut gap_stream = stream_eth::StreamRoots::new(gap_config).await;
+                let mut gap_stream = tokio::select! {
+                    _ = cancelled(&mut backfill_cancel) => {
+                        tracing::info!("backfill interrupted by shutdown before subscribing");
+                        return Ok(());
+                    }
+                    s = stream_eth::StreamRoots::new(gap_config) => s,
+                };
                 let mut filled = 0u64;
                 let flush_size = cfg.flush_every.get() as usize;
                 let mut batch_buf = Vec::with_capacity(flush_size);
@@ -302,7 +317,14 @@ async fn main() -> Result<()> {
         .with_max_parallelism(compute_parallelism(cfg.max_fetch_tasks))
         .build();
 
-    let mut root_stream = stream_eth::StreamRoots::new(stream_config).await;
+    // The initial subscribe retries without bound while the source is down; let SIGTERM win.
+    let mut root_stream = tokio::select! {
+        _ = cancelled(&mut cancel_rx) => {
+            tracing::info!("shutdown requested before the root stream connected; exiting");
+            return Ok(());
+        }
+        s = stream_eth::StreamRoots::new(stream_config) => s,
+    };
 
     // ── Chain head tracker (for ETA) ───────────────────────────────────
     let current_head = http_client.get_last_block().await.unwrap_or(0);

--- a/archiver/src/store.rs
+++ b/archiver/src/store.rs
@@ -39,6 +39,11 @@ pub enum StoreError {
         incoming_root: H256,
         incoming_hash: H256,
     },
+    /// The database was built from a different source chain than the one the RPC endpoints
+    /// now serve. Archiving foreign roots under this archive name would silently corrupt
+    /// every proof later built from it, so this is fatal.
+    #[error("archive was built from chain_id {stored} but the source RPC now serves chain_id {live}; refusing to write foreign roots")]
+    ChainIdMismatch { stored: u64, live: u64 },
 }
 
 /// A stored entry: the merkle root plus the source block hash it was derived from.
@@ -63,6 +68,9 @@ const META_TREE: &[u8] = b"__archiver_meta";
 
 /// Key inside [`META_TREE`] that stores the cached entry counter as a u64-BE.
 const META_KEY_COUNT: &[u8] = b"count";
+/// Key inside [`META_TREE`] that pins the source chain id (u64-BE) this archive was built
+/// from. Set on the first run; every later run and every RPC reconnect must match it.
+const META_KEY_CHAIN_ID: &[u8] = b"chain_id";
 
 /// Thread-safe handle to the root store. Cheap to clone (wraps Arc<sled::Db>).
 #[derive(Clone)]
@@ -132,6 +140,32 @@ impl RootStore {
     /// backfill replays). Legacy entries (32-byte, hash unknown) only conflict on the
     /// root: a matching root with a previously-unknown hash is accepted and upgraded to
     /// the 64-byte layout.
+    /// Pin the source chain id this archive belongs to.
+    ///
+    /// The first call records `live`; every later call must pass the same value or fails
+    /// with [`StoreError::ChainIdMismatch`]. Returns the previously pinned id (`None` when
+    /// this call pinned it). A database written before this column existed is pinned on
+    /// its first start with the new binary.
+    pub fn pin_chain_id(&self, live: u64) -> Result<Option<u64>> {
+        match self.meta.get(META_KEY_CHAIN_ID)? {
+            Some(raw) => {
+                let bytes: [u8; 8] = raw.as_ref().try_into().with_context(|| {
+                    format!("invalid chain_id length: expected 8, got {}", raw.len())
+                })?;
+                let stored = u64::from_be_bytes(bytes);
+                if stored != live {
+                    return Err(StoreError::ChainIdMismatch { stored, live }.into());
+                }
+                Ok(Some(stored))
+            }
+            None => {
+                self.meta.insert(META_KEY_CHAIN_ID, &live.to_be_bytes())?;
+                self.meta.flush()?;
+                Ok(None)
+            }
+        }
+    }
+
     pub fn put_roots(&self, roots: &[(u64, H256, H256)]) -> Result<()> {
         // Reorg / inconsistency guard. Scan first; this is a cheap point-read per entry
         // and means we never run the batch insert with a mixed-conflict payload.
@@ -595,5 +629,38 @@ mod tests {
 
         let gaps = store.find_gaps(Some(5)).unwrap();
         assert_eq!(gaps, vec![(5, 9), (12, 14), (16, 19)]);
+    }
+
+    #[test]
+    fn chain_id_pins_on_first_run_and_matches_afterwards() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = RootStore::open(dir.path().join("test.sled")).unwrap();
+        assert_eq!(store.pin_chain_id(56).unwrap(), None);
+        assert_eq!(store.pin_chain_id(56).unwrap(), Some(56));
+        // Persisted in the meta tree (the reopen path is exercised by the sibling reopen
+        // tests; not repeated here to avoid the sled lock-release race they guard against).
+        assert_eq!(
+            store.meta.get(META_KEY_CHAIN_ID).unwrap().unwrap().as_ref(),
+            &56u64.to_be_bytes()
+        );
+    }
+
+    #[test]
+    fn chain_id_mismatch_is_fatal_and_leaves_the_pin_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = RootStore::open(dir.path().join("test.sled")).unwrap();
+        store.pin_chain_id(56).unwrap();
+        let err = store.pin_chain_id(1).unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<StoreError>(),
+                Some(StoreError::ChainIdMismatch {
+                    stored: 56,
+                    live: 1
+                })
+            ),
+            "{err:?}"
+        );
+        assert_eq!(store.pin_chain_id(56).unwrap(), Some(56));
     }
 }

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -80,6 +80,8 @@ pub enum Error {
     UrlParseError(#[from] url::ParseError),
     #[error("Unsupported URL scheme. Please use http(s):// or ws(s)://. Found: {0}")]
     UnsupportedUrl(String),
+    #[error("RPC endpoint changed chain on reconnect: expected chain_id {expected}, node now reports {got}; keeping the previous connection")]
+    ChainIdChanged { expected: u64, got: u64 },
 }
 
 impl Error {
@@ -500,6 +502,23 @@ impl Client {
 
     pub async fn reconnect(&mut self) -> Result<(), Error> {
         let (url, rpc_provider, chain_id) = Self::init_rpc(self.url.as_ref()).await?;
+
+        // Fail closed if the endpoint now serves a different chain (DNS / load-balancer /
+        // provider flip). Every caller treats a reconnect error as "retry later", which is
+        // exactly right: keep the old (dead) connection rather than silently continuing
+        // against foreign data.
+        if chain_id != self.chain_id {
+            tracing::error!(
+                url = %redact_url_query(url.as_str()),
+                expected = self.chain_id,
+                got = chain_id,
+                "⛔ RPC endpoint changed chain_id on reconnect; refusing to switch"
+            );
+            return Err(Error::ChainIdChanged {
+                expected: self.chain_id,
+                got: chain_id,
+            });
+        }
 
         // Reconnect each fallback against its own URL too, otherwise a
         // recovered primary would silently keep using a stale fallback


### PR DESCRIPTION
Follow-ups to the archiver liveness/performance audit of 2026-09-11 (findings 3, 5, 7). Findings 1 (watchdog over stream construction) and 2 (health/freshness) follow in separate PRs.

## Finding 3 – chain identity pinned across restarts and reconnects
- `RootStore::pin_chain_id`: the sled meta tree records the source `chain_id` on first run; every later start must match or the archiver exits with `archive was built from chain_id X but the source RPC now serves chain_id Y; refusing to write foreign roots`.
- Reconnect loop: a replacement WS client with a different `chain_id` is refused (logged at error) and retried, never archived.
- `eth::Client::reconnect` now fails closed with `Error::ChainIdChanged` instead of adopting the new chain id; the previous connection is kept and callers already treat reconnect errors as retryable (continuity, tip stream, attestor).

## Finding 5 – SIGTERM and shutdown during reconnect
- SIGTERM is handled like Ctrl+C (Kubernetes/systemd stop pods with SIGTERM; before, every pod stop was effectively a kill).
- The shutdown signal is a `watch` and is selected on in the main loop, the reconnect backoff sleep, the WS reconnect, the `StreamRoots` constructor wait, and the backfill poll loop. The audit's "SIGINT while replacement constructor is waiting → required a kill" case now exits through the final-batch/final-flush path.

## Finding 7 – flush window decoupled from `FLUSH_EVERY`
- New `--tip-window` / `TIP_WINDOW` (default 256 blocks): per-block writes only within this many blocks of the target. Previously (#1335) the window was `FLUSH_EVERY` = 10,000, so the last 10k blocks of any catch-up ran with a write + fsync per block (the audit measured ~9× slower over a 2,000-root catch-up).
- Durability flushes at the tip are throttled to one per `TIP_FLUSH_INTERVAL` (1 s). The write already makes the root visible to `/roots`; sled's own 500 ms flusher runs regardless.
- `FLUSH_EVERY` keeps its meaning as the catch-up batch size. Docs/README updated.

## Verification
- `cargo test -p archiver`: 20 passed (new: chain-id pin/mismatch, flush throttle, tip window).
- `cargo clippy -p archiver -p eth -p continuity -p stream_eth -p attestor -p proof-gen-api-server --all-targets -- -D warnings`, `cargo fmt --check`: clean.
- Local smoke against `reth --dev` (chain 1337) + anvil (31337): SIGTERM while following → `shutting down… / flushing final state… / archiver stopped` within 8 s; tip flush lines at ~1 s spacing; restarting the same sled against anvil → exit 1 with the mismatch error.
