### PR TITLE
fix(stream_eth): seed the block stream from eth_blockNumber and poll heads alongside newHeads

### DIFF
--- a/archiver/README.md
+++ b/archiver/README.md
@@ -42,6 +42,8 @@ All flags can also be set via environment variables (see below).
 | `--flush-every` | `FLUSH_EVERY` | `10000` | Catch-up batch size: write roots (and request a flush) every N blocks |
 | `--tip-window` | `TIP_WINDOW` | `256` | Within N blocks of the head, write every root immediately; durability flushes throttled to ~1/s |
 | `--backfill` | — | `false` | Scan for gaps and fill them before resuming |
+| `--head-poll-interval-secs` | `HEAD_POLL_INTERVAL_SECS` | `12` | `eth_blockNumber` poll alongside the `newHeads` subscription; bounds how long a silent subscription can stall archiving |
+| `--rpc-timeout-secs` | `RPC_TIMEOUT_SECS` | `30` | Deadline per RPC call while (re)establishing the block stream |
 | `--finalization_lag_override` | - | *(none)* | Configurable finalization lag override |
 
 A `.env` file in the working directory is loaded automatically.

--- a/archiver/src/config.rs
+++ b/archiver/src/config.rs
@@ -87,4 +87,15 @@ pub struct Config {
     /// Scan the database for gaps and fill them before resuming normal operation.
     #[arg(long, default_value_t = false)]
     pub backfill: bool,
+
+    /// Seconds between `eth_blockNumber` polls that run alongside the `newHeads` subscription.
+    /// The poll is the liveness floor: a subscription that acknowledges but stops delivering
+    /// headers cannot stall archiving for longer than this.
+    #[arg(long, env = "HEAD_POLL_INTERVAL_SECS", default_value = "12")]
+    pub head_poll_interval_secs: NonZeroU64,
+
+    /// Deadline in seconds for each RPC call made while (re)establishing the block stream
+    /// (subscribe, initial head read, head polls). alloy transports have no default timeout.
+    #[arg(long, env = "RPC_TIMEOUT_SECS", default_value = "30")]
+    pub rpc_timeout_secs: NonZeroU64,
 }

