### PR TITLE
feat(archiver): bind the API before the source handshake; wire fallback RPC URLs

### DIFF
--- a/archiver/README.md
+++ b/archiver/README.md
@@ -28,8 +28,9 @@ All flags can also be set via environment variables (see below).
 
 | Flag | Env | Default | Description |
 |------|-----|---------|-------------|
-| `--rpc-http` | `RPC_HTTP` | *(required)* | HTTP RPC endpoint for block fetching |
-| `--rpc-ws` | `RPC_WS` | *(required)* | WebSocket RPC endpoint for new-head subscriptions |
+| `--rpc-http` | `RPC_HTTP` | *(required)* | HTTP RPC endpoint for chain-head tracking and the canonical-anchor check |
+| `--rpc-ws` | `RPC_WS` | *(required)* | WebSocket RPC endpoint for the new-head subscription and block fetching |
+| `--rpc-fallback-urls` | `RPC_FALLBACK_URLS` | *(none)* | Comma-separated extra RPCs tried in order when the primary returns "not found" or a transport error for a block fetch; must serve the same chain id; if any is unreachable at dial time the archiver warns and continues with the primary alone |
 | `--cc3-rpc_url` | `CC3_RPC_URL` | `ws://localhost:9944` | Url for connecting to CC3 chain |
 | `--chain-key` | `CHAIN_KEY` | *(none)* | Chain key for supported chains entry of the chain we're archiving |
 | `--start-height` | `START_HEIGHT` | `0` | Block height to start from (ignored if DB has progress) |
@@ -52,6 +53,10 @@ All flags can also be set via environment variables (see below).
 A `.env` file in the working directory is loaded automatically.
 
 ## API Endpoints
+
+The API binds before the source-chain handshake, so `/status` and `/roots*` answer during the
+handshake, the anchor check and a long `--backfill`. `/ready` is 503 with
+`source chain handshake not complete` until the source identity is verified and pinned.
 
 ### `GET /status`
 
@@ -118,7 +123,7 @@ Chain (WS) ──► StreamRoots ──► Merkle root computation ──► Sle
                        (exponential backoff)              (resume height)
 ```
 
-1. **StreamRoots** subscribes to new block headers via WebSocket and fetches full blocks via HTTP
+1. **StreamRoots** subscribes to new block headers over the WebSocket client and fetches full blocks and receipts over that same client (falling back to `--rpc-fallback-urls` on "not found" / transport errors); the HTTP endpoint is used for chain-head tracking and the canonical-anchor check
 2. Blocks are merkleized in parallel using `spawn_blocking` to avoid blocking the async runtime
 3. Roots are batched and written to sled in height order
 4. On restart, the archiver reads the latest stored height and resumes from there

--- a/archiver/src/config.rs
+++ b/archiver/src/config.rs
@@ -13,14 +13,23 @@ use url::Url;
     about = "Source chain archiver — fetches blocks, computes merkle roots, serves data over HTTP"
 )]
 pub struct Config {
-    /// HTTP RPC endpoint for block fetching.
+    /// HTTP RPC endpoint, used for chain-head tracking and the canonical-anchor check (blocks
+    /// themselves are fetched over the WebSocket client that also carries the subscription).
     #[arg(long, env = "RPC_HTTP", alias = "rpc-url", required = true)]
     pub rpc_http: Url,
 
-    /// WebSocket RPC endpoint for new-head subscriptions.
+    /// WebSocket RPC endpoint for the new-head subscription and block fetching.
     /// Required for the root stream to follow the chain tip.
     #[arg(long, env = "RPC_WS", required = true)]
     pub rpc_ws: Url,
+
+    /// Additional RPC endpoints (comma-separated) tried in order when the primary returns
+    /// "not found" or a transport error for a block fetch. Every fallback must serve the same
+    /// chain id as the primary. If any fallback is unreachable (or on another chain) at dial
+    /// time, the archiver logs a warning and continues with the primary alone rather than
+    /// letting a backup endpoint block startup or reconnection.
+    #[arg(long, env = "RPC_FALLBACK_URLS", value_delimiter = ',', num_args = 0..)]
+    pub rpc_fallback_urls: Vec<String>,
 
     /// Creditcoin3 RPC (WebSocket). `CC3_RPC_URL` or `--cc3-rpc-url` (CLI overrides env; not in YAML).
     #[arg(long, default_value = "ws://localhost:9944", env = "CC3_RPC_URL")]

--- a/archiver/src/health.rs
+++ b/archiver/src/health.rs
@@ -6,7 +6,7 @@
 //! return HTTP 200 on `/status`.
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use serde::Serialize;
@@ -16,8 +16,9 @@ const NEVER: u64 = u64::MAX;
 
 pub struct Health {
     started: Instant,
-    pub chain_id: u64,
-    pub finalization_lag: u64,
+    /// `(chain_id, finalization_lag)`, known only once the source-chain handshake completes.
+    /// The API is up before that so probes can see the process; until then it is not ready.
+    source: OnceLock<(u64, u64)>,
     ready_lag_blocks: u64,
     stale_after: Duration,
 
@@ -34,8 +35,9 @@ pub struct Health {
 /// What `/status` and `/ready` serialize. Ages are milliseconds; `null` means "never".
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct HealthSnapshot {
-    pub chain_id: u64,
-    pub finalization_lag: u64,
+    /// `null` until the source-chain handshake has completed.
+    pub chain_id: Option<u64>,
+    pub finalization_lag: Option<u64>,
     pub uptime_ms: u64,
     pub latest_archived_block: Option<u64>,
     pub total_blocks: usize,
@@ -56,16 +58,10 @@ pub struct HealthSnapshot {
 }
 
 impl Health {
-    pub fn new(
-        chain_id: u64,
-        finalization_lag: u64,
-        ready_lag_blocks: u64,
-        stale_after: Duration,
-    ) -> Self {
+    pub fn new(ready_lag_blocks: u64, stale_after: Duration) -> Self {
         Self {
             started: Instant::now(),
-            chain_id,
-            finalization_lag,
+            source: OnceLock::new(),
             ready_lag_blocks,
             stale_after,
             source_head: AtomicU64::new(0),
@@ -77,6 +73,12 @@ impl Health {
             last_flush_error: Mutex::new(None),
             reconnects: AtomicU64::new(0),
         }
+    }
+
+    /// Record the verified source identity. Called once the ws/http/Creditcoin handshake and
+    /// the chain-id pin have passed; a second call is ignored.
+    pub fn set_source(&self, chain_id: u64, finalization_lag: u64) {
+        let _ = self.source.set((chain_id, finalization_lag));
     }
 
     fn now_ms(&self) -> u64 {
@@ -128,7 +130,11 @@ impl Health {
         let head_at = self.source_head_at.load(Ordering::Acquire);
         let source_head = (head_at != NEVER).then(|| self.source_head.load(Ordering::Acquire));
         let source_head_age_ms = self.age(head_at);
-        let mature_target = source_head.map(|h| h.saturating_sub(self.finalization_lag));
+        let source = self.source.get().copied();
+        let mature_target = match (source_head, source) {
+            (Some(h), Some((_, lag))) => Some(h.saturating_sub(lag)),
+            _ => None,
+        };
         let lag_blocks = match (mature_target, latest_archived_block) {
             (Some(target), Some(latest)) => Some(target.saturating_sub(latest)),
             (Some(target), None) => Some(target),
@@ -141,6 +147,9 @@ impl Health {
             .clone();
 
         let mut not_ready_reasons = Vec::new();
+        if source.is_none() {
+            not_ready_reasons.push("source chain handshake not complete".to_owned());
+        }
         match source_head_age_ms {
             None => not_ready_reasons.push("source head never observed".to_owned()),
             Some(age) if age > self.stale_after.as_millis() as u64 => {
@@ -163,8 +172,8 @@ impl Health {
         }
 
         HealthSnapshot {
-            chain_id: self.chain_id,
-            finalization_lag: self.finalization_lag,
+            chain_id: source.map(|(id, _)| id),
+            finalization_lag: source.map(|(_, lag)| lag),
             uptime_ms: self.now_ms(),
             latest_archived_block,
             total_blocks,
@@ -188,7 +197,30 @@ mod tests {
     use super::*;
 
     fn health() -> Health {
-        Health::new(56, 10, 1_000, Duration::from_secs(60))
+        let h = Health::new(1_000, Duration::from_secs(60));
+        h.set_source(56, 10);
+        h
+    }
+
+    #[test]
+    fn not_ready_before_the_handshake_even_with_a_fresh_head() {
+        let h = Health::new(1_000, Duration::from_secs(60));
+        h.note_head(500);
+        let s = h.snapshot(Some(490), 491);
+        assert!(!s.ready);
+        assert_eq!(s.chain_id, None);
+        assert_eq!(s.mature_target, None, "no lag known, no target");
+        assert_eq!(
+            s.not_ready_reasons,
+            vec!["source chain handshake not complete".to_owned()]
+        );
+        h.set_source(56, 10);
+        let s = h.snapshot(Some(490), 491);
+        assert!(s.ready, "{:?}", s.not_ready_reasons);
+        assert_eq!(s.chain_id, Some(56));
+        // A second set_source is ignored.
+        h.set_source(99, 0);
+        assert_eq!(h.snapshot(None, 0).chain_id, Some(56));
     }
 
     #[test]
@@ -256,7 +288,8 @@ mod tests {
 
     #[test]
     fn empty_archive_reports_the_whole_target_as_lag() {
-        let h = Health::new(1, 0, 100, Duration::from_secs(60));
+        let h = Health::new(100, Duration::from_secs(60));
+        h.set_source(1, 0);
         h.note_head(250);
         let s = h.snapshot(None, 0);
         assert_eq!(s.lag_blocks, Some(250));

--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -111,8 +111,9 @@ async fn main() -> Result<()> {
     // `CHAIN_KEY` is set that `chain_id` must be the one registered on Creditcoin for
     // this archiver's chain key. Both are fatal: archiving the wrong chain under a
     // given archive name silently corrupts every proof later built from it.
-    let ws_client = dial(cfg.rpc_ws.as_str(), &cfg.rpc_fallback_urls).await?;
-    let http_client = dial(cfg.rpc_http.as_str(), &cfg.rpc_fallback_urls).await?;
+    let rpc_timeout = Duration::from_secs(cfg.rpc_timeout_secs.get());
+    let ws_client = dial(cfg.rpc_ws.as_str(), &cfg.rpc_fallback_urls, rpc_timeout).await?;
+    let http_client = dial(cfg.rpc_http.as_str(), &cfg.rpc_fallback_urls, rpc_timeout).await?;
     if ws_client.chain_id() != http_client.chain_id() {
         return Err(anyhow!(
             "chain_id's from ws vs http don't match! ws_chain_id: {}, http_chain_id: {}",
@@ -190,7 +191,6 @@ async fn main() -> Result<()> {
     // The stored tip must still be the canonical block at that height; otherwise the tail
     // sits on an abandoned fork and resuming from `tip + 1` would splice canonical roots on
     // top of fork roots. Fail closed unless the operator allowed bounded re-anchoring.
-    let rpc_timeout = Duration::from_secs(cfg.rpc_timeout_secs.get());
     let anchored = anchor::reconcile(&store, cfg.reanchor_max_depth, |h| {
         canonical_block_hash(&http_client, h, rpc_timeout)
     })
@@ -228,6 +228,11 @@ async fn main() -> Result<()> {
 
     // ── Determine finalization lag ──────────────────────────────────────
     let finaliztion_lag = resolve_finalization_lag(cfg.finalization_lag_override, on_chain_lag)?;
+
+    // Identity verified, pinned and lag known: publish it now, before the anchor check and a
+    // possibly hours-long `--backfill`, so probes see the real startup phase (lag against the
+    // head) rather than a stale "handshake not complete".
+    health.set_source(source_chain_id, finaliztion_lag);
 
     // ── Shutdown signal (SIGINT + SIGTERM) ──────────────────────────────
     // A `watch` rather than a oneshot so every phase (main loop, reconnect backoff, stream
@@ -270,7 +275,7 @@ async fn main() -> Result<()> {
                         tracing::info!("backfill interrupted by shutdown before dialing");
                         return Ok(());
                     }
-                    c = dial(cfg.rpc_ws.as_str(), &cfg.rpc_fallback_urls) => c?,
+                    c = dial(cfg.rpc_ws.as_str(), &cfg.rpc_fallback_urls, rpc_timeout) => c?,
                 };
                 // Same identity rule as startup and reconnect: a fresh dial that lands on
                 // another chain must not fill gaps with foreign roots (the reorg guard only
@@ -390,9 +395,6 @@ async fn main() -> Result<()> {
     let cfg_rpc_timeout_secs = cfg.rpc_timeout_secs.get();
     let head_poll_interval = Duration::from_secs(cfg.head_poll_interval_secs.get());
 
-    // The source identity is verified and pinned: `/ready` may now turn green.
-    health.set_source(source_chain_id, finaliztion_lag);
-
     // ── Chain head tracker (for ETA and freshness) ─────────────────────
     let current_head = match http_client.get_last_block().await {
         Ok(h) => {
@@ -502,7 +504,7 @@ async fn main() -> Result<()> {
 
                     let connect = tokio::select! {
                         _ = cancelled(&mut cancel_rx) => { shutting_down = true; break; }
-                        c = dial(cfg.rpc_ws.as_str(), &cfg.rpc_fallback_urls) => c,
+                        c = dial(cfg.rpc_ws.as_str(), &cfg.rpc_fallback_urls, rpc_timeout) => c,
                     };
                     match connect {
                         // The endpoint must still be the chain this archive is pinned to. A
@@ -693,18 +695,33 @@ fn should_request_flush(
 /// Dial an RPC endpoint with the configured fallbacks. A fallback that cannot be reached (or
 /// serves another chain) must never keep the archiver from starting or reconnecting on a
 /// healthy primary, so on fallback failure the dial is retried with the primary alone.
-async fn dial(url: &str, fallback_urls: &[String]) -> Result<eth::Client> {
+///
+/// Every dial runs under `deadline`: alloy transports have no default timeout, so without one a
+/// black-holed fallback (or primary) would hang the handshake or a reconnect attempt forever.
+async fn dial(url: &str, fallback_urls: &[String], deadline: Duration) -> Result<eth::Client> {
+    let primary_only = || async {
+        tokio::time::timeout(deadline, eth::Client::new(url, None))
+            .await
+            .map_err(|_| anyhow!("timed out after {deadline:?} dialing {url}"))?
+    };
     if fallback_urls.is_empty() {
-        return eth::Client::new(url, None).await;
+        return primary_only().await;
     }
-    match eth::Client::new_with_fallbacks(url, fallback_urls, None).await {
+    let with_fallbacks = tokio::time::timeout(
+        deadline,
+        eth::Client::new_with_fallbacks(url, fallback_urls, None),
+    )
+    .await
+    .map_err(|_| anyhow!("timed out after {deadline:?} dialing {url} with fallbacks"))
+    .and_then(|r| r);
+    match with_fallbacks {
         Ok(client) => Ok(client),
         Err(e) => {
             tracing::warn!(
                 fallbacks = fallback_urls.len(),
                 "dial with fallback RPCs failed, retrying with the primary only: {e:#}"
             );
-            eth::Client::new(url, None).await
+            primary_only().await
         }
     }
 }

--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -59,6 +59,33 @@ async fn main() -> Result<()> {
 
     let store = RootStore::open(&cfg.sled_db_path)?;
 
+    // ── HTTP API + health, before any network handshake ─────────────────
+    // The source-chain handshake, the anchor check and especially `--backfill` can take a long
+    // time. Probes and `/roots` readers must be able to see the process during all of it, so
+    // the API binds first; `/ready` stays 503 ("handshake not complete") until the source
+    // identity is verified below.
+    let health = Arc::new(health::Health::new(
+        cfg.ready_lag_blocks,
+        Duration::from_secs(cfg.stale_after_secs.get()),
+    ));
+    let api_state = Arc::new(api::AppState {
+        store: store.clone(),
+        max_api_range: cfg.max_api_range,
+        health: health.clone(),
+    });
+    let api_router = api::router(api_state);
+    let listener = tokio::net::TcpListener::bind(cfg.api_bind).await?;
+    tracing::info!(bind = %cfg.api_bind, "HTTP API listening");
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        axum::serve(listener, api_router)
+            .with_graceful_shutdown(async {
+                shutdown_rx.await.ok();
+            })
+            .await
+            .ok();
+    });
+
     // ── Determine resume height ─────────────────────────────────────────
     let latest_stored = store.latest_height()?;
 
@@ -84,8 +111,8 @@ async fn main() -> Result<()> {
     // `CHAIN_KEY` is set that `chain_id` must be the one registered on Creditcoin for
     // this archiver's chain key. Both are fatal: archiving the wrong chain under a
     // given archive name silently corrupts every proof later built from it.
-    let ws_client = eth::Client::new(cfg.rpc_ws.as_str(), None).await?;
-    let http_client = eth::Client::new(cfg.rpc_http.as_str(), None).await?;
+    let ws_client = dial(cfg.rpc_ws.as_str(), &cfg.rpc_fallback_urls).await?;
+    let http_client = dial(cfg.rpc_http.as_str(), &cfg.rpc_fallback_urls).await?;
     if ws_client.chain_id() != http_client.chain_id() {
         return Err(anyhow!(
             "chain_id's from ws vs http don't match! ws_chain_id: {}, http_chain_id: {}",
@@ -243,7 +270,7 @@ async fn main() -> Result<()> {
                         tracing::info!("backfill interrupted by shutdown before dialing");
                         return Ok(());
                     }
-                    c = eth::Client::new(cfg.rpc_ws.as_str(), None) => c?,
+                    c = dial(cfg.rpc_ws.as_str(), &cfg.rpc_fallback_urls) => c?,
                 };
                 // Same identity rule as startup and reconnect: a fresh dial that lands on
                 // another chain must not fill gaps with foreign roots (the reorg guard only
@@ -363,13 +390,8 @@ async fn main() -> Result<()> {
     let cfg_rpc_timeout_secs = cfg.rpc_timeout_secs.get();
     let head_poll_interval = Duration::from_secs(cfg.head_poll_interval_secs.get());
 
-    // ── Health / freshness bookkeeping ──────────────────────────────────
-    let health = Arc::new(health::Health::new(
-        source_chain_id,
-        finaliztion_lag,
-        cfg.ready_lag_blocks,
-        Duration::from_secs(cfg.stale_after_secs.get()),
-    ));
+    // The source identity is verified and pinned: `/ready` may now turn green.
+    health.set_source(source_chain_id, finaliztion_lag);
 
     // ── Chain head tracker (for ETA and freshness) ─────────────────────
     let current_head = match http_client.get_last_block().await {
@@ -415,27 +437,6 @@ async fn main() -> Result<()> {
         api = %cfg.api_bind,
         "starting archiver"
     );
-
-    // ── HTTP API ────────────────────────────────────────────────────────
-    let api_state = Arc::new(api::AppState {
-        store: store.clone(),
-        max_api_range: cfg.max_api_range,
-        health: health.clone(),
-    });
-
-    let api_router = api::router(api_state);
-    let listener = tokio::net::TcpListener::bind(cfg.api_bind).await?;
-    tracing::info!(bind = %cfg.api_bind, "HTTP API listening");
-
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    tokio::spawn(async move {
-        axum::serve(listener, api_router)
-            .with_graceful_shutdown(async {
-                shutdown_rx.await.ok();
-            })
-            .await
-            .ok();
-    });
 
     // ── Background flush task ───────────────────────────────────────────
     let flush_store = store.clone();
@@ -501,7 +502,7 @@ async fn main() -> Result<()> {
 
                     let connect = tokio::select! {
                         _ = cancelled(&mut cancel_rx) => { shutting_down = true; break; }
-                        c = eth::Client::new(cfg.rpc_ws.as_str(), None) => c,
+                        c = dial(cfg.rpc_ws.as_str(), &cfg.rpc_fallback_urls) => c,
                     };
                     match connect {
                         // The endpoint must still be the chain this archive is pinned to. A
@@ -689,6 +690,25 @@ fn should_request_flush(
 }
 
 /// Resolves once the shutdown signal has fired. Cheap to call repeatedly from `select!`.
+/// Dial an RPC endpoint with the configured fallbacks. A fallback that cannot be reached (or
+/// serves another chain) must never keep the archiver from starting or reconnecting on a
+/// healthy primary, so on fallback failure the dial is retried with the primary alone.
+async fn dial(url: &str, fallback_urls: &[String]) -> Result<eth::Client> {
+    if fallback_urls.is_empty() {
+        return eth::Client::new(url, None).await;
+    }
+    match eth::Client::new_with_fallbacks(url, fallback_urls, None).await {
+        Ok(client) => Ok(client),
+        Err(e) => {
+            tracing::warn!(
+                fallbacks = fallback_urls.len(),
+                "dial with fallback RPCs failed, retrying with the primary only: {e:#}"
+            );
+            eth::Client::new(url, None).await
+        }
+    }
+}
+
 /// Hash of the canonical block at `height` as seen by `client`, under the RPC deadline.
 async fn canonical_block_hash(
     client: &eth::Client,


### PR DESCRIPTION
Fifth PR of the archiver liveness audit (finding 8). Stacked on #1347 → #1346 → #1345 → #1344; retarget to `usc-dev` as those merge.

## Changes

- **API up before any network handshake.** The HTTP API and the health tracker bind right after the sled store opens, ahead of the ws/http/Creditcoin handshake, the canonical-anchor check and `--backfill` (which can run for hours). Probes and `/roots*` readers see the process the whole time. `/ready` answers 503 with `source chain handshake not complete` until the source identity is verified and pinned; `chain_id` and `finalization_lag` in `/status` are `null` until then (`Health::set_source`, `OnceLock`, second call ignored).
- **`--rpc-fallback-urls`** (`RPC_FALLBACK_URLS`, comma-separated) feeds `eth::Client::new_with_fallbacks` on every dial: startup ws/http, backfill, reconnect. Block fetches then walk `[primary, fallbacks…]` on "not found" / transport errors, as the proof-gen server already does. If any fallback is unreachable (or on another chain) at dial time the archiver warns and continues with the primary alone, so a dead backup can never block startup or recovery.
- **Docs**: the README and flag help no longer claim blocks are fetched over HTTP. The WS client carries both the `newHeads` subscription and the block/receipt fetches; the HTTP endpoint is used for head tracking and the anchor check.

## Verification

- `cargo test -p archiver -p continuity` (36 archiver tests, 1 new: not ready before the handshake even with a fresh head, ready after `set_source`, second `set_source` ignored), clippy `-D warnings`, fmt.
- Fake RPC whose WS `eth_chainId` takes 20 s: during the handshake `/status` → 200 `{chain_id: null, ready: false, not_ready_reasons: ["source chain handshake not complete", "source head never observed"]}`, `/ready` → 503, `/roots/latest` → `{"latest_block": null}`.
- `reth --dev` with `--rpc-fallback-urls http://127.0.0.1:1,http://127.0.0.1:18845`: `dial with fallback RPCs failed, retrying with the primary only: Failed to connect to fallback RPC URL #0 …`, then `starting archiver` and normal archiving. With only the live fallback: starts cleanly, anchor check passes.