### PR TITLE
feat(archiver): freshness-aware /status and a /ready probe

### DIFF
--- a/archiver/README.md
+++ b/archiver/README.md
@@ -44,6 +44,8 @@ All flags can also be set via environment variables (see below).
 | `--backfill` | — | `false` | Scan for gaps and fill them before resuming |
 | `--head-poll-interval-secs` | `HEAD_POLL_INTERVAL_SECS` | `12` | `eth_blockNumber` poll alongside the `newHeads` subscription; bounds how long a silent subscription can stall archiving |
 | `--rpc-timeout-secs` | `RPC_TIMEOUT_SECS` | `30` | Deadline per RPC call while (re)establishing the block stream |
+| `--ready-lag-blocks` | `READY_LAG_BLOCKS` | `1000` | `/ready` is 503 when more than this many blocks behind the mature target |
+| `--stale-after-secs` | `STALE_AFTER_SECS` | `60` | `/ready` is 503 when the source head has not been sampled for this long |
 | `--finalization_lag_override` | - | *(none)* | Configurable finalization lag override |
 
 A `.env` file in the working directory is loaded automatically.
@@ -52,14 +54,38 @@ A `.env` file in the working directory is loaded automatically.
 
 ### `GET /status`
 
-Returns archiver status.
+Liveness plus freshness. Always `200` while the store is readable (a store error is `500`), so a
+stale archive is visible in the body rather than hidden behind a status code. Ages are
+milliseconds; `null` means "never".
 
 ```json
 {
+  "chain_id": 56,
+  "finalization_lag": 10,
+  "uptime_ms": 86400000,
   "latest_archived_block": 1234567,
-  "total_blocks": 1234568
+  "total_blocks": 1234568,
+  "source_head": 1234580,
+  "source_head_age_ms": 2100,
+  "mature_target": 1234570,
+  "lag_blocks": 3,
+  "last_progress_age_ms": 900,
+  "last_flush_ok_age_ms": 400,
+  "flush_errors": 0,
+  "last_flush_error": null,
+  "reconnects": 2,
+  "ready": true,
+  "not_ready_reasons": []
 }
 ```
+
+### `GET /ready`
+
+Same body as `/status`; `200` only when the source head was sampled within `STALE_AFTER_SECS`,
+`lag_blocks <= READY_LAG_BLOCKS`, and the last durability flush succeeded, otherwise `503`.
+Point Kubernetes readiness probes and the proof provider's health check here. A halted source
+chain with a fresh head sample and full coverage is ready; a silently stale subscription with an
+unchanged height is not.
 
 ### `GET /roots/latest`
 

--- a/archiver/src/api.rs
+++ b/archiver/src/api.rs
@@ -1,7 +1,8 @@
 //! HTTP API for serving archived root data.
 //!
 //! Endpoints:
-//! - GET /status          — archiver status (latest block, total stored)
+//! - GET /status          — liveness + freshness snapshot (always 200 when the store is readable)
+//! - GET /ready           — same body; 200 only when the archive is current and durable, else 503
 //! - GET /roots/latest    — latest archived block number
 //! - GET /roots           — roots for a block range (?from=X&to=Y)
 
@@ -17,17 +18,20 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use tower_http::trace::TraceLayer;
 
+use crate::health::{Health, HealthSnapshot};
 use crate::store::RootStore;
 
 /// Shared application state for the API handlers.
 pub struct AppState {
     pub store: RootStore,
     pub max_api_range: u64,
+    pub health: Arc<Health>,
 }
 
 pub fn router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/status", get(status))
+        .route("/ready", get(ready))
         .route("/roots/latest", get(roots_latest))
         .route("/roots", get(roots))
         .layer(TraceLayer::new_for_http())
@@ -36,19 +40,39 @@ pub fn router(state: Arc<AppState>) -> Router {
 
 // ── Handlers ────────────────────────────────────────────────────────────────
 
-#[derive(Serialize)]
-struct StatusResponse {
-    latest_archived_block: Option<u64>,
-    total_blocks: usize,
+fn snapshot(state: &AppState) -> Result<HealthSnapshot, (StatusCode, String)> {
+    // A storage error is a failure, not `null`: it must page, not read as an empty archive.
+    let latest = state.store.latest_height().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("store read failed: {e}"),
+        )
+    })?;
+    Ok(state.health.snapshot(latest, state.store.count()))
 }
 
