### PR TITLE
feat(archiver): verify the stored tip is canonical on start and reconnect

### DIFF
--- a/archiver/README.md
+++ b/archiver/README.md
@@ -46,6 +46,7 @@ All flags can also be set via environment variables (see below).
 | `--rpc-timeout-secs` | `RPC_TIMEOUT_SECS` | `30` | Deadline per RPC call while (re)establishing the block stream |
 | `--ready-lag-blocks` | `READY_LAG_BLOCKS` | `1000` | `/ready` is 503 when more than this many blocks behind the mature target |
 | `--stale-after-secs` | `STALE_AFTER_SECS` | `60` | `/ready` is 503 when the source head has not been sampled for this long |
+| `--reanchor-max-depth` | `REANCHOR_MAX_DEPTH` | `0` | Stored blocks the archiver may drop to re-anchor on the canonical chain when the stored tip is on a fork; `0` fails closed |
 | `--finalization_lag_override` | - | *(none)* | Configurable finalization lag override |
 
 A `.env` file in the working directory is loaded automatically.
@@ -122,6 +123,27 @@ Chain (WS) ──► StreamRoots ──► Merkle root computation ──► Sle
 3. Roots are batched and written to sled in height order
 4. On restart, the archiver reads the latest stored height and resumes from there
 5. The `--backfill` flag scans for any gaps and fills them before continuing
+
+## Canonical anchor
+
+The reorg guard in the store only fires when an already-stored height is written again with
+different content. Resuming after a restart and reconnecting after a stream death both continue
+from `stored tip + 1`, so on its own that guard cannot notice a reorg that happened while the
+archiver was away (or a finalization lag that was set too small).
+
+Before (re)starting the stream the archiver therefore re-fetches the block at the stored tip and
+compares its hash with the one persisted next to the root:
+
+- match → resume from `tip + 1`
+- legacy entry without a stored hash → warn, resume (cannot be verified)
+- mismatch → the tail sits on an abandoned fork. With the default `--reanchor-max-depth 0` the
+  archiver exits with `AnchorMismatch` and leaves the store untouched. With `N > 0` it walks back
+  at most `N` stored blocks to the last canonical one, deletes everything above it and resumes
+  from there; if no canonical block is found within `N` it still fails closed. The bound is what
+  keeps an RPC that serves the wrong chain from wiping the archive.
+
+Note: the chain-id pin (`ChainIdMismatch`) catches an endpoint that serves a *different* chain;
+the anchor check catches the *same* chain having moved under us.
 
 ## Reconnection
 

