### PR TITLE
fix(archiver): keep the stream watchdog above the eth client's fetch retry budget

### DIFF
--- a/archiver/README.md
+++ b/archiver/README.md
@@ -37,7 +37,7 @@ All flags can also be set via environment variables (see below).
 | `--end-height` | `END_HEIGHT` | *(none)* | Stop after this block (inclusive). Omit to follow the tip |
 | `--max-fetch-tasks` | `MAX_FETCH_TASKS` | `8` | Max concurrent block fetch tasks (IO-bound) |
 | `--max-api-range` | `MAX_API_RANGE` | `1000` | Max block range per `/roots` API request |
-| `--stream-timeout-secs` | `STREAM_TIMEOUT_SECS` | `120` | Seconds before treating a stream as stalled |
+| `--stream-timeout-secs` | `STREAM_TIMEOUT_SECS` | `180` | Seconds without a new root before the stream is rebuilt; keep it above the eth client's 130 s block-fetch retry budget so fallbacks get a chance to serve |
 | `--sled-db-path` | `SLED_DB_PATH` | `./data/roots.sled` | Path to the sled database directory |
 | `--api-bind` | `API_BIND` | `0.0.0.0:8080` | HTTP API bind address |
 | `--flush-every` | `FLUSH_EVERY` | `10000` | Catch-up batch size: write roots (and request a flush) every N blocks |

--- a/archiver/src/config.rs
+++ b/archiver/src/config.rs
@@ -59,9 +59,14 @@ pub struct Config {
     #[arg(long, env = "MAX_API_RANGE", default_value = "1000")]
     pub max_api_range: u64,
 
-    /// Timeout in seconds for the stream before treating it as stalled.
-    #[arg(long, env = "STREAM_TIMEOUT_SECS", default_value = "120")]
-    pub stream_timeout_secs: u64,
+    /// Seconds without a new root before the stream is declared stalled and rebuilt
+    /// (reconnect + anchor check). This is the outer watchdog; it must be longer than the
+    /// block-fetch retry budget inside the eth client (5 sweeps over `[primary, fallbacks]`
+    /// with 10/20/40/60 s back-off, i.e. 130 s of waiting) or the watchdog tears the stream
+    /// down while the client is still walking its fallbacks, and a block that only a fallback
+    /// can serve never gets served.
+    #[arg(long, env = "STREAM_TIMEOUT_SECS", default_value = "180")]
+    pub stream_timeout_secs: NonZeroU64,
 
     /// Path to the sled database directory for root storage.
     #[arg(long, env = "SLED_DB_PATH", default_value = "./data/roots.sled")]

--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -462,7 +462,7 @@ async fn main() -> Result<()> {
     let flush_size = cfg.flush_every.get() as usize;
     let mut batch_buf = Vec::with_capacity(flush_size);
 
-    let stream_timeout = Duration::from_secs(cfg.stream_timeout_secs);
+    let stream_timeout = Duration::from_secs(cfg.stream_timeout_secs.get());
     let mut last_height: Option<u64> = None;
     // Stamped in the past so the first block at the tip is flushed immediately.
     let mut last_tip_flush = Instant::now() - TIP_FLUSH_INTERVAL;


### PR DESCRIPTION
Sixth (and smallest) PR of the archiver liveness audit (finding 6). Stacked on #1348 → #1347 → #1346 → #1345 → #1344; retarget to `usc-dev` as those merge.

## Problem

`eth::Client::try_fetch_block` retries a block fetch for 5 sweeps over `[primary, fallbacks…]` with 10/20/40/60 s back-off: 130 s of waiting before it gives up. The archiver's stream watchdog (`--stream-timeout-secs`) defaulted to 120 s. On a block that only a fallback can serve, or a primary that is flapping, the watchdog tore the stream down (reconnect, anchor check, re-subscribe) 10 s before the client would have either succeeded through a fallback or surfaced the real error. With #1348 wiring fallbacks into the archiver this mismatch would have made them mostly pointless.

## Changes

- Default `--stream-timeout-secs` 120 → **180**.
- The flag is now `NonZeroU64`: `0` produced an immediate timeout and an endless reconnect loop.
- The relationship to the client's retry budget is documented on the flag help and in the README.

No behaviour change for deployments that set the flag explicitly (other than rejecting `0`).

## Verification

`cargo test -p archiver` (36), clippy `-D warnings`, fmt.