-async fn status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let latest = state.store.latest_height().ok().flatten();
+/// Liveness plus the freshness fields. Always 200 while the store is readable, so a stale
+/// archive is visible in the body (`ready`, `lag_blocks`, `source_head_age_ms`, ...) rather
+/// than hidden behind a status code.
+async fn status(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    snapshot(&state).map(Json)
+}
 
-    Json(StatusResponse {
-        latest_archived_block: latest,
-        total_blocks: state.store.count(),
-    })
+/// Readiness: 200 only when the source head was observed recently, the archive is within the
+/// allowed lag of the mature target, and the last durability flush succeeded. Point
+/// Kubernetes readiness probes and the proof provider's health check here.
+async fn ready(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let snap = snapshot(&state)?;
+    let code = if snap.ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    Ok((code, Json(snap)))
 }
 
 #[derive(Serialize)]
@@ -56,11 +80,18 @@ struct LatestResponse {
     latest_block: Option<u64>,
 }
 
-async fn roots_latest(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let latest = state.store.latest_height().ok().flatten();
-    Json(LatestResponse {
+async fn roots_latest(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let latest = state.store.latest_height().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("store read failed: {e}"),
+        )
+    })?;
+    Ok(Json(LatestResponse {
         latest_block: latest,
-    })
+    }))
 }
 
 #[derive(Deserialize)]

--- a/archiver/src/config.rs
+++ b/archiver/src/config.rs
@@ -98,4 +98,16 @@ pub struct Config {
     /// (subscribe, initial head read, head polls). alloy transports have no default timeout.
     #[arg(long, env = "RPC_TIMEOUT_SECS", default_value = "30")]
     pub rpc_timeout_secs: NonZeroU64,
+
+    /// `/ready` reports 503 when the archive is more than this many blocks behind the mature
+    /// target (`source head - finalization lag`). Size it to the chain's block rate: it is the
+    /// catch-up debt you are willing to serve proofs from.
+    #[arg(long, env = "READY_LAG_BLOCKS", default_value = "1000")]
+    pub ready_lag_blocks: u64,
+
+    /// `/ready` reports 503 when the source head has not been sampled successfully for this
+    /// many seconds. Distinguishes "the chain is idle" (fresh sample, no new blocks: ready)
+    /// from "we lost sight of the chain" (not ready).
+    #[arg(long, env = "STALE_AFTER_SECS", default_value = "60")]
+    pub stale_after_secs: NonZeroU64,
 }

--- a/archiver/src/health.rs
+++ b/archiver/src/health.rs
@@ -1,0 +1,265 @@
+//! Progress / freshness bookkeeping behind `/status` and `/ready`.
+//!
+//! Liveness (the process answers) and readiness (the archive is current and durable) are
+//! deliberately separate. A halted source chain with a fresh head sample and full coverage is
+//! healthy; a silently stale subscription with an unchanged height is not, even though both
+//! return HTTP 200 on `/status`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+
+/// Sentinel for "never happened" in the millisecond-offset atomics.
+const NEVER: u64 = u64::MAX;
+
+pub struct Health {
+    started: Instant,
+    pub chain_id: u64,
+    pub finalization_lag: u64,
+    ready_lag_blocks: u64,
+    stale_after: Duration,
+
+    source_head: AtomicU64,
+    source_head_at: AtomicU64,
+    last_progress_height: AtomicU64,
+    last_progress_at: AtomicU64,
+    last_flush_ok_at: AtomicU64,
+    flush_errors: AtomicU64,
+    last_flush_error: Mutex<Option<String>>,
+    reconnects: AtomicU64,
+}
+
+/// What `/status` and `/ready` serialize. Ages are milliseconds; `null` means "never".
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct HealthSnapshot {
+    pub chain_id: u64,
+    pub finalization_lag: u64,
+    pub uptime_ms: u64,
+    pub latest_archived_block: Option<u64>,
+    pub total_blocks: usize,
+    pub source_head: Option<u64>,
+    pub source_head_age_ms: Option<u64>,
+    /// `source_head - finalization_lag`: the highest block the archiver should have by now.
+    pub mature_target: Option<u64>,
+    /// `mature_target - latest_archived_block`, floored at 0.
+    pub lag_blocks: Option<u64>,
+    pub last_progress_age_ms: Option<u64>,
+    pub last_flush_ok_age_ms: Option<u64>,
+    pub flush_errors: u64,
+    pub last_flush_error: Option<String>,
+    pub reconnects: u64,
+    pub ready: bool,
+    /// Human-readable reasons when `ready` is false; empty otherwise.
+    pub not_ready_reasons: Vec<String>,
+}
+
+impl Health {
+    pub fn new(
+        chain_id: u64,
+        finalization_lag: u64,
+        ready_lag_blocks: u64,
+        stale_after: Duration,
+    ) -> Self {
+        Self {
+            started: Instant::now(),
+            chain_id,
+            finalization_lag,
+            ready_lag_blocks,
+            stale_after,
+            source_head: AtomicU64::new(0),
+            source_head_at: AtomicU64::new(NEVER),
+            last_progress_height: AtomicU64::new(0),
+            last_progress_at: AtomicU64::new(NEVER),
+            last_flush_ok_at: AtomicU64::new(NEVER),
+            flush_errors: AtomicU64::new(0),
+            last_flush_error: Mutex::new(None),
+            reconnects: AtomicU64::new(0),
+        }
+    }
+
+    fn now_ms(&self) -> u64 {
+        self.started.elapsed().as_millis() as u64
+    }
+
+    fn age(&self, at: u64) -> Option<u64> {
+        (at != NEVER).then(|| self.now_ms().saturating_sub(at))
+    }
+
+    pub fn note_head(&self, head: u64) {
+        self.source_head.store(head, Ordering::Release);
+        self.source_head_at.store(self.now_ms(), Ordering::Release);
+    }
+
+    pub fn note_progress(&self, height: u64) {
+        self.last_progress_height.store(height, Ordering::Release);
+        self.last_progress_at
+            .store(self.now_ms(), Ordering::Release);
+    }
+
+    pub fn note_flush_ok(&self) {
+        self.last_flush_ok_at
+            .store(self.now_ms(), Ordering::Release);
+        *self
+            .last_flush_error
+            .lock()
+            .unwrap_or_else(|p| p.into_inner()) = None;
+    }
+
+    pub fn note_flush_error(&self, err: impl ToString) {
+        self.flush_errors.fetch_add(1, Ordering::AcqRel);
+        *self
+            .last_flush_error
+            .lock()
+            .unwrap_or_else(|p| p.into_inner()) = Some(err.to_string());
+    }
+
+    pub fn note_reconnect(&self) {
+        self.reconnects.fetch_add(1, Ordering::AcqRel);
+    }
+
+    /// Evaluate readiness against the store's view. Pure apart from reading the clock.
+    pub fn snapshot(
+        &self,
+        latest_archived_block: Option<u64>,
+        total_blocks: usize,
+    ) -> HealthSnapshot {
+        let head_at = self.source_head_at.load(Ordering::Acquire);
+        let source_head = (head_at != NEVER).then(|| self.source_head.load(Ordering::Acquire));
+        let source_head_age_ms = self.age(head_at);
+        let mature_target = source_head.map(|h| h.saturating_sub(self.finalization_lag));
+        let lag_blocks = match (mature_target, latest_archived_block) {
+            (Some(target), Some(latest)) => Some(target.saturating_sub(latest)),
+            (Some(target), None) => Some(target),
+            _ => None,
+        };
+        let last_flush_error = self
+            .last_flush_error
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone();
+
+        let mut not_ready_reasons = Vec::new();
+        match source_head_age_ms {
+            None => not_ready_reasons.push("source head never observed".to_owned()),
+            Some(age) if age > self.stale_after.as_millis() as u64 => {
+                not_ready_reasons.push(format!(
+                    "source head sample is {age} ms old (stale after {} ms)",
+                    self.stale_after.as_millis()
+                ))
+            }
+            _ => {}
+        }
+        match lag_blocks {
+            Some(lag) if lag > self.ready_lag_blocks => not_ready_reasons.push(format!(
+                "{lag} blocks behind the mature target (allowed {})",
+                self.ready_lag_blocks
+            )),
+            _ => {}
+        }
+        if let Some(err) = &last_flush_error {
+            not_ready_reasons.push(format!("last flush failed: {err}"));
+        }
+
+        HealthSnapshot {
+            chain_id: self.chain_id,
+            finalization_lag: self.finalization_lag,
+            uptime_ms: self.now_ms(),
+            latest_archived_block,
+            total_blocks,
+            source_head,
+            source_head_age_ms,
+            mature_target,
+            lag_blocks,
+            last_progress_age_ms: self.age(self.last_progress_at.load(Ordering::Acquire)),
+            last_flush_ok_age_ms: self.age(self.last_flush_ok_at.load(Ordering::Acquire)),
+            flush_errors: self.flush_errors.load(Ordering::Acquire),
+            last_flush_error,
+            reconnects: self.reconnects.load(Ordering::Acquire),
+            ready: not_ready_reasons.is_empty(),
+            not_ready_reasons,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn health() -> Health {
+        Health::new(56, 10, 1_000, Duration::from_secs(60))
+    }
+
+    #[test]
+    fn not_ready_until_the_source_head_has_been_observed() {
+        let h = health();
+        let s = h.snapshot(Some(100), 101);
+        assert!(!s.ready);
+        assert_eq!(
+            s.not_ready_reasons,
+            vec!["source head never observed".to_owned()]
+        );
+        assert_eq!(s.lag_blocks, None);
+    }
+
+    #[test]
+    fn ready_when_within_lag_and_head_is_fresh() {
+        let h = health();
+        h.note_head(1_000_500);
+        h.note_progress(1_000_000);
+        let s = h.snapshot(Some(1_000_000), 1);
+        assert_eq!(s.mature_target, Some(1_000_490));
+        assert_eq!(s.lag_blocks, Some(490));
+        assert!(s.ready, "{:?}", s.not_ready_reasons);
+    }
+
+    #[test]
+    fn a_halted_source_with_full_coverage_is_still_ready() {
+        // No progress for a long time is fine as long as we have observed the head recently
+        // and we are caught up to it: the chain is idle, not the archiver.
+        let h = health();
+        h.note_head(5_000);
+        let s = h.snapshot(Some(4_990), 4_991);
+        assert_eq!(s.lag_blocks, Some(0));
+        assert!(s.ready);
+    }
+
+    #[test]
+    fn falling_behind_the_mature_target_is_not_ready() {
+        let h = health();
+        h.note_head(50_000);
+        let s = h.snapshot(Some(10_000), 10_001);
+        assert!(!s.ready);
+        assert_eq!(s.lag_blocks, Some(39_990));
+        assert!(s.not_ready_reasons[0].contains("blocks behind"));
+    }
+
+    #[test]
+    fn flush_errors_block_readiness_until_the_next_successful_flush() {
+        let h = health();
+        h.note_head(100);
+        h.note_flush_error("disk full");
+        let s = h.snapshot(Some(90), 91);
+        assert!(!s.ready);
+        assert_eq!(s.flush_errors, 1);
+        assert_eq!(s.last_flush_error.as_deref(), Some("disk full"));
+        h.note_flush_ok();
+        let s = h.snapshot(Some(90), 91);
+        assert!(s.ready);
+        assert_eq!(
+            s.flush_errors, 1,
+            "the counter is history, the error is cleared"
+        );
+        assert_eq!(s.last_flush_error, None);
+    }
+
+    #[test]
+    fn empty_archive_reports_the_whole_target_as_lag() {
+        let h = Health::new(1, 0, 100, Duration::from_secs(60));
+        h.note_head(250);
+        let s = h.snapshot(None, 0);
+        assert_eq!(s.lag_blocks, Some(250));
+        assert!(!s.ready);
+    }
+}

--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -35,6 +35,7 @@ fn compute_parallelism(max_fetch_tasks: std::num::NonZeroUsize) -> std::num::Non
 
 mod api;
 mod config;
+mod health;
 mod store;
 
 use config::Config;
@@ -330,17 +331,48 @@ async fn main() -> Result<()> {
         s = stream_eth::StreamRoots::new(stream_config) => s,
     };
 
-    // ── Chain head tracker (for ETA) ───────────────────────────────────
-    let current_head = http_client.get_last_block().await.unwrap_or(0);
+    let cfg_rpc_timeout_secs = cfg.rpc_timeout_secs.get();
+    let head_poll_interval = Duration::from_secs(cfg.head_poll_interval_secs.get());
+
+    // ── Health / freshness bookkeeping ──────────────────────────────────
+    let health = Arc::new(health::Health::new(
+        source_chain_id,
+        finaliztion_lag,
+        cfg.ready_lag_blocks,
+        Duration::from_secs(cfg.stale_after_secs.get()),
+    ));
+
+    // ── Chain head tracker (for ETA and freshness) ─────────────────────
+    let current_head = match http_client.get_last_block().await {
+        Ok(h) => {
+            health.note_head(h);
+            h
+        }
+        Err(e) => {
+            tracing::warn!("initial head read failed: {e}");
+            0
+        }
+    };
     let chain_head = Arc::new(AtomicU64::new(current_head));
     {
         let head = chain_head.clone();
         let client = http_client.clone();
+        let health = health.clone();
         tokio::spawn(async move {
             loop {
-                tokio::time::sleep(Duration::from_secs(12)).await;
-                if let Ok(h) = client.get_last_block().await {
-                    head.store(h, Ordering::Release);
+                tokio::time::sleep(head_poll_interval).await;
+                match tokio::time::timeout(
+                    Duration::from_secs(cfg_rpc_timeout_secs),
+                    client.get_last_block(),
+                )
+                .await
+                {
+                    Ok(Ok(h)) => {
+                        head.store(h, Ordering::Release);
+                        health.note_head(h);
+                    }
+                    Ok(Err(e)) => tracing::warn!("head poll failed: {e}"),
+                    Err(_) => tracing::warn!("head poll timed out"),
                 }
             }
         });
@@ -359,6 +391,7 @@ async fn main() -> Result<()> {
     let api_state = Arc::new(api::AppState {
         store: store.clone(),
         max_api_range: cfg.max_api_range,
+        health: health.clone(),
     });
 
     let api_router = api::router(api_state);
@@ -377,11 +410,16 @@ async fn main() -> Result<()> {
 
     // ── Background flush task ───────────────────────────────────────────
     let flush_store = store.clone();
+    let flush_health = health.clone();
     let (flush_tx, mut flush_rx) = tokio::sync::mpsc::channel::<()>(1);
     tokio::spawn(async move {
         while flush_rx.recv().await.is_some() {
-            if let Err(e) = flush_store.flush().await {
-                tracing::error!("flush failed: {e}");
+            match flush_store.flush().await {
+                Ok(()) => flush_health.note_flush_ok(),
+                Err(e) => {
+                    tracing::error!("flush failed: {e}");
+                    flush_health.note_flush_error(&e);
+                }
             }
         }
     });
@@ -411,6 +449,7 @@ async fn main() -> Result<()> {
                     _ => "ended unexpectedly",
                 };
                 tracing::warn!(?last_height, reason = msg, "stream died, reconnecting...");
+                health.note_reconnect();
 
                 // Flush any pending batch before reconnecting.
                 if !batch_buf.is_empty() {
@@ -489,6 +528,7 @@ async fn main() -> Result<()> {
         // Persist the source block hash with the root for reorg reconciliation.
         batch_buf.push((height, root, block_hash));
         count += 1;
+        health.note_progress(height);
 
         let end_reached = cfg.end_height.is_some_and(|end| height >= end);
         let target = cfg

--- a/common/continuity/src/archiver.rs
+++ b/common/continuity/src/archiver.rs
@@ -33,6 +33,18 @@ struct LatestResponse {
     latest_block: Option<u64>,
 }
 
+/// The subset of `GET /status` this crate acts on. Every field is optional so an archiver
+/// that predates the freshness fields still parses: `ready: None` means "unknown".
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct ArchiverStatus {
+    pub latest_archived_block: Option<u64>,
+    pub ready: Option<bool>,
+    pub lag_blocks: Option<u64>,
+    pub source_head_age_ms: Option<u64>,
+    #[serde(default)]
+    pub not_ready_reasons: Vec<String>,
+}
+
 /// A non-2xx response from the archiver's HTTP API.
 ///
 /// Kept as a typed error rather than collapsing straight into `anyhow!` so callers can tell three
@@ -173,6 +185,25 @@ impl ArchiverClient {
     }
 
     /// Get the latest archived block number.
+    /// `GET /status`: liveness plus freshness. Unlike `/roots/latest`, this tells us whether
+    /// the archive is *current*, not merely whether the process answers.
+    pub async fn status(&self) -> Result<ArchiverStatus> {
+        let url = format!("{}/status", self.base_url);
+        debug!(archiver_url = %self.base_url, "📡 ➡️  archiver GET /status");
+        let response = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .context("archiver request failed")?
+            .error_for_status()
+            .context("archiver returned error status")?;
+        response
+            .json::<ArchiverStatus>()
+            .await
+            .context("failed to parse archiver status")
+    }
+
     pub async fn get_latest_block(&self) -> Result<Option<u64>> {
         let url = format!("{}/roots/latest", self.base_url);
         debug!(
@@ -319,13 +350,28 @@ impl EthRpcProvider for ArchiverEthProvider {
     }
 
     async fn is_healthy(&self) -> Result<bool> {
-        // Check both the archiver and the fallback RPC for health.
-        let archiver_healthy = self
-            .archiver
-            .get_latest_block()
-            .await
-            .map(|_| true)
-            .unwrap_or(false);
+        // The archiver must be reachable *and* current. `/status` carries a `ready` verdict
+        // (recent source-head sample, within the allowed lag, last flush succeeded); an
+        // archiver too old to report it counts as healthy when reachable, as before, so a
+        // rollout of proof-gen ahead of the archiver does not flip health.
+        let archiver_healthy = match self.archiver.status().await {
+            Ok(status) => {
+                if status.ready == Some(false) {
+                    warn!(
+                        archiver_url = %self.archiver.base_url,
+                        lag_blocks = ?status.lag_blocks,
+                        source_head_age_ms = ?status.source_head_age_ms,
+                        reasons = ?status.not_ready_reasons,
+                        "archiver reachable but not ready"
+                    );
+                }
+                status.ready.unwrap_or(true)
+            }
+            Err(err) => {
+                warn!(archiver_url = %self.archiver.base_url, %err, "archiver status unavailable");
+                false
+            }
+        };
 
         let eth_healthy = self.eth_fallback.is_healthy().await.unwrap_or(false);
 


### PR DESCRIPTION
Third PR of the archiver liveness audit (finding 2). Stacked on #1345 (which stacks on #1344); retarget to `usc-dev` once those merge.

## Problem

The archiver could sit behind a dead or silent source for hours while `/status` kept returning 200 with a frozen `latest_archived_block`. Nothing external (k8s, the proof-gen server's `is_healthy`) had any way to notice.

## Changes

- **`archiver/src/health.rs`** (new): tracks the latest source head sample and its age, archived height, last flush outcome and reconnect count; produces a `HealthSnapshot` with a `ready` verdict and `not_ready_reasons`.
- **`/status`** now reports `source_head`, `lag_blocks`, `source_head_age_ms`, `last_flush_error`, `reconnects`, `ready`, `not_ready_reasons`. A store error is a 500, not a 200 with zeros (same for `/roots/latest`).
- **`/ready`** (new): 200 only when the head sample is younger than `--stale-after-secs` (default 60), lag is within `--ready-lag-blocks` (default 1000) and the last flush succeeded; otherwise 503 with the reasons in the body.
- Head tracker uses `--head-poll-interval-secs` and `--rpc-timeout-secs` instead of hard-coded 12 s / no timeout.
- `continuity::ArchiverClient::status()` added; `is_healthy()` honours the archiver's own `ready` verdict when present (older archivers without the field keep the old behaviour).
- README documents the endpoints and flags.

## Ops note

The archiver k8s chart currently has **no** liveness/readiness probes. Once this ships, point the readiness probe at `GET /ready` (and optionally liveness at `/status`). That is an IaC change and not part of this PR.

## Verification

- `cargo test -p archiver -p continuity` (26 archiver tests incl. 6 new health tests), clippy `-D warnings`, fmt.
- Local smoke test against `reth --dev`: at tip `/ready` → 200, `lag_blocks 0`. After killing reth and waiting past the stale window: `/status` still 200 with the snapshot, `/ready` → 503 `source head sample is 25031 ms old (stale after 5000 ms)`. SIGTERM still stops gracefully.