--- a/archiver/src/anchor.rs
+++ b/archiver/src/anchor.rs
@@ -1,0 +1,257 @@
+//! Canonical-anchor reconciliation.
+//!
+//! The reorg guard in [`RootStore::put_roots`] only fires when a height that is *already
+//! stored* is written again with different content. Two paths never hit it: resuming after a
+//! restart and reconnecting after a stream death, both of which continue from `stored tip + 1`
+//! and trust that everything at or below the tip is still canonical. If the source chain
+//! reorged past the finalization lag while the archiver was away, or the lag was simply set
+//! too small, the archive tail sits on an abandoned fork and canonical roots get spliced on
+//! top of fork roots without anything noticing.
+//!
+//! This module closes that hole: before (re)starting the stream, re-fetch the block at the
+//! stored tip and compare its hash with the one persisted alongside the root. By default a
+//! mismatch is fatal (fail closed). With `--reanchor-max-depth N` the archiver walks back at
+//! most `N` stored blocks to find the last canonical one, drops everything above it and
+//! resumes from there; the bound keeps a misbehaving RPC from wiping the archive.
+
+use std::future::Future;
+
+use anyhow::{anyhow, Context, Result};
+use sp_core::H256;
+
+use crate::store::{RootStore, StoreError};
+
+/// What reconciliation found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Anchor {
+    /// The store holds no roots; nothing to anchor against.
+    Empty,
+    /// The stored tip matches the canonical block at that height.
+    Verified { tip: u64 },
+    /// The stored tip predates the block-hash column, so it cannot be checked.
+    Unverifiable { tip: u64 },
+    /// The tail sat on an abandoned fork; `removed` entries above `tip` were dropped and the
+    /// stream must resume from `tip + 1`.
+    Reanchored { tip: u64, removed: u64 },
+}
+
+impl Anchor {
+    /// The height the stream must resume from after reconciliation, if the store is
+    /// non-empty.
+    pub fn resume_from(&self) -> Option<u64> {
+        match self {
+            Anchor::Empty => None,
+            Anchor::Verified { tip }
+            | Anchor::Unverifiable { tip }
+            | Anchor::Reanchored { tip, .. } => Some(tip + 1),
+        }
+    }
+}
+
+/// Reconcile the store's tail against the canonical chain.
+///
+/// `canonical_hash(height)` must return the hash of the canonical block at `height`.
+/// `max_depth` is how many stored blocks below the tip may be dropped to find a canonical
+/// anchor; `0` means fail closed on any tip mismatch.
+pub async fn reconcile<F, Fut>(
+    store: &RootStore,
+    max_depth: u64,
+    mut canonical_hash: F,
+) -> Result<Anchor>
+where
+    F: FnMut(u64) -> Fut,
+    Fut: Future<Output = Result<H256>>,
+{
+    let Some(tip) = store.latest_height()? else {
+        return Ok(Anchor::Empty);
+    };
+
+    // Candidates, highest first: the tip plus at most `max_depth` stored blocks below it.
+    // Gaps below the tip simply yield fewer candidates; they are the backfiller's problem.
+    let floor = tip.saturating_sub(max_depth);
+    let mut candidates = store.get_range(floor, tip)?;
+    candidates.reverse();
+
+    let mut tip_mismatch: Option<(H256, H256)> = None;
+    for (height, stored) in candidates {
+        if stored.block_hash.is_zero() {
+            // Legacy entry without a hash. At the tip that is merely unverifiable; below a
+            // mismatching tip it means the fork point cannot be located, so stop here and
+            // let the operator decide.
+            if height == tip {
+                return Ok(Anchor::Unverifiable { tip });
+            }
+            break;
+        }
+        let canonical = canonical_hash(height)
+            .await
+            .with_context(|| format!("fetching canonical block {height} for anchor check"))?;
+        if canonical == stored.block_hash {
+            if height == tip {
+                return Ok(Anchor::Verified { tip });
+            }
+            let removed = store.truncate_above(height)?;
+            return Ok(Anchor::Reanchored {
+                tip: height,
+                removed,
+            });
+        }
+        if height == tip {
+            tip_mismatch = Some((stored.block_hash, canonical));
+        }
+    }
+
+    let (stored_hash, canonical_hash) =
+        tip_mismatch.expect("the tip is always the first candidate and did not match");
+    Err(anyhow!(StoreError::AnchorMismatch {
+        height: tip,
+        stored_hash,
+        canonical_hash,
+    })
+    .context(if max_depth == 0 {
+        "refusing to resume on top of a fork; re-run with --reanchor-max-depth N to drop up to N \
+         fork blocks and recompute them, or restore the archive from a known-good snapshot"
+            .to_string()
+    } else {
+        format!(
+            "no canonical block found within --reanchor-max-depth {max_depth} of the stored tip; \
+             the fork is deeper than allowed (or the RPC is serving another chain)"
+        )
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn store_with(entries: &[(u64, H256)]) -> (tempfile::TempDir, RootStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = RootStore::open(dir.path().join("t.sled")).unwrap();
+        let rows: Vec<_> = entries
+            .iter()
+            .map(|(h, hash)| (*h, H256::random(), *hash))
+            .collect();
+        store.put_roots(&rows).unwrap();
+        (dir, store)
+    }
+
+    fn chain(map: HashMap<u64, H256>) -> impl FnMut(u64) -> std::future::Ready<Result<H256>> {
+        move |h| std::future::ready(map.get(&h).copied().ok_or_else(|| anyhow!("no block {h}")))
+    }
+
+    #[tokio::test]
+    async fn empty_store_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = RootStore::open(dir.path().join("t.sled")).unwrap();
+        let a = reconcile(&store, 0, chain(HashMap::new())).await.unwrap();
+        assert_eq!(a, Anchor::Empty);
+        assert_eq!(a.resume_from(), None);
+    }
+
+    #[tokio::test]
+    async fn matching_tip_is_verified_without_touching_the_store() {
+        let hashes: Vec<H256> = (0..3).map(|_| H256::random()).collect();
+        let (_d, store) = store_with(&[(10, hashes[0]), (11, hashes[1]), (12, hashes[2])]);
+        let mut calls = 0;
+        let a = reconcile(&store, 5, |h| {
+            calls += 1;
+            std::future::ready(Ok(hashes[(h - 10) as usize]))
+        })
+        .await
+        .unwrap();
+        assert_eq!(a, Anchor::Verified { tip: 12 });
+        assert_eq!(a.resume_from(), Some(13));
+        assert_eq!(calls, 1, "only the tip is fetched when it matches");
+        assert_eq!(store.count(), 3);
+    }
+
+    #[tokio::test]
+    async fn tip_mismatch_fails_closed_by_default() {
+        let good = H256::random();
+        let (_d, store) = store_with(&[(10, good), (11, H256::random())]);
+        let canon: HashMap<u64, H256> = [(10, good), (11, H256::random())].into();
+        let err = reconcile(&store, 0, chain(canon)).await.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<StoreError>(),
+                Some(StoreError::AnchorMismatch { height: 11, .. })
+            ),
+            "{err:?}"
+        );
+        assert!(format!("{err:#}").contains("--reanchor-max-depth"));
+        assert_eq!(store.count(), 2, "fail closed must not modify the store");
+    }
+
+    #[tokio::test]
+    async fn reanchors_within_depth_and_truncates_the_fork_tail() {
+        let canon: Vec<H256> = (0..5).map(|_| H256::random()).collect(); // heights 10..=14
+        let fork: Vec<H256> = (0..2).map(|_| H256::random()).collect(); // stored at 13, 14
+        let (_d, store) = store_with(&[
+            (10, canon[0]),
+            (11, canon[1]),
+            (12, canon[2]),
+            (13, fork[0]),
+            (14, fork[1]),
+        ]);
+        let map: HashMap<u64, H256> = (10..=14).map(|h| (h, canon[(h - 10) as usize])).collect();
+        let a = reconcile(&store, 3, chain(map)).await.unwrap();
+        assert_eq!(
+            a,
+            Anchor::Reanchored {
+                tip: 12,
+                removed: 2
+            }
+        );
+        assert_eq!(a.resume_from(), Some(13));
+        assert_eq!(store.latest_height().unwrap(), Some(12));
+        assert_eq!(store.count(), 3);
+    }
+
+    #[tokio::test]
+    async fn fork_deeper_than_depth_fails_without_truncating() {
+        let (_d, store) = store_with(&[
+            (10, H256::random()),
+            (11, H256::random()),
+            (12, H256::random()),
+        ]);
+        let map: HashMap<u64, H256> = (10..=12).map(|h| (h, H256::random())).collect();
+        let err = reconcile(&store, 1, chain(map)).await.unwrap_err();
+        assert!(matches!(
+            err.downcast_ref::<StoreError>(),
+            Some(StoreError::AnchorMismatch { height: 12, .. })
+        ));
+        assert!(format!("{err:#}").contains("deeper than allowed"));
+        assert_eq!(store.count(), 3);
+    }
+
+    #[tokio::test]
+    async fn legacy_tip_without_hash_is_unverifiable() {
+        let (_d, store) = store_with(&[(10, H256::random()), (11, H256::zero())]);
+        let a = reconcile(&store, 3, chain(HashMap::new())).await.unwrap();
+        assert_eq!(a, Anchor::Unverifiable { tip: 11 });
+        assert_eq!(store.count(), 2);
+    }
+
+    #[tokio::test]
+    async fn legacy_entry_below_a_mismatching_tip_stops_the_walk() {
+        let (_d, store) = store_with(&[(10, H256::zero()), (11, H256::random())]);
+        let map: HashMap<u64, H256> = [(11, H256::random())].into();
+        let err = reconcile(&store, 5, chain(map)).await.unwrap_err();
+        assert!(matches!(
+            err.downcast_ref::<StoreError>(),
+            Some(StoreError::AnchorMismatch { height: 11, .. })
+        ));
+        assert_eq!(store.count(), 2);
+    }
+
+    #[tokio::test]
+    async fn rpc_error_propagates_without_truncating() {
+        let (_d, store) = store_with(&[(10, H256::random()), (11, H256::random())]);
+        let err = reconcile(&store, 5, chain(HashMap::new()))
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("no block 11"));
+        assert_eq!(store.count(), 2);
+    }
+}