--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -232,6 +232,8 @@ async fn main() -> Result<()> {
                     .with_finalization_lag(finaliztion_lag)
                     .with_max_concurrency(cfg.max_fetch_tasks)
                     .with_max_parallelism(compute_parallelism(cfg.max_fetch_tasks))
+                    .with_head_poll_interval(Duration::from_secs(cfg.head_poll_interval_secs.get()))
+                    .with_rpc_call_timeout(Duration::from_secs(cfg.rpc_timeout_secs.get()))
                     .build();
 
                 let mut gap_stream = tokio::select! {
@@ -315,6 +317,8 @@ async fn main() -> Result<()> {
         .with_finalization_lag(finaliztion_lag)
         .with_max_concurrency(cfg.max_fetch_tasks)
         .with_max_parallelism(compute_parallelism(cfg.max_fetch_tasks))
+        .with_head_poll_interval(Duration::from_secs(cfg.head_poll_interval_secs.get()))
+        .with_rpc_call_timeout(Duration::from_secs(cfg.rpc_timeout_secs.get()))
         .build();
 
     // The initial subscribe retries without bound while the source is down; let SIGTERM win.
@@ -449,6 +453,12 @@ async fn main() -> Result<()> {
                                 .with_finalization_lag(finaliztion_lag)
                                 .with_max_concurrency(cfg.max_fetch_tasks)
                                 .with_max_parallelism(compute_parallelism(cfg.max_fetch_tasks))
+                                .with_head_poll_interval(Duration::from_secs(
+                                    cfg.head_poll_interval_secs.get(),
+                                ))
+                                .with_rpc_call_timeout(Duration::from_secs(
+                                    cfg.rpc_timeout_secs.get(),
+                                ))
                                 .build();
                             let built = tokio::select! {
                                 _ = cancelled(&mut cancel_rx) => { shutting_down = true; break; }

--- a/common/streams/eth/src/roots.rs
+++ b/common/streams/eth/src/roots.rs
@@ -324,13 +324,16 @@ async fn stream_rpc(
     let subscribed = stream_headers.map(|header| Some(header.number));
     let poll_client = config.client.clone();
     let poll_timeout = config.rpc_call_timeout;
-    let polled = futures::stream::unfold(
-        tokio::time::interval(config.head_poll_interval),
-        |mut ticker| async move {
-            ticker.tick().await;
-            Some(((), ticker))
-        },
-    )
+    // `Delay` rather than tokio's default `Burst`: this stream is not polled while
+    // `expand_heads` drains the seeded `start..=head` range, and after a long catch-up the
+    // missed ticks would otherwise fire back-to-back as a flood of `eth_blockNumber` calls on
+    // the same socket that carries block fetches and `newHeads`.
+    let mut ticker = tokio::time::interval(config.head_poll_interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let polled = futures::stream::unfold(ticker, |mut ticker| async move {
+        ticker.tick().await;
+        Some(((), ticker))
+    })
     .skip(1) // the first tick fires immediately; the seed above already covered it
     .then(move |_| {
         let client = poll_client.clone();

--- a/common/streams/eth/src/roots.rs
+++ b/common/streams/eth/src/roots.rs
@@ -18,7 +18,23 @@ pub struct Config {
     /// existing builders keep working.
     #[default(usc_abi_encoding::common::EncodingVersion::V1)]
     pub encoding: usc_abi_encoding::common::EncodingVersion,
+
+    /// How often to poll `eth_blockNumber` alongside the `newHeads` subscription. The poll is
+    /// the liveness floor: a subscription that acknowledges but stops delivering headers (seen
+    /// through proxies and load balancers) no longer stalls the stream, and no work waits on
+    /// a future header before it can start.
+    #[default(DEFAULT_HEAD_POLL_INTERVAL)]
+    pub head_poll_interval: std::time::Duration,
+
+    /// Deadline for the individual RPC calls made while establishing the stream (subscribe,
+    /// initial head). alloy transports have no default timeout, so without this a blackholed
+    /// endpoint could hang construction indefinitely.
+    #[default(DEFAULT_RPC_CALL_TIMEOUT)]
+    pub rpc_call_timeout: std::time::Duration,
 }
+
+pub const DEFAULT_HEAD_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(12);
+pub const DEFAULT_RPC_CALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Ordered Eth root stream, backed by [`eth::Client`] under the hood.
 ///
@@ -254,25 +270,44 @@ async fn stream_rpc(
 ) -> stream_util::BoxedStream<Result<eth::OrderedBlock, Error>> {
     use futures::StreamExt as _;
 
-    // Initial subscribe, repairing the client between attempts. This runs from `new()` and from
-    // `reset()` (whose backup config's client may have died since construction), and as the
-    // second layer under `StreamRoots::reconnect`. `eth::Client` is a value clone — a dead
-    // connection inside it never self-heals — so a loop that only re-`subscribe()`s can spin on
-    // a dead client forever, pinning production until the watchdog restarts the pod. The
-    // repaired client stays in `config`, so the block fetches in the stream body use it too.
-    // First attempt goes straight to `subscribe()` so a healthy construction pays no extra dial.
+    // Initial subscribe + head read, repairing the client between attempts. This runs from
+    // `new()` and from `reset()` (whose backup config's client may have died since
+    // construction), and as the second layer under `StreamRoots::reconnect`. `eth::Client` is
+    // a value clone — a dead connection inside it never self-heals — so a loop that only
+    // re-`subscribe()`s can spin on a dead client forever, pinning production until the
+    // watchdog restarts the pod. The repaired client stays in `config`, so the block fetches
+    // in the stream body use it too. First attempt goes straight to `subscribe()` so a healthy
+    // construction pays no extra dial.
+    //
+    // The starting head comes from `eth_blockNumber`, not from the first `newHeads` frame:
+    // catch-up begins immediately, and a subscription that acknowledges but never delivers
+    // (or a chain that is simply idle) cannot hold construction hostage. Each attempt is
+    // bounded by `rpc_call_timeout`.
     let mut delays = tokio_retry::strategy::ExponentialBackoff::from_millis(100)
         .max_delay(std::time::Duration::from_millis(5_000))
         .map(tokio_retry::strategy::jitter);
-    let (stream_headers, next) = loop {
-        match config.client.subscribe().await.map_err(Error::Client) {
-            Ok(mut stream_headers) => match stream_headers.next().await {
-                Some(header) => break (stream_headers, header.number),
-                None => tracing::warn!("Eth header stream ended before yielding — retrying"),
-            },
-            Err(err) => {
-                tracing::warn!(?err, "Eth subscribe failed — repairing client and retrying");
+    let (stream_headers, head) = loop {
+        let attempt = async {
+            let headers = config.client.subscribe().await.map_err(Error::Client)?;
+            let head = config
+                .client
+                .get_last_block()
+                .await
+                .map_err(Error::Client)?;
+            Ok::<_, Error>((headers, head))
+        };
+        match tokio::time::timeout(config.rpc_call_timeout, attempt).await {
+            Ok(Ok(seed)) => break seed,
+            Ok(Err(err)) => {
+                tracing::warn!(
+                    ?err,
+                    "Eth subscribe/head read failed — repairing client and retrying"
+                )
             }
+            Err(_) => tracing::warn!(
+                timeout = ?config.rpc_call_timeout,
+                "Eth subscribe/head read timed out — repairing client and retrying"
+            ),
         }
         if let Err(err) = config.client.reconnect().await {
             tracing::warn!(?err, "Eth client reconnect failed");
@@ -283,25 +318,45 @@ async fn stream_rpc(
         tokio::time::sleep(delay).await;
     };
 
-    let mut stream_n = futures::stream::iter(config.start_height..=next)
-        .chain(
-            stream_headers
-                .scan(next + 1, |next, header| {
-                    // Backfill missing blocks
-                    if header.number >= *next {
-                        let missing = *next..=header.number;
-                        *next = header.number + 1;
-                        futures::future::ready(Some(futures::stream::iter(missing)))
-                    } else {
-                        #[allow(clippy::reversed_empty_ranges)]
-                        futures::future::ready(Some(futures::stream::iter(1..=0)))
-                    }
-                })
-                .flatten(),
-        )
+    // Head numbers from the subscription, merged with a periodic `eth_blockNumber` poll. The
+    // merged stream ends when the subscription ends (that is how a dead socket surfaces and
+    // triggers reconnection); poll results only ever advance the target.
+    let subscribed = stream_headers.map(|header| Some(header.number));
+    let poll_client = config.client.clone();
+    let poll_timeout = config.rpc_call_timeout;
+    let polled = futures::stream::unfold(
+        tokio::time::interval(config.head_poll_interval),
+        |mut ticker| async move {
+            ticker.tick().await;
+            Some(((), ticker))
+        },
+    )
+    .skip(1) // the first tick fires immediately; the seed above already covered it
+    .then(move |_| {
+        let client = poll_client.clone();
+        async move {
+            match tokio::time::timeout(poll_timeout, client.get_last_block()).await {
+                Ok(Ok(n)) => Some(n),
+                Ok(Err(err)) => {
+                    tracing::debug!(%err, "head poll failed; relying on subscription");
+                    None
+                }
+                Err(_) => {
+                    tracing::debug!("head poll timed out; relying on subscription");
+                    None
+                }
+            }
+        }
+    })
+    .filter_map(futures::future::ready);
+    let heads = merge_heads(subscribed, polled.map(Some));
+
+    // Boxed: the poll side holds `!Unpin` futures and `select!` needs `Unpin` to call `next()`.
+    let mut stream_n = expand_heads(config.start_height, head, heads)
         .skip_while(move |number| {
             futures::future::ready(*number < config.start_height + config.finalization_lag)
-        });
+        })
+        .boxed();
 
     let mut blocks = tokio::task::JoinSet::new();
 
@@ -383,4 +438,88 @@ async fn stream_rpc(
         }
     }
     .boxed()
+}
+
+/// Merge subscription head numbers with polled head numbers. `subscribed` yields `Some(n)` per
+/// header and must be followed by a `None` sentinel when the subscription ends; the merged
+/// stream ends there, so a dead socket still surfaces as "stream ended" to the caller. Polled
+/// values are plain `Some(n)`.
+fn merge_heads<S, P>(subscribed: S, polled: P) -> impl futures::Stream<Item = u64>
+where
+    S: futures::Stream<Item = Option<u64>>,
+    P: futures::Stream<Item = Option<u64>>,
+{
+    use futures::StreamExt as _;
+    let subscribed = subscribed.chain(futures::stream::once(futures::future::ready(None)));
+    futures::stream::select(subscribed, polled)
+        .take_while(|head| futures::future::ready(head.is_some()))
+        .filter_map(futures::future::ready)
+}
+
+/// The height sequence to fetch: `start..=head` up front, then every height newly revealed by
+/// a head observation. Observations that do not advance the frontier (repeats, lower heads
+/// from a lagging peer) contribute nothing, so subscription and poll can freely overlap.
+fn expand_heads<H>(
+    start: attestor_primitives::Height,
+    head: attestor_primitives::Height,
+    heads: H,
+) -> impl futures::Stream<Item = attestor_primitives::Height>
+where
+    H: futures::Stream<Item = attestor_primitives::Height>,
+{
+    use futures::StreamExt as _;
+    futures::stream::iter(start..=head).chain(
+        heads
+            .scan(head + 1, |next, observed| {
+                if observed >= *next {
+                    let missing = *next..=observed;
+                    *next = observed + 1;
+                    futures::future::ready(Some(futures::stream::iter(missing)))
+                } else {
+                    #[allow(clippy::reversed_empty_ranges)]
+                    futures::future::ready(Some(futures::stream::iter(1..=0)))
+                }
+            })
+            .flatten(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt as _;
+
+    #[tokio::test]
+    async fn expand_heads_fills_gaps_and_ignores_non_advancing_observations() {
+        let heads = futures::stream::iter(vec![5u64, 5, 7, 6, 10]);
+        let got: Vec<u64> = expand_heads(3, 5, heads).collect().await;
+        assert_eq!(got, vec![3, 4, 5, 6, 7, 8, 9, 10]);
+    }
+
+    #[tokio::test]
+    async fn expand_heads_starts_immediately_from_the_seeded_head() {
+        // No subsequent observation at all: catch-up to the seeded head still happens.
+        let got: Vec<u64> = expand_heads(10, 12, futures::stream::pending::<u64>())
+            .take(3)
+            .collect()
+            .await;
+        assert_eq!(got, vec![10, 11, 12]);
+    }
+
+    #[tokio::test]
+    async fn merged_heads_keep_flowing_from_polls_while_the_subscription_is_silent() {
+        // Subscription acknowledged but never delivers; polls carry the stream.
+        let silent = futures::stream::pending::<Option<u64>>();
+        let polls = futures::stream::iter(vec![Some(4u64), Some(6)]);
+        let got: Vec<u64> = merge_heads(silent, polls).take(2).collect().await;
+        assert_eq!(got, vec![4, 6]);
+    }
+
+    #[tokio::test]
+    async fn merged_heads_end_when_the_subscription_ends() {
+        let subscribed = futures::stream::iter(vec![Some(1u64), Some(2)]);
+        let polls = futures::stream::pending::<Option<u64>>();
+        let got: Vec<u64> = merge_heads(subscribed, polls).collect().await;
+        assert_eq!(got, vec![1, 2]);
+    }
 }


### PR DESCRIPTION
Stacked on #1344 (base is `fix/archiver-liveness-a`; retarget to `usc-dev` once that merges). Liveness audit finding 1.

## Problem
`stream_rpc` waited for the **first `newHeads` frame with no deadline** before any historical work could start, and the archiver awaited that constructor at startup, in backfill and inside its reconnect loop. A subscription that acknowledges but never delivers (seen through proxies/load balancers, or simply an idle chain) wedged the process indefinitely while `/status` kept returning 200. The audit reproduced this: "suppress notifications on replacement sockets → stalled at height 24 with no further connection attempts".

## Fix
- **Seed from `eth_blockNumber`**: catch-up begins immediately and never depends on a future header. Each subscribe/head attempt is bounded by `rpc_call_timeout` (default 30 s; alloy transports have no default timeout).
- **Merged head sources**: subscription head numbers are merged with a periodic `eth_blockNumber` poll (`head_poll_interval`, default 12 s). Observations that don't advance the frontier contribute nothing, so the two sources overlap freely. The merged stream still **ends when the subscription ends**, so a dead socket surfaces exactly as before and triggers reconnection.
- `expand_heads` / `merge_heads` extracted as pure functions with unit tests (the first tests in `stream_eth`).
- Archiver: `--head-poll-interval-secs` / `HEAD_POLL_INTERVAL_SECS` and `--rpc-timeout-secs` / `RPC_TIMEOUT_SECS`, plumbed into all three stream constructions. The attestor uses the same `StreamRoots` and picks up the defaults unchanged.

## Verification
- `cargo test -p stream_eth -p archiver`: 4 new + 20 passing; clippy `-D warnings` on stream_eth/archiver/attestor; fmt clean.
- Reproduced the audit scenario with a frame-dropping WS proxy in front of `reth --dev` (1 s blocks, poll 3 s):

| Scenario | Result |
|---|---|
| Start with `eth_subscription` frames suppressed | API up at t+12 s, archived 14 (head 16); t+18 s archived 21 → **progress while silent** |
| Restore notifications | t+22 s archived 27 = head |
| Suppress again mid-run | t+30 s archived 33 (head 34) → **progress while silent** |
| Watchdog reconnects during the run | 0 |
| SIGTERM | graceful stop |

Previously the first scenario left the process alive with no API listener and no progress (audit table, last row).
