### PR TITLE
fix(proof-gen): share one Arc<CcClient> and supervise the cc3 event task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10932,6 +10932,7 @@ dependencies = [
  "sysinfo 0.37.2",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite 0.26.2",
  "tower 0.5.3",
  "tower-http 0.6.8",
  "tracing",

--- a/proof-gen-api-server/Cargo.toml
+++ b/proof-gen-api-server/Cargo.toml
@@ -73,8 +73,9 @@ default = []
 integration-tests = []
 
 [dev-dependencies]
-alloy-node-bindings = "0.11"       # kept at 0.11 due to compatibility with alloy
+alloy-node-bindings = "0.11"             # kept at 0.11 due to compatibility with alloy
 async-trait = { workspace = true }
 parameterized = "2.1.0"
 reqwest = { workspace = true }
+tokio-tungstenite = { workspace = true }
 wiremock = "0.6"

--- a/proof-gen-api-server/src/events/mod.rs
+++ b/proof-gen-api-server/src/events/mod.rs
@@ -35,7 +35,7 @@ pub fn get_last_attestation(chain_key: u64) -> Option<LastAttestation> {
 /// Start a single CC3 event subscription for all configured chain keys (one finalized-block stream).
 /// Will automatically reconnect to the CC3 node if the connection is lost.
 pub async fn start_cc3_event_subscription(
-    cc3_client: CcClient,
+    cc3_client: Arc<CcClient>,
     checkpoint_intervals: CheckpointIntervalMap,
     last_checkpoint_blocks: LastCheckpointBlockMap,
     service: Arc<ContinuityService>,

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -32,7 +32,11 @@ use eth::redact_url_query;
 
 pub struct Server {
     config: Config,
-    cc3_client: CcClient,
+    /// The one Creditcoin client every consumer shares. `CcClient::clone` produces an
+    /// independent connection slot (a fresh `ArcSwap`), so value-cloning here would leave the
+    /// builders on a dead socket after the event task reconnects its own copy. Everything
+    /// holds this `Arc` instead, so one `reconnect()` repairs all of them.
+    cc3_client: Arc<CcClient>,
     /// One continuity builder per configured source chain.
     builders: Vec<Arc<ContinuityBuilder>>,
     /// Per-chain handle to the raw block cache, so its occupancy can be reported. Each entry
@@ -56,7 +60,7 @@ impl Server {
             chain_count = config.chains.len(),
             "🚀 [startup] connecting Creditcoin3 read-only client (cc3_rpc_url)"
         );
-        let cc3_client =
+        let cc3_client = Arc::new(
             CcClient::new_read_only(&config.cc3_rpc_url)
                 .await
                 .with_context(|| {
@@ -65,8 +69,8 @@ impl Server {
                          Ensure the node is up, the URL scheme (ws/wss) matches, and network/firewall allows the connection.",
                         config.cc3_rpc_url
                     )
-                })?
-        ;
+                })?,
+        );
         debug!("🚀 ✅ [startup] Creditcoin3 client connected");
 
         let mut builders: Vec<Arc<ContinuityBuilder>> = Vec::with_capacity(config.chains.len());
@@ -95,7 +99,7 @@ impl Server {
             }
             let (builder, block_cache) = Self::build_continuity_for_chain(
                 &config,
-                cc3_client.clone(),
+                &cc3_client,
                 chain,
                 &checkpoint_intervals,
                 &last_checkpoint_blocks,
@@ -120,7 +124,7 @@ impl Server {
 
     async fn build_continuity_for_chain(
         global: &Config,
-        cc3_client: CcClient,
+        cc3_client: &Arc<CcClient>,
         chain: &ChainConfig,
         checkpoint_intervals: &Arc<RwLock<HashMap<u64, u64>>>,
         last_checkpoint_blocks: &Arc<RwLock<HashMap<u64, u64>>>,
@@ -327,7 +331,7 @@ impl Server {
         );
         let builder = Arc::new(ContinuityBuilder::new_with_providers(
             continuity_config,
-            Arc::new(cc3_client.clone()),
+            cc3_client.clone(),
             eth_provider,
         ));
 
@@ -383,32 +387,28 @@ impl Server {
         let last_checkpoint_blocks_clone = self.last_checkpoint_blocks.clone();
         let cc3_client_clone = self.cc3_client.clone();
 
-        tokio::spawn(async move {
-            if let Err(e) = events::start_cc3_event_subscription(
-                cc3_client_clone,
-                checkpoint_intervals_clone,
-                last_checkpoint_blocks_clone,
-                service,
-            )
-            .await
-            {
-                error!("❌ 🔗 CC3 event subscription failed: {e}");
-            }
-        });
+        // The event task is supervised, not fire-and-forget. `StreamCC3` ends itself only
+        // when history is gone for good (state pruned, or a reconnect gap past its replay
+        // cap); its contract is that the consumer restarts. A prover that keeps serving after
+        // that answers from caches that no longer track the chain — newer proofs fail with
+        // `BlockNotReady`, and missed checkpoint/reversion events are never repaired.
+        let events = tokio::spawn(events::start_cc3_event_subscription(
+            cc3_client_clone,
+            checkpoint_intervals_clone,
+            last_checkpoint_blocks_clone,
+            service.clone(),
+        ));
 
-        select! {
-            res = &mut server => {
-                if let Err(err) = res {
-                    error!("❌ HTTP server exited with error: {err}");
-                }
-                bail!("API HTTP server exited!");
-            }
-            _ = shutdown_signal() => {
-                let _ = http_shutdown_tx.send(());
-                tracing::info!("🛑 Global shutdown requested, exiting");
-                Ok(())
-            }
-        }
+        supervise(
+            server,
+            events,
+            shutdown_signal(),
+            http_shutdown_tx,
+            |reason| {
+                service.mark_event_stream_dead(reason);
+            },
+        )
+        .await
     }
 
     pub async fn get_checkpoint_interval(&self, chain_key: u64) -> Option<u64> {
@@ -427,6 +427,63 @@ impl Server {
             .copied()
     }
 }
+
+/// Run the HTTP server, the cc3 event task and the shutdown signal to the first exit.
+///
+/// - shutdown signal: ask HTTP to drain and return `Ok`.
+/// - HTTP server exit: fatal.
+/// - event task exit (error, end of stream or panic): mark the replica unready via
+///   `mark_dead`, ask HTTP to drain, give in-flight requests a moment, then return `Err` so
+///   the process exits nonzero and the orchestrator replaces it with a fresh boot that
+///   re-seeds from the current finalized head.
+async fn supervise<S, D, M>(
+    mut server: S,
+    events: tokio::task::JoinHandle<Result<()>>,
+    shutdown: D,
+    http_shutdown_tx: tokio::sync::oneshot::Sender<()>,
+    mark_dead: M,
+) -> Result<()>
+where
+    S: std::future::Future<Output = Result<()>> + Unpin,
+    D: std::future::Future<Output = ()>,
+    M: FnOnce(&str),
+{
+    tokio::pin!(shutdown);
+    select! {
+        res = &mut server => {
+            if let Err(err) = res {
+                error!("❌ HTTP server exited with error: {err}");
+            }
+            bail!("API HTTP server exited!");
+        }
+        joined = events => {
+            let reason = match joined {
+                Ok(Ok(())) => "cc3 event task returned without error".to_string(),
+                Ok(Err(err)) => format!("{err:#}"),
+                Err(join) if join.is_panic() => format!("cc3 event task panicked: {join}"),
+                Err(join) => format!("cc3 event task cancelled: {join}"),
+            };
+            error!(
+                %reason,
+                "❌ 🔗 CC3 event subscription ended; this replica can no longer track the chain — \
+                 shutting down so the orchestrator restarts it from a fresh finalized head"
+            );
+            mark_dead(&reason);
+            let _ = http_shutdown_tx.send(());
+            let _ = tokio::time::timeout(EVENT_EXIT_DRAIN, &mut server).await;
+            bail!("cc3 event subscription ended: {reason}");
+        }
+        _ = &mut shutdown => {
+            let _ = http_shutdown_tx.send(());
+            tracing::info!("🛑 Global shutdown requested, exiting");
+            Ok(())
+        }
+    }
+}
+
+/// How long `supervise` lets the HTTP server drain after the event task dies before the
+/// process exits regardless.
+const EVENT_EXIT_DRAIN: std::time::Duration = std::time::Duration::from_secs(5);
 
 pub async fn shutdown_signal() {
     let ctrl_c = async {
@@ -452,4 +509,80 @@ pub async fn shutdown_signal() {
     }
 
     info!("🛑 Shutdown signal received");
+}
+
+#[cfg(test)]
+mod supervise_tests {
+    use super::*;
+
+    fn never_shutdown() -> std::future::Pending<()> {
+        std::future::pending()
+    }
+
+    #[tokio::test]
+    async fn event_task_error_is_fatal_and_marks_the_replica_dead() {
+        let (tx, rx) = channel::<()>();
+        let server = Box::pin(async move {
+            let _ = rx.await;
+            Ok(())
+        });
+        let events = tokio::spawn(async { anyhow::bail!("End of unbounded event stream") });
+        let marked = std::sync::Mutex::new(None);
+        let res = supervise(server, events, never_shutdown(), tx, |r| {
+            *marked.lock().unwrap() = Some(r.to_string());
+        })
+        .await;
+        let err = res.expect_err("event task death must exit the process");
+        assert!(
+            err.to_string().contains("End of unbounded event stream"),
+            "{err}"
+        );
+        assert!(marked
+            .lock()
+            .unwrap()
+            .as_deref()
+            .unwrap()
+            .contains("End of unbounded"));
+    }
+
+    #[tokio::test]
+    async fn event_task_panic_is_fatal() {
+        let (tx, rx) = channel::<()>();
+        let server = Box::pin(async move {
+            let _ = rx.await;
+            Ok(())
+        });
+        let events = tokio::spawn(async { panic!("boom") });
+        let res = supervise(server, events, never_shutdown(), tx, |_| {}).await;
+        assert!(res.unwrap_err().to_string().contains("panicked"));
+    }
+
+    #[tokio::test]
+    async fn shutdown_signal_drains_http_and_returns_ok() {
+        let (tx, rx) = channel::<()>();
+        let drained = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let d = drained.clone();
+        let server = Box::pin(async move {
+            let _ = rx.await;
+            d.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        });
+        let events = tokio::spawn(async { std::future::pending::<Result<()>>().await });
+        let res = supervise(server, events, std::future::ready(()), tx, |_| {
+            panic!("shutdown must not mark the replica dead")
+        })
+        .await;
+        assert!(res.is_ok());
+        // The drain request was sent; the server future observes it once polled.
+        tokio::task::yield_now().await;
+    }
+
+    #[tokio::test]
+    async fn http_server_exit_is_fatal() {
+        let (tx, _rx) = channel::<()>();
+        let server = Box::pin(async { anyhow::bail!("bind failed") });
+        let events = tokio::spawn(async { std::future::pending::<Result<()>>().await });
+        let res = supervise(server, events, never_shutdown(), tx, |_| {}).await;
+        assert!(res.unwrap_err().to_string().contains("HTTP server exited"));
+    }
 }

--- a/proof-gen-api-server/src/networking/routes/health.rs
+++ b/proof-gen-api-server/src/networking/routes/health.rs
@@ -25,6 +25,10 @@ pub struct HealthCheckResponse {
     cc3_cache_fresh: bool,
     /// Seconds since the least-recently-advanced chain's cache last changed.
     cc3_cache_age_seconds: u64,
+    /// Why the cc3 event task ended, when it has. A replica in this state is draining and
+    /// about to exit; it must not receive new traffic.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cc3_event_stream_dead: Option<String>,
     uptime_seconds: u64,
 }
 
@@ -81,7 +85,8 @@ pub async fn health_check(
         );
     }
 
-    let status = if freshness.fresh && eth_connected {
+    let event_stream_dead = service.event_stream_dead();
+    let status = if freshness.fresh && eth_connected && event_stream_dead.is_none() {
         "healthy".to_string()
     } else {
         "degraded".to_string()
@@ -93,6 +98,7 @@ pub async fn health_check(
         eth_rpc_connected: eth_connected,
         cc3_cache_fresh: freshness.fresh,
         cc3_cache_age_seconds: freshness.max_age_seconds,
+        cc3_event_stream_dead: event_stream_dead,
         uptime_seconds: service.uptime_seconds(),
     })
 }

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -187,6 +187,11 @@ pub type ServiceResult<T> = Result<T, ServiceError>;
 pub struct ContinuityService {
     chains: HashMap<u64, Arc<ChainState>>,
     start_time: Instant,
+    /// Set (with the reason) when the cc3 event task has ended for good. From that moment
+    /// the caches no longer track the chain and this replica must not be considered ready;
+    /// the supervisor exits the process right after setting this, so the flag mostly serves
+    /// the in-flight drain window and diagnostics.
+    event_stream_dead: std::sync::Mutex<Option<String>>,
     /// Prometheus metrics for instrumentation (uses NoopMetrics when disabled).
     metrics: Metrics,
     /// Maximum amount of concurrent futures spawned when generating proofs for batch requests or when extracting transaction indexes from transaction hashes.
@@ -367,6 +372,7 @@ impl ContinuityService {
         Ok(Self {
             chains,
             start_time: Instant::now(),
+            event_stream_dead: std::sync::Mutex::new(None),
             metrics,
             max_batch_size,
             max_batch_span,
@@ -817,6 +823,25 @@ impl ContinuityService {
 
     pub fn uptime_seconds(&self) -> u64 {
         self.start_time.elapsed().as_secs()
+    }
+
+    /// Record that the cc3 event task has ended permanently. Idempotent; the first reason wins.
+    pub fn mark_event_stream_dead(&self, reason: &str) {
+        let mut guard = self
+            .event_stream_dead
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        if guard.is_none() {
+            *guard = Some(reason.to_owned());
+        }
+    }
+
+    /// Why the cc3 event task ended, if it has. `None` while it is (believed) running.
+    pub fn event_stream_dead(&self) -> Option<String> {
+        self.event_stream_dead
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
     }
 
     /// Live cc3 RPC probe: a lightweight storage read on **every** configured chain.

--- a/proof-gen-api-server/tests/cc3_ws_fixture/mod.rs
+++ b/proof-gen-api-server/tests/cc3_ws_fixture/mod.rs
@@ -1,0 +1,129 @@
+//! A disposable loopback Creditcoin WebSocket node for liveness tests.
+//!
+//! Answers just enough of the Substrate RPC surface for `cc_client::Client` to connect
+//! (metadata, runtime version, finalized head, storage reads) and lets a test close every
+//! open socket or serve pruned history on demand. No live chain is involved.
+
+#![allow(dead_code)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use futures::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use tokio::task::{JoinHandle, JoinSet};
+use tokio_tungstenite::tungstenite::Message;
+
+pub struct WsFixture {
+    pub url: String,
+    /// Send to close every currently open connection (the server keeps accepting).
+    pub close: broadcast::Sender<()>,
+    /// Number of connections accepted so far.
+    pub accepted: Arc<AtomicUsize>,
+    task: JoinHandle<()>,
+}
+
+impl Drop for WsFixture {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+pub fn mock_header(height: u64) -> Value {
+    let hash = format!("0x{}", "11".repeat(32));
+    json!({"number": format!("0x{height:x}"), "parentHash": hash, "stateRoot": hash,
+        "extrinsicsRoot": hash, "digest": {"logs": []}})
+}
+
+impl WsFixture {
+    /// Healthy node: answers RPC, emits no finalized-head notifications.
+    pub async fn start() -> Self {
+        Self::start_with_pruned_events(false).await
+    }
+
+    /// When `prune_second_block` is set, the node pushes finalized heads 1 and 2 right after
+    /// the subscription is accepted and answers every `state_getStorage` after the first with
+    /// `State already discarded`, which is the permanent-pruned path in `StreamCC3`.
+    pub async fn start_with_pruned_events(prune_second_block: bool) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}", listener.local_addr().unwrap());
+        let (close, _) = broadcast::channel(4);
+        let signal = close.clone();
+        let accepted = Arc::new(AtomicUsize::new(0));
+        let count = accepted.clone();
+        let task = tokio::spawn(async move {
+            let mut connections = JoinSet::new();
+            loop {
+                let (socket, _) = listener.accept().await.unwrap();
+                count.fetch_add(1, Ordering::SeqCst);
+                let mut close = signal.subscribe();
+                connections.spawn(async move {
+                    let mut ws = tokio_tungstenite::accept_async(socket).await.unwrap();
+                    let mut event_fetches = 0;
+                    loop {
+                        tokio::select! {
+                            _ = close.recv() => {
+                                let _ = ws.close(None).await;
+                                break;
+                            }
+                            incoming = ws.next() => {
+                                let text = match incoming {
+                                    Some(Ok(Message::Text(text))) => text,
+                                    Some(Ok(Message::Ping(payload))) => {
+                                        let _ = ws.send(Message::Pong(payload)).await;
+                                        continue;
+                                    }
+                                    _ => break,
+                                };
+                                let req: Value = serde_json::from_str(text.as_str()).unwrap();
+                                if req["method"] == "state_getStorage" {
+                                    event_fetches += 1;
+                                    if prune_second_block && event_fetches > 1 {
+                                        let response = json!({"jsonrpc": "2.0", "id": req["id"],
+                                            "error": {"code": -32000, "message": "UnknownBlock: State already discarded"}});
+                                        let _ = ws.send(Message::Text(response.to_string().into())).await;
+                                        continue;
+                                    }
+                                }
+                                let result = match req["method"].as_str().unwrap() {
+                                    "chain_getFinalizedHead" | "chain_getBlockHash" => json!(format!("0x{}", "11".repeat(32))),
+                                    "chain_getHeader" => mock_header(0),
+                                    "state_getStorage" => json!("0x00"),
+                                    "state_getRuntimeVersion" => json!({"specVersion": 1, "transactionVersion": 1}),
+                                    "state_call" => {
+                                        let metadata = include_bytes!("../../../common/cc-client/artifacts/metadata.scale");
+                                        // SCALE Option<OpaqueMetadata>: Some + compact Vec length + bytes.
+                                        let mut encoded = vec![1u8];
+                                        encoded.extend_from_slice(&(((metadata.len() as u32) << 2) | 2).to_le_bytes());
+                                        encoded.extend_from_slice(metadata);
+                                        json!(format!("0x{}", hex::encode(encoded)))
+                                    }
+                                    "chain_subscribeFinalizedHeads" => json!("fixture-subscription"),
+                                    "chain_unsubscribeFinalizedHeads" => json!(true),
+                                    other => panic!("unexpected fixture RPC: {other}"),
+                                };
+                                let response = json!({"jsonrpc": "2.0", "id": req["id"], "result": result});
+                                if ws.send(Message::Text(response.to_string().into())).await.is_err() { break; }
+                                if prune_second_block && req["method"] == "chain_subscribeFinalizedHeads" {
+                                    for height in [1, 2] {
+                                        let event = json!({"jsonrpc": "2.0", "method": "chain_finalizedHead",
+                                            "params": {"subscription": "fixture-subscription", "result": mock_header(height)}});
+                                        let _ = ws.send(Message::Text(event.to_string().into())).await;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+        Self {
+            url,
+            close,
+            accepted,
+            task,
+        }
+    }
+}

--- a/proof-gen-api-server/tests/liveness_event_task.rs
+++ b/proof-gen-api-server/tests/liveness_event_task.rs
@@ -1,0 +1,116 @@
+//! Liveness regression tests for the cc3 event task and the shared Creditcoin client.
+//! All endpoints are disposable loopback fixtures; no live chain is touched.
+
+mod cc3_ws_fixture;
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cc3_ws_fixture::WsFixture;
+
+/// The server hands one `Arc<CcClient>` to the builders and the event task. A reconnect
+/// through any holder must repair every holder — that is the property the `Arc` buys and the
+/// reason value-cloning (`CcClient::clone`, a fresh connection slot) is no longer used.
+#[tokio::test]
+async fn reconnect_through_the_shared_arc_repairs_every_holder() {
+    let fixture = WsFixture::start().await;
+    let builder_client = Arc::new(
+        cc_client::Client::new_read_only(&fixture.url)
+            .await
+            .unwrap(),
+    );
+    let event_client = builder_client.clone();
+    assert!(builder_client
+        .legacy()
+        .chain_get_finalized_head()
+        .await
+        .is_ok());
+
+    fixture.close.send(()).unwrap();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while builder_client
+            .legacy()
+            .chain_get_finalized_head()
+            .await
+            .is_ok()
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("client must notice the closed socket");
+
+    event_client.reconnect().await.unwrap();
+    assert!(event_client
+        .legacy()
+        .chain_get_finalized_head()
+        .await
+        .is_ok());
+    assert!(
+        builder_client
+            .legacy()
+            .chain_get_finalized_head()
+            .await
+            .is_ok(),
+        "the builders' handle must observe the event task's reconnect"
+    );
+    assert_eq!(
+        fixture.accepted.load(Ordering::SeqCst),
+        2,
+        "exactly one redial"
+    );
+}
+
+/// Permanently pruned history ends the stream; the event task must return an error (the
+/// supervisor in `Server::run` turns that into a nonzero process exit) and must not keep
+/// looping on a dead subscription.
+#[tokio::test]
+async fn pruned_history_makes_the_event_task_return_an_error() {
+    let fixture = WsFixture::start_with_pruned_events(true).await;
+    let cc = Arc::new(
+        cc_client::Client::new_read_only(&fixture.url)
+            .await
+            .unwrap(),
+    );
+    let (cc_provider, eth_provider) = continuity::mocks::make_mock_providers(2);
+    let cfg = continuity::ContinuityConfig::builder()
+        .cc3_rpc_url(&fixture.url)
+        .eth_rpc_url("http://mock")
+        .chain_key(2)
+        .attestation_interval(10)
+        .checkpoint_interval(10)
+        .build();
+    let builder = Arc::new(continuity::ContinuityBuilder::new_with_providers(
+        cfg,
+        cc_provider,
+        eth_provider,
+    ));
+    let metrics = Arc::new(proof_gen_api_server::prom::ProofGenMetrics::new(&[2]));
+    let service = Arc::new(
+        proof_gen_api_server::ContinuityService::new(vec![builder], metrics.clone(), 10, 1000)
+            .await
+            .unwrap(),
+    );
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        proof_gen_api_server::events::start_cc3_event_subscription(
+            cc,
+            Arc::default(),
+            Arc::default(),
+            service.clone(),
+        ),
+    )
+    .await
+    .expect("event task must exit on pruned history");
+    let err = result.expect_err("end of stream is an error, not a clean return");
+    assert!(
+        err.to_string().contains("End of unbounded event stream"),
+        "{err}"
+    );
+
+    // What the supervisor does next: the replica reports itself dead and degraded.
+    service.mark_event_stream_dead(&err.to_string());
+    assert!(service.event_stream_dead().is_some());
+}


### PR DESCRIPTION
First PR of the prover liveness audit (2026-09-11), findings **7** and **1**.

## Problems

- **Finding 7.** `CcClient::clone` creates an independent connection slot (a fresh `ArcSwap`). `Server` value-cloned the client into each `ContinuityBuilder` and again into the event task. After a socket close the event task reconnected *its* copy; the builders stayed on the dead socket permanently (reproduced with a loopback WS node: the reconnected client succeeds, the builder-side client keeps failing).
- **Finding 1.** `StreamCC3` ends itself only when history is permanently gone (pruned state, or a reconnect gap past `MAX_BACKFILL_BLOCKS`) and its contract is that the consumer restarts. `Server::run` spawned the event task and dropped the handle; the HTTP server kept serving from caches that no longer tracked the chain, so newer proofs failed with `BlockNotReady` and missed checkpoint/reversion events were never repaired.

## Changes

- One `Arc<CcClient>` is created in `Server::new` and handed to every builder and to the event task. `start_cc3_event_subscription` takes `Arc<CcClient>`.
- `Server::run` supervises the event task through a new `supervise()` helper. When the task ends (error, clean return, or panic) the server marks the replica dead (`ContinuityService::mark_event_stream_dead`), asks axum to drain, waits up to 5 s for in-flight requests, and returns an error so the process **exits nonzero** and the orchestrator restarts it from a fresh finalized head. This is the same policy the attestor's production task applies to the same stream.
- `/api/v1/health` reports `degraded` with `cc3_event_stream_dead: <reason>` during the drain window. Readiness/503 semantics come in a later PR of this series (finding 5).

## Tests

- 4 unit tests for `supervise`: event-task error, event-task panic, shutdown signal, HTTP server exit.
- `tests/liveness_event_task.rs` with a disposable in-process WebSocket "Creditcoin node" (`tests/cc3_ws_fixture`): reconnect through the shared `Arc` repairs every holder with exactly one redial; pruned history makes the event task return `End of unbounded event stream`.
- `cargo test -p proof-gen-api-server` (81 unit, 27 route, 2 liveness), clippy `-D warnings`, fmt, taplo, machete.

## Series

A (this) → B finding 2 (stream progress watchdog) → C findings 3+4 (ETH repair lock, tip failover) → D findings 5+8 (readiness, consistent startup) → E finding 6 (admission budget, single-flight fills). Each stacks on the previous branch.