--- a/archiver/src/config.rs
+++ b/archiver/src/config.rs
@@ -110,4 +110,12 @@ pub struct Config {
     /// from "we lost sight of the chain" (not ready).
     #[arg(long, env = "STALE_AFTER_SECS", default_value = "60")]
     pub stale_after_secs: NonZeroU64,
+
+    /// On start and on every reconnect the stored tip is re-fetched from the source and its
+    /// hash compared with the stored one. A mismatch means the archive tail sits on an
+    /// abandoned fork. `0` (default) fails closed. `N > 0` lets the archiver walk back at most
+    /// `N` stored blocks to the last canonical one, drop everything above it and recompute;
+    /// the bound keeps a misbehaving RPC from wiping the archive.
+    #[arg(long, env = "REANCHOR_MAX_DEPTH", default_value = "0")]
+    pub reanchor_max_depth: u64,
 }

--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -33,6 +33,7 @@ fn compute_parallelism(max_fetch_tasks: std::num::NonZeroUsize) -> std::num::Non
     std::num::NonZeroUsize::new(parallelism).unwrap_or(std::num::NonZeroUsize::MIN)
 }
 
+mod anchor;
 mod api;
 mod config;
 mod health;
@@ -61,7 +62,7 @@ async fn main() -> Result<()> {
     // ── Determine resume height ─────────────────────────────────────────
     let latest_stored = store.latest_height()?;
 
-    let start_height = match latest_stored {
+    let mut start_height = match latest_stored {
         Some(latest) => {
             let resume = latest + 1;
             tracing::info!(
@@ -77,18 +78,6 @@ async fn main() -> Result<()> {
             cfg.start_height
         }
     };
-
-    // Check if we've already passed the end height.
-    if let Some(end) = cfg.end_height {
-        if end < start_height {
-            tracing::info!(
-                end_height = end,
-                start_height,
-                "already archived past end-height, nothing to do"
-            );
-            return Ok(());
-        }
-    }
 
     // ── Source chain identity ───────────────────────────────────────────
     // Connect both RPC endpoints up front. They must agree on `chain_id`, and when
@@ -168,6 +157,46 @@ async fn main() -> Result<()> {
     match store.pin_chain_id(source_chain_id)? {
         None => tracing::info!(chain_id = source_chain_id, "pinned archive to source chain"),
         Some(pinned) => tracing::debug!(chain_id = pinned, "archive chain pin verified"),
+    }
+
+    // ── Canonical anchor ────────────────────────────────────────────────
+    // The stored tip must still be the canonical block at that height; otherwise the tail
+    // sits on an abandoned fork and resuming from `tip + 1` would splice canonical roots on
+    // top of fork roots. Fail closed unless the operator allowed bounded re-anchoring.
+    let rpc_timeout = Duration::from_secs(cfg.rpc_timeout_secs.get());
+    let anchored = anchor::reconcile(&store, cfg.reanchor_max_depth, |h| {
+        canonical_block_hash(&http_client, h, rpc_timeout)
+    })
+    .await?;
+    match anchored {
+        anchor::Anchor::Empty => {}
+        anchor::Anchor::Verified { tip } => tracing::info!(tip, "stored tip is canonical"),
+        anchor::Anchor::Unverifiable { tip } => tracing::warn!(
+            tip,
+            "stored tip predates the block-hash column; canonical anchor cannot be verified"
+        ),
+        anchor::Anchor::Reanchored { tip, removed } => {
+            tracing::warn!(
+                tip,
+                removed,
+                "stored tail was on an abandoned fork; dropped it and re-anchored"
+            );
+        }
+    }
+    if let Some(resume) = anchored.resume_from() {
+        start_height = resume;
+    }
+
+    // Check if we've already passed the end height.
+    if let Some(end) = cfg.end_height {
+        if end < start_height {
+            tracing::info!(
+                end_height = end,
+                start_height,
+                "already archived past end-height, nothing to do"
+            );
+            return Ok(());
+        }
     }
 
     // ── Determine finalization lag ──────────────────────────────────────
@@ -460,7 +489,7 @@ async fn main() -> Result<()> {
                 // Reconnect with exponential backoff. Every wait here selects on the shutdown
                 // signal, so a SIGTERM during an outage (or a stuck stream constructor) still
                 // exits through the final-flush path instead of needing a kill.
-                let resume_from = last_height.map(|h| h + 1).unwrap_or(start_height);
+                let mut resume_from = last_height.map(|h| h + 1).unwrap_or(start_height);
                 let mut delay = RECONNECT_BASE_DELAY;
                 let mut shutting_down = false;
                 loop {
@@ -486,6 +515,40 @@ async fn main() -> Result<()> {
                             );
                         }
                         Ok(new_ws) => {
+                            // The chain may have reorged past our tail while we were away.
+                            // Same rule as startup: verify the anchor, fail closed unless
+                            // bounded re-anchoring is allowed. An RPC error here is just a
+                            // failed reconnect attempt and is retried.
+                            let anchored = tokio::select! {
+                                _ = cancelled(&mut cancel_rx) => { shutting_down = true; break; }
+                                a = anchor::reconcile(&store, cfg.reanchor_max_depth, |h| {
+                                    canonical_block_hash(&new_ws, h, rpc_timeout)
+                                }) => a,
+                            };
+                            match anchored {
+                                Ok(anchor::Anchor::Reanchored { tip, removed }) => {
+                                    tracing::warn!(
+                                        tip,
+                                        removed,
+                                        "stored tail was on an abandoned fork; dropped it and re-anchored"
+                                    );
+                                    resume_from = tip + 1;
+                                    last_height = Some(tip);
+                                }
+                                Ok(a) => {
+                                    if let Some(resume) = a.resume_from() {
+                                        resume_from = resume;
+                                    }
+                                }
+                                Err(e) if e.downcast_ref::<store::StoreError>().is_some() => {
+                                    return Err(e);
+                                }
+                                Err(e) => {
+                                    tracing::warn!("anchor check failed on reconnect: {e:#}");
+                                    delay = (delay * 2).min(RECONNECT_MAX_DELAY);
+                                    continue;
+                                }
+                            }
                             let new_config = stream_eth::roots::ConfigBuilder::new()
                                 .with_client(new_ws)
                                 .with_start_height(resume_from)
@@ -626,6 +689,18 @@ fn should_request_flush(
 }
 
 /// Resolves once the shutdown signal has fired. Cheap to call repeatedly from `select!`.
+/// Hash of the canonical block at `height` as seen by `client`, under the RPC deadline.
+async fn canonical_block_hash(
+    client: &eth::Client,
+    height: u64,
+    timeout: Duration,
+) -> Result<sp_core::H256> {
+    let block = tokio::time::timeout(timeout, client.get_eth_block(height))
+        .await
+        .map_err(|_| anyhow!("timed out fetching block {height}"))??;
+    Ok(sp_core::H256::from_slice(block.header.hash.as_slice()))
+}
+
 async fn cancelled(rx: &mut tokio::sync::watch::Receiver<bool>) {
     if *rx.borrow() {
         return;

--- a/archiver/src/store.rs
+++ b/archiver/src/store.rs
@@ -44,6 +44,16 @@ pub enum StoreError {
     /// every proof later built from it, so this is fatal.
     #[error("archive was built from chain_id {stored} but the source RPC now serves chain_id {live}; refusing to write foreign roots")]
     ChainIdMismatch { stored: u64, live: u64 },
+    /// The highest stored block is no longer the canonical block at that height on the
+    /// source chain: the archive's tail sits on an abandoned fork. Resuming from `tip + 1`
+    /// would splice canonical roots on top of fork roots, so this is fatal unless the
+    /// operator opted into bounded re-anchoring (`--reanchor-max-depth`).
+    #[error("stored tip {height} is not canonical: stored block hash {stored_hash:?}, canonical block hash {canonical_hash:?}; the archive tail sits on an abandoned fork")]
+    AnchorMismatch {
+        height: u64,
+        stored_hash: H256,
+        canonical_hash: H256,
+    },
 }
 
 /// A stored entry: the merkle root plus the source block hash it was derived from.
@@ -227,6 +237,43 @@ impl RootStore {
         Ok(())
     }
 
+    /// Delete every stored entry with `height > keep_through` and return how many were
+    /// removed. Used to drop a tail that turned out to sit on an abandoned fork so the
+    /// stream can recompute those heights from the canonical chain.
+    ///
+    /// The entry counter is corrected and persisted; the roots batch and the counter write
+    /// are not atomic (same best-effort contract as `put_roots`), so a crash in between
+    /// drifts the counter by at most this call until the next successful `put_roots`.
+    pub fn truncate_above(&self, keep_through: u64) -> Result<u64> {
+        let Some(first_removed) = keep_through.checked_add(1) else {
+            return Ok(0);
+        };
+        let mut batch = sled::Batch::default();
+        let mut removed = 0_u64;
+        for item in self.db.range(first_removed.to_be_bytes()..) {
+            let (key, _) = item.context("failed to read from sled")?;
+            batch.remove(key);
+            removed += 1;
+        }
+        if removed == 0 {
+            return Ok(0);
+        }
+        self.db
+            .apply_batch(batch)
+            .context("failed to apply truncate batch")?;
+        let new_total = self
+            .entry_count
+            .fetch_sub(removed as usize, Ordering::AcqRel)
+            .saturating_sub(removed as usize);
+        if let Err(e) = self
+            .meta
+            .insert(META_KEY_COUNT, &(new_total as u64).to_be_bytes())
+        {
+            tracing::warn!(error = %e, "failed to persist entry count to meta tree");
+        }
+        Ok(removed)
+    }
+
     /// Get roots for an inclusive block range [from, to].
     /// Returns `(block_number, StoredRoot)` pairs in ascending order.
     pub fn get_range(&self, from: u64, to: u64) -> Result<Vec<(u64, StoredRoot)>> {
@@ -338,6 +385,32 @@ mod tests {
     /// Test helper: build a `(height, root, block_hash)` tuple with a random hash.
     fn entry(height: u64, root: H256) -> (u64, H256, H256) {
         (height, root, H256::random())
+    }
+
+    #[test]
+    fn truncate_above_drops_only_the_tail_and_fixes_the_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = RootStore::open(dir.path().join("test.sled")).unwrap();
+        let entries: Vec<_> = (10..=15).map(|h| entry(h, H256::random())).collect();
+        store.put_roots(&entries).unwrap();
+        assert_eq!(store.count(), 6);
+
+        assert_eq!(store.truncate_above(12).unwrap(), 3);
+        assert_eq!(store.count(), 3);
+        assert_eq!(store.latest_height().unwrap(), Some(12));
+        assert!(store.get_range(13, 15).unwrap().is_empty());
+        assert_eq!(store.get_range(12, 12).unwrap()[0].1.root, entries[2].1);
+
+        // Nothing above: a no-op that leaves the count alone.
+        assert_eq!(store.truncate_above(12).unwrap(), 0);
+        assert_eq!(store.truncate_above(u64::MAX).unwrap(), 0);
+        assert_eq!(store.count(), 3);
+
+        // The corrected count survives reopen (persisted to meta).
+        drop(store);
+        let store = RootStore::open(dir.path().join("test.sled")).unwrap();
+        assert_eq!(store.count(), 3);
+        assert_eq!(store.latest_height().unwrap(), Some(12));
     }
 
     #[test]


### PR DESCRIPTION
Fourth PR of the archiver liveness audit (finding 4). Stacked on #1346 → #1345 → #1344; retarget to `usc-dev` as those merge.

## Problem

`RootStore::put_roots` only detects a reorg when a height that is *already stored* is written again with different content. Two paths never touch stored heights: resuming after a restart and reconnecting after a stream death both continue from `stored tip + 1`. If the source reorged past the finalization lag while the archiver was away (or the lag is set too small), the tail sits on an abandoned fork and canonical roots get spliced on top of fork roots. Every proof built across that seam is wrong and nothing notices.

## Changes

- **`archiver/src/anchor.rs`** (new): `reconcile(store, max_depth, canonical_hash)` re-fetches the block at the stored tip and compares hashes.
  - match → `Verified`, resume from `tip + 1`
  - legacy entry without a stored hash → `Unverifiable`, warn and resume
  - mismatch → **fail closed** with `StoreError::AnchorMismatch` (store untouched) and an operator hint
- **`--reanchor-max-depth N`** (default `0`): opt-in bounded self-healing. Walk back at most `N` stored blocks to the last canonical one, `truncate_above` it and resume. No canonical block within `N` still fails closed, so an RPC serving the wrong chain cannot wipe the archive. A legacy hash-less entry below a mismatching tip also stops the walk (fork point cannot be located).
- **`RootStore::truncate_above(height)`**: deletes the tail, corrects and persists the entry counter.
- Runs at startup (after the chain-id pin, before backfill) and on every reconnect against the freshly dialled client, selected against SIGTERM. On reconnect an RPC error is just a failed attempt (retried with backoff); a mismatch exits the process.
- The `--end-height` early-exit check moved after the anchor step so a truncation cannot be skipped by it.
- README: new "Canonical anchor" section, flag row. Also spells out the difference from the chain-id pin: the pin catches a *different* chain, the anchor catches the *same* chain having moved under us.

## Verification

- `cargo test -p archiver`: 35 tests (8 new anchor tests: empty, verified-without-extra-fetches, fail-closed default, reanchor-within-depth truncates exactly the fork tail, deeper-than-depth fails without truncating, legacy tip, legacy-below-mismatch stops the walk, RPC error propagates without truncating; 1 new store test for `truncate_above` incl. count persistence across reopen). clippy `-D warnings`, fmt.
- Empirical, against `reth --dev`: archived 49 blocks, then swapped in a fresh dev chain (same chain id 1337, different hashes) and let it pass height 49.
  - default: exit 1, `refusing to resume on top of a fork; re-run with --reanchor-max-depth N …` / `stored tip 49 is not canonical: stored block hash 0x44fe…, canonical block hash 0x8e10…`
  - `--reanchor-max-depth 3` and `100`: exit 1, `no canonical block found within --reanchor-max-depth …; the fork is deeper than allowed`, store still holds 49 entries
  - same chain restarted: `stored tip is canonical tip=49`, resumes normally
  - a stored tip that the source has not reached yet fails with the fetch error (`Failed to get block 49`), which is the conservative outcome for a lagging replica.