### PR TITLE
fix(eth,continuity): lock-free ETH repair with shared generations; tip reads fail over; HTTP deadlines

### DIFF
--- a/common/continuity/src/rpc.rs
+++ b/common/continuity/src/rpc.rs
@@ -28,6 +28,15 @@ const RECONNECT_BACKOFF_MAX_MS: u64 = 5_000;
 /// as the number of *retries*, so we pass `RECONNECT_MAX_ATTEMPTS - 1` to `.take(..)`.
 const RECONNECT_MAX_ATTEMPTS: usize = 5;
 
+/// Upper bound on one attempt of one RPC operation, wrapping every retry `eth::Client` does
+/// internally. Transports carry their own per-request deadlines, but a WebSocket request has
+/// none, and no deadline at all means a single hung request pins a caller (and its batch)
+/// forever. Generous on purpose: a 1000-block continuity range on a slow RPC is minutes.
+const ETH_RPC_CALL_TIMEOUT: Duration = Duration::from_secs(300);
+/// Upper bound on one repair: re-dialling the primary and every fallback and reading their
+/// chain ids.
+const ETH_RPC_DIAL_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// ETH RPC provider that owns one long-lived [`eth::Client`] and reconnects it on transport
 /// failures.
 ///
@@ -35,10 +44,22 @@ const RECONNECT_MAX_ATTEMPTS: usize = 5;
 /// retry the call after reconnecting with exponential backoff + jitter, and surface a clean
 /// error if reconnection itself can't recover.
 ///
+/// Repairs never hold the client lock across network I/O. A replacement connection is dialled
+/// on a clone, under a deadline, and swapped in atomically once it is up; callers keep reading
+/// the current client meanwhile and are never queued behind someone else's slow dial.
+/// Concurrent failures share one repair: each caller remembers the connection generation it
+/// failed against and only dials if nobody has published a newer one since.
+///
 /// [`ReconnectingRuntimeApi`]: cc_client::api::ReconnectingRuntimeApi
 #[derive(Debug)]
 pub struct ReconnectingEthRpcProvider {
     client: RwLock<eth::Client>,
+    /// Bumped every time a repaired client is published.
+    generation: std::sync::atomic::AtomicU64,
+    /// Serialises repairs so N simultaneous failures cost one dial, not N.
+    repair: tokio::sync::Mutex<()>,
+    call_timeout: Duration,
+    dial_timeout: Duration,
     /// Source-chain block encoding, derived from CC3 supported-chain metadata at
     /// startup. Used for all block fetching / continuity building so that a
     /// per-chain or future encoding change is honoured instead of assuming V1.
@@ -49,8 +70,32 @@ impl ReconnectingEthRpcProvider {
     pub fn new(client: eth::Client, encoding: EncodingVersion) -> Self {
         Self {
             client: RwLock::new(client),
+            generation: std::sync::atomic::AtomicU64::new(0),
+            repair: tokio::sync::Mutex::new(()),
+            call_timeout: ETH_RPC_CALL_TIMEOUT,
+            dial_timeout: ETH_RPC_DIAL_TIMEOUT,
             encoding,
         }
+    }
+
+    /// Override the per-attempt call deadline and the per-repair dial deadline.
+    #[must_use]
+    pub fn with_timeouts(mut self, call_timeout: Duration, dial_timeout: Duration) -> Self {
+        self.call_timeout = call_timeout;
+        self.dial_timeout = dial_timeout;
+        self
+    }
+
+    /// Connection generation currently published. Changes only when a repair succeeds.
+    pub fn generation(&self) -> u64 {
+        self.generation.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Cheap snapshot of the live client plus the generation it belongs to.
+    async fn snapshot(&self) -> (eth::Client, u64) {
+        let guard = self.client.read().await;
+        let generation = self.generation();
+        (guard.clone(), generation)
     }
 
     /// Run an RPC call, reconnecting and retrying on failure.
@@ -64,10 +109,10 @@ impl ReconnectingEthRpcProvider {
         let mut last_err: Option<anyhow::Error> = None;
 
         for attempt in 1..=ETH_RPC_MAX_ATTEMPTS {
-            let client = self.client.read().await.clone();
-            match call(client).await {
-                Ok(value) => return Ok(value),
-                Err(err) => {
+            let (client, generation) = self.snapshot().await;
+            let err = match tokio::time::timeout(self.call_timeout, call(client)).await {
+                Ok(Ok(value)) => return Ok(value),
+                Ok(Err(err)) => {
                     // A user-initiated shutdown (Ctrl+C / service stop) surfaces here as an
                     // `anyhow::Error` carrying `user::Shutdown` (via `propagate_shutdown` in the
                     // block-fetch closures). It is not a transport failure, so do not reconnect
@@ -90,19 +135,24 @@ impl ReconnectingEthRpcProvider {
                         );
                         return Err(err);
                     }
-                    warn!(
-                        op,
-                        attempt,
-                        max = ETH_RPC_MAX_ATTEMPTS,
-                        error = %err,
-                        "ETH RPC call failed",
-                    );
-                    last_err = Some(err);
+                    err
                 }
-            }
+                Err(_elapsed) => anyhow!(
+                    "{op} timed out after {:?} (attempt {attempt})",
+                    self.call_timeout
+                ),
+            };
+            warn!(
+                op,
+                attempt,
+                max = ETH_RPC_MAX_ATTEMPTS,
+                error = %err,
+                "ETH RPC call failed",
+            );
+            last_err = Some(err);
 
             if attempt < ETH_RPC_MAX_ATTEMPTS {
-                self.reconnect(op).await?;
+                self.reconnect(op, generation).await?;
             }
         }
 
@@ -111,8 +161,23 @@ impl ReconnectingEthRpcProvider {
             .context(format!("{op} failed after {ETH_RPC_MAX_ATTEMPTS} attempts")))
     }
 
-    /// Reconnect the shared client with exponential backoff + jitter.
-    async fn reconnect(&self, op: &'static str) -> Result<()> {
+    /// Repair the shared client unless someone already did since `observed_generation`.
+    ///
+    /// Dials happen on a clone, outside the client lock and under `dial_timeout`; the lock is
+    /// taken only for the instantaneous swap, so callers running other operations are never
+    /// blocked behind a slow or black-holed endpoint.
+    async fn reconnect(&self, op: &'static str, observed_generation: u64) -> Result<()> {
+        let _serialised = self.repair.lock().await;
+        if self.generation() != observed_generation {
+            tracing::debug!(
+                op,
+                observed_generation,
+                current = self.generation(),
+                "ETH RPC client already repaired by another caller; retrying on it"
+            );
+            return Ok(());
+        }
+
         // `tokio_retry` runs the action once, then drains the strategy iterator on each retry.
         // Subtract one so `RECONNECT_MAX_ATTEMPTS` reflects total attempts (matches
         // `ETH_RPC_MAX_ATTEMPTS`).
@@ -123,12 +188,15 @@ impl ReconnectingEthRpcProvider {
 
         tokio_retry::Retry::spawn(strategy, || async {
             warn!(op, "reconnecting ETH RPC client");
-            self.client
-                .write()
+            let mut candidate = self.client.read().await.clone();
+            tokio::time::timeout(self.dial_timeout, candidate.reconnect())
                 .await
-                .reconnect()
-                .await
-                .map_err(|e| anyhow!("{e}"))
+                .map_err(|_| anyhow!("dial timed out after {:?}", self.dial_timeout))?
+                .map_err(|e| anyhow!("{e}"))?;
+            *self.client.write().await = candidate;
+            self.generation
+                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            Ok::<(), anyhow::Error>(())
         })
         .await
         .with_context(|| format!("failed to reconnect ETH RPC client for {op}"))?;

--- a/common/continuity/src/rpc.rs
+++ b/common/continuity/src/rpc.rs
@@ -33,8 +33,9 @@ const RECONNECT_MAX_ATTEMPTS: usize = 5;
 /// none, and no deadline at all means a single hung request pins a caller (and its batch)
 /// forever. Generous on purpose: a 1000-block continuity range on a slow RPC is minutes.
 const ETH_RPC_CALL_TIMEOUT: Duration = Duration::from_secs(300);
-/// Upper bound on one repair: re-dialling the primary and every fallback and reading their
-/// chain ids.
+/// Upper bound on re-dialling the *primary* during one repair (chain-id read included).
+/// Fallbacks are re-dialled after it under `eth`'s own per-fallback bound and never decide
+/// the repair's outcome.
 const ETH_RPC_DIAL_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// ETH RPC provider that owns one long-lived [`eth::Client`] and reconnects it on transport
@@ -78,7 +79,7 @@ impl ReconnectingEthRpcProvider {
         }
     }
 
-    /// Override the per-attempt call deadline and the per-repair dial deadline.
+    /// Override the per-attempt call deadline and the per-repair primary dial deadline.
     #[must_use]
     pub fn with_timeouts(mut self, call_timeout: Duration, dial_timeout: Duration) -> Self {
         self.call_timeout = call_timeout;
@@ -189,9 +190,9 @@ impl ReconnectingEthRpcProvider {
         tokio_retry::Retry::spawn(strategy, || async {
             warn!(op, "reconnecting ETH RPC client");
             let mut candidate = self.client.read().await.clone();
-            tokio::time::timeout(self.dial_timeout, candidate.reconnect())
+            candidate
+                .reconnect_with_deadline(self.dial_timeout)
                 .await
-                .map_err(|_| anyhow!("dial timed out after {:?}", self.dial_timeout))?
                 .map_err(|e| anyhow!("{e}"))?;
             *self.client.write().await = candidate;
             self.generation

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -25,6 +25,9 @@ use alloy::{
     transports::{http::reqwest::Url, TransportErrorKind},
 };
 
+use alloy::rpc::client::RpcClient as AlloyRpcClient;
+use alloy::transports::http::{reqwest, Http};
+use alloy::transports::utils::guess_local_url;
 use anyhow::{Context, Result};
 use hex::FromHexError;
 use sp_core::H256;
@@ -398,7 +401,18 @@ pub struct Client {
     /// `None` = no caching (default). Survives [`Client::reconnect`] since cached finalized
     /// blocks are immutable.
     mem_cache: Option<std::sync::Arc<mem_block_cache::MemBlockCache>>,
+    /// Every fallback URL as configured, including ones that were unreachable when dialled.
+    /// [`Client::reconnect`] re-dials from this list, so a backup that was down at startup is
+    /// picked up on the next repair instead of being forgotten for the life of the process.
+    fallback_urls: Vec<String>,
 }
+
+/// Per-request deadline on the HTTP transport. alloy's default reqwest client has no timeout
+/// at all, so a server that accepts the connection and never answers keeps the request (and
+/// every caller waiting on it) pending forever.
+const HTTP_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+/// TCP/TLS connect deadline on the HTTP transport.
+const HTTP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 impl Client {
     async fn init_rpc(url: &str) -> Result<(Url, AlloyProvider, u64), Error> {
@@ -406,9 +420,20 @@ impl Client {
         let url_scheme = url.scheme();
 
         let rpc_provider = match url_scheme {
-            "http" | "https" => ProviderBuilder::new()
-                .network::<Ethereum>()
-                .on_http(url.clone()),
+            "http" | "https" => {
+                let http_client = reqwest::Client::builder()
+                    .connect_timeout(HTTP_CONNECT_TIMEOUT)
+                    .timeout(HTTP_REQUEST_TIMEOUT)
+                    .build()
+                    .map_err(|e| {
+                        Error::ClientError(anyhow::anyhow!("building HTTP client: {e}"))
+                    })?;
+                let transport = Http::with_client(http_client, url.clone());
+                let is_local = guess_local_url(url.as_str());
+                ProviderBuilder::new()
+                    .network::<Ethereum>()
+                    .on_client(AlloyRpcClient::new(transport, is_local))
+            }
 
             "ws" | "wss" => {
                 let ws = WsConnect::new(url.clone());
@@ -446,6 +471,7 @@ impl Client {
             fallback_providers: Vec::new(),
             chain_id,
             mem_cache: None,
+            fallback_urls: Vec::new(),
         })
     }
 
@@ -495,6 +521,7 @@ impl Client {
             fallback_providers,
             chain_id,
             mem_cache: None,
+            fallback_urls: fallback_urls.to_vec(),
         })
     }
 
@@ -510,19 +537,29 @@ impl Client {
         // fails to reconnect (transport error or chain_id mismatch), keep the
         // existing provider in place, log a loud error, and let the next
         // primary-failure path retry it on its own.
-        let mut new_fallbacks = Vec::with_capacity(self.fallback_providers.len());
-        for (idx, fp) in self.fallback_providers.iter().enumerate() {
-            match Self::init_rpc(fp.url.as_ref()).await {
+        //
+        // Re-dial from the *configured* list, not from the providers currently held: a
+        // fallback that was unreachable at startup (and therefore never became a provider) is
+        // retried here instead of being lost for the life of the process.
+        let mut new_fallbacks = Vec::with_capacity(self.fallback_urls.len());
+        for (idx, raw_url) in self.fallback_urls.iter().enumerate() {
+            let previous = self.fallback_providers.iter().find(|fp| {
+                fp.url.as_str() == raw_url.as_str()
+                    || fp.url.as_str().trim_end_matches('/') == raw_url.trim_end_matches('/')
+            });
+            match Self::init_rpc(raw_url).await {
                 Ok((fp_url, fp_provider, fp_chain_id)) => {
                     if fp_chain_id != chain_id {
                         tracing::error!(
                             fallback_index = idx,
-                            fallback_url = %redact_url_query(fp.url.as_str()),
+                            fallback_url = %redact_url_query(raw_url),
                             fallback_chain_id = fp_chain_id,
                             primary_chain_id = chain_id,
-                            "⛔ Fallback RPC chain_id mismatch on reconnect; keeping previous fallback provider"
+                            "⛔ Fallback RPC chain_id mismatch on reconnect; keeping previous fallback provider if any"
                         );
-                        new_fallbacks.push(fp.clone());
+                        if let Some(fp) = previous {
+                            new_fallbacks.push(fp.clone());
+                        }
                     } else {
                         new_fallbacks.push(FallbackProvider {
                             url: fp_url,
@@ -533,11 +570,13 @@ impl Client {
                 Err(err) => {
                     tracing::error!(
                         fallback_index = idx,
-                        fallback_url = %redact_url_query(fp.url.as_str()),
+                        fallback_url = %redact_url_query(raw_url),
                         error = %err,
-                        "⛔ Failed to reconnect fallback RPC; keeping previous fallback provider"
+                        "⛔ Failed to reconnect fallback RPC; keeping previous fallback provider if any"
                     );
-                    new_fallbacks.push(fp.clone());
+                    if let Some(fp) = previous {
+                        new_fallbacks.push(fp.clone());
+                    }
                 }
             }
         }
@@ -558,13 +597,22 @@ impl Client {
     ) -> anyhow::Result<Vec<FallbackProvider>> {
         let mut providers: Vec<FallbackProvider> = Vec::with_capacity(fallback_urls.len());
         for (idx, raw_url) in fallback_urls.iter().enumerate() {
-            let (url, provider, chain_id) =
-                Self::init_rpc(raw_url.as_ref()).await.with_context(|| {
-                    format!(
-                        "Failed to connect to fallback RPC URL #{idx} ({})",
-                        redact_url_query(raw_url),
-                    )
-                })?;
+            // An unreachable backup must not stop a healthy primary from serving: log it and
+            // carry on without it; `reconnect` re-dials every configured URL and picks it up
+            // once it is back. A backup on the *wrong chain* is a misconfiguration and stays
+            // fatal — silently serving from it would corrupt proofs.
+            let (url, provider, chain_id) = match Self::init_rpc(raw_url.as_ref()).await {
+                Ok(connected) => connected,
+                Err(err) => {
+                    tracing::error!(
+                        fallback_index = idx,
+                        fallback_url = %redact_url_query(raw_url),
+                        error = %err,
+                        "⛔ Fallback RPC unreachable at startup; continuing without it until the next reconnect"
+                    );
+                    continue;
+                }
+            };
 
             if chain_id != primary_chain_id {
                 anyhow::bail!(
@@ -910,8 +958,37 @@ impl Client {
         }
     }
 
+    /// Current chain head, tried on the primary first and then on each fallback in order.
+    ///
+    /// Every proof request validates its heights against the confirmed tip, so a tip read
+    /// that only ever asked the primary made a healthy backup useless for serving proofs the
+    /// moment the primary failed. A fallback that lags reports a lower tip, which can only
+    /// make the confirmation check *stricter*, never accept an unconfirmed block.
     pub async fn get_last_block(&self) -> Result<u64, Error> {
-        Ok(self.rpc_provider.get_block_number().await?)
+        let mut failures: Vec<(
+            String,
+            alloy::transports::RpcError<alloy::transports::TransportErrorKind>,
+        )> = Vec::new();
+        for (label, provider) in self.providers_with_labels() {
+            match provider.get_block_number().await {
+                Ok(number) => {
+                    for (failed, err) in &failures {
+                        tracing::warn!(
+                            provider = %failed,
+                            served_by = %label,
+                            error = %err,
+                            "eth_blockNumber: provider errored but another succeeded"
+                        );
+                    }
+                    return Ok(number);
+                }
+                Err(err) => failures.push((label, err)),
+            }
+        }
+        // Surface the primary's error so callers' transient/permanent classifiers see the
+        // same shape they always did.
+        let (_, primary_err) = failures.remove(0);
+        Err(primary_err.into())
     }
 
     pub async fn get_chain_id(&self) -> Result<u64, Error> {

--- a/common/eth/src/lib.rs
+++ b/common/eth/src/lib.rs
@@ -413,6 +413,11 @@ pub struct Client {
 const HTTP_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 /// TCP/TLS connect deadline on the HTTP transport.
 const HTTP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+/// Default bound on re-dialling the primary in [`Client::reconnect`].
+pub const DEFAULT_PRIMARY_DIAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+/// Bound on re-dialling one fallback during [`Client::reconnect_with_deadline`]. Fallbacks are
+/// best-effort there; a slow one must not hold a repaired primary hostage.
+pub const FALLBACK_DIAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 impl Client {
     async fn init_rpc(url: &str) -> Result<(Url, AlloyProvider, u64), Error> {
@@ -525,8 +530,29 @@ impl Client {
         })
     }
 
+    /// Re-dial the primary under [`DEFAULT_PRIMARY_DIAL_TIMEOUT`]; see
+    /// [`Self::reconnect_with_deadline`].
     pub async fn reconnect(&mut self) -> Result<(), Error> {
-        let (url, rpc_provider, chain_id) = Self::init_rpc(self.url.as_ref()).await?;
+        self.reconnect_with_deadline(DEFAULT_PRIMARY_DIAL_TIMEOUT)
+            .await
+    }
+
+    /// Re-dial the primary under `primary_deadline`, then each fallback under its own
+    /// [`FALLBACK_DIAL_TIMEOUT`]. The primary's outcome alone decides success: a fallback that
+    /// hangs or fails keeps its previous provider (if any) and is logged, it never discards a
+    /// primary connection that already came up.
+    pub async fn reconnect_with_deadline(
+        &mut self,
+        primary_deadline: std::time::Duration,
+    ) -> Result<(), Error> {
+        let (url, rpc_provider, chain_id) =
+            tokio::time::timeout(primary_deadline, Self::init_rpc(self.url.as_ref()))
+                .await
+                .map_err(|_| {
+                    Error::ClientError(anyhow::anyhow!(
+                        "primary RPC dial timed out after {primary_deadline:?}"
+                    ))
+                })??;
 
         // Reconnect each fallback against its own URL too, otherwise a
         // recovered primary would silently keep using a stale fallback
@@ -547,7 +573,15 @@ impl Client {
                 fp.url.as_str() == raw_url.as_str()
                     || fp.url.as_str().trim_end_matches('/') == raw_url.trim_end_matches('/')
             });
-            match Self::init_rpc(raw_url).await {
+            let dialed = tokio::time::timeout(FALLBACK_DIAL_TIMEOUT, Self::init_rpc(raw_url))
+                .await
+                .map_err(|_| {
+                    Error::ClientError(anyhow::anyhow!(
+                        "fallback dial timed out after {FALLBACK_DIAL_TIMEOUT:?}"
+                    ))
+                })
+                .and_then(|r| r);
+            match dialed {
                 Ok((fp_url, fp_provider, fp_chain_id)) => {
                     if fp_chain_id != chain_id {
                         tracing::error!(

--- a/proof-gen-api-server/tests/liveness_eth_rpc.rs
+++ b/proof-gen-api-server/tests/liveness_eth_rpc.rs
@@ -1,0 +1,168 @@
+//! Liveness regression tests for the source-chain RPC layer: tip failover, lock-free repair,
+//! shared repairs and tolerant fallback startup. Endpoints are wiremock servers on loopback.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use continuity::rpc::{EthRpcProvider, ReconnectingEthRpcProvider};
+use serde_json::{json, Value};
+use wiremock::{matchers::method, Mock, MockServer, ResponseTemplate};
+
+const ENCODING: usc_abi_encoding::common::EncodingVersion =
+    usc_abi_encoding::common::EncodingVersion::V1;
+
+/// JSON-RPC fixture: `eth_chainId` → 31337, `eth_blockNumber` → 1000 (or an error when
+/// `fail_tip`), everything under `delay`.
+async fn rpc_fixture(server: &MockServer, fail_tip: bool, delay: Duration) {
+    Mock::given(method("POST"))
+        .respond_with(move |request: &wiremock::Request| {
+            let req: Value = request.body_json().unwrap();
+            let body = if fail_tip && req["method"] == "eth_blockNumber" {
+                json!({"jsonrpc": "2.0", "id": req["id"],
+                       "error": {"code": -32000, "message": "upstream unavailable"}})
+            } else {
+                let result = if req["method"] == "eth_chainId" { "0x7a69" } else { "0x3e8" };
+                json!({"jsonrpc": "2.0", "id": req["id"], "result": result})
+            };
+            ResponseTemplate::new(200)
+                .set_body_json(body)
+                .set_delay(delay)
+        })
+        .mount(server)
+        .await;
+}
+
+async fn count_method(server: &MockServer, name: &str) -> usize {
+    server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.body_json::<Value>().unwrap()["method"] == name)
+        .count()
+}
+
+#[tokio::test]
+async fn tip_read_is_served_by_a_healthy_fallback_when_the_primary_fails() {
+    let primary = MockServer::start().await;
+    let fallback = MockServer::start().await;
+    rpc_fixture(&primary, true, Duration::ZERO).await;
+    rpc_fixture(&fallback, false, Duration::ZERO).await;
+    let client = eth::Client::new_with_fallbacks(&primary.uri(), &[fallback.uri()], None)
+        .await
+        .unwrap();
+    let provider = ReconnectingEthRpcProvider::new(client, ENCODING);
+
+    assert_eq!(provider.get_last_block().await.unwrap(), 1000);
+    assert!(
+        count_method(&fallback, "eth_blockNumber").await >= 1,
+        "the fallback must have answered the tip read"
+    );
+    assert_eq!(provider.generation(), 0, "no repair was needed");
+}
+
+#[tokio::test]
+async fn a_slow_repair_does_not_block_other_callers() {
+    let server = MockServer::start().await;
+    rpc_fixture(&server, false, Duration::ZERO).await;
+    let client = eth::Client::new(&server.uri(), None).await.unwrap();
+    let provider = Arc::new(ReconnectingEthRpcProvider::new(client, ENCODING));
+
+    // Fail the operation immediately; the repair then blocks on a slow chain-id read.
+    server.reset().await;
+    Mock::given(method("POST"))
+        .respond_with(|request: &wiremock::Request| {
+            let req: Value = request.body_json().unwrap();
+            if req["method"] == "eth_chainId" {
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_secs(10))
+                    .set_body_json(json!({"jsonrpc": "2.0", "id": req["id"], "result": "0x7a69"}))
+            } else {
+                ResponseTemplate::new(503)
+            }
+        })
+        .mount(&server)
+        .await;
+    let worker_provider = provider.clone();
+    let worker = tokio::spawn(async move { worker_provider.get_last_block().await });
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while count_method(&server, "eth_chainId").await == 0 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the worker must have started its repair dial");
+
+    // Upstream is healthy again for every NEW request while the worker's dial still hangs.
+    server.reset().await;
+    rpc_fixture(&server, false, Duration::ZERO).await;
+    let other = tokio::time::timeout(Duration::from_secs(2), provider.get_last_block())
+        .await
+        .expect("an unrelated caller must not wait behind another caller's dial");
+    assert_eq!(other.unwrap(), 1000);
+
+    worker.abort();
+    let _ = worker.await;
+}
+
+#[tokio::test]
+async fn concurrent_failures_share_one_repair_dial() {
+    let server = MockServer::start().await;
+    rpc_fixture(&server, false, Duration::ZERO).await;
+    let client = eth::Client::new(&server.uri(), None).await.unwrap();
+    let provider = Arc::new(ReconnectingEthRpcProvider::new(client, ENCODING));
+    assert_eq!(count_method(&server, "eth_chainId").await, 1, "initial connect");
+
+    // Tip reads always fail; each repair dial takes 400 ms.
+    server.reset().await;
+    Mock::given(method("POST"))
+        .respond_with(|request: &wiremock::Request| {
+            let req: Value = request.body_json().unwrap();
+            if req["method"] == "eth_chainId" {
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_millis(400))
+                    .set_body_json(json!({"jsonrpc": "2.0", "id": req["id"], "result": "0x7a69"}))
+            } else {
+                ResponseTemplate::new(503)
+            }
+        })
+        .mount(&server)
+        .await;
+
+    let a = provider.clone();
+    let b = provider.clone();
+    let (ra, rb) = tokio::join!(a.get_last_block(), b.get_last_block());
+    assert!(ra.is_err() && rb.is_err());
+
+    // Two callers × (3 attempts, 2 repairs each) would be 4 dials unshared. Shared: the
+    // caller that loses the race sees a newer generation and retries without dialling, so
+    // there is exactly one dial per retry round.
+    assert_eq!(count_method(&server, "eth_chainId").await, 2);
+    assert_eq!(provider.generation(), 2);
+}
+
+#[tokio::test]
+async fn an_unreachable_fallback_is_skipped_at_startup_but_a_wrong_chain_is_fatal() {
+    let primary = MockServer::start().await;
+    rpc_fixture(&primary, false, Duration::ZERO).await;
+
+    let dead = "http://127.0.0.1:1".to_string();
+    let client = eth::Client::new_with_fallbacks(&primary.uri(), &[dead], None)
+        .await
+        .expect("a dead backup must not stop a healthy primary");
+    assert_eq!(client.get_last_block().await.unwrap(), 1000);
+
+    let wrong_chain = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(|request: &wiremock::Request| {
+            let req: Value = request.body_json().unwrap();
+            ResponseTemplate::new(200)
+                .set_body_json(json!({"jsonrpc": "2.0", "id": req["id"], "result": "0x1"}))
+        })
+        .mount(&wrong_chain)
+        .await;
+    let err = eth::Client::new_with_fallbacks(&primary.uri(), &[wrong_chain.uri()], None)
+        .await
+        .expect_err("a backup on another chain is a misconfiguration");
+    assert!(format!("{err:#}").contains("chain_id"), "{err:#}");
+}

--- a/proof-gen-api-server/tests/liveness_eth_rpc.rs
+++ b/proof-gen-api-server/tests/liveness_eth_rpc.rs
@@ -21,7 +21,11 @@ async fn rpc_fixture(server: &MockServer, fail_tip: bool, delay: Duration) {
                 json!({"jsonrpc": "2.0", "id": req["id"],
                        "error": {"code": -32000, "message": "upstream unavailable"}})
             } else {
-                let result = if req["method"] == "eth_chainId" { "0x7a69" } else { "0x3e8" };
+                let result = if req["method"] == "eth_chainId" {
+                    "0x7a69"
+                } else {
+                    "0x3e8"
+                };
                 json!({"jsonrpc": "2.0", "id": req["id"], "result": result})
             };
             ResponseTemplate::new(200)
@@ -111,7 +115,11 @@ async fn concurrent_failures_share_one_repair_dial() {
     rpc_fixture(&server, false, Duration::ZERO).await;
     let client = eth::Client::new(&server.uri(), None).await.unwrap();
     let provider = Arc::new(ReconnectingEthRpcProvider::new(client, ENCODING));
-    assert_eq!(count_method(&server, "eth_chainId").await, 1, "initial connect");
+    assert_eq!(
+        count_method(&server, "eth_chainId").await,
+        1,
+        "initial connect"
+    );
 
     // Tip reads always fail; each repair dial takes 400 ms.
     server.reset().await;


### PR DESCRIPTION
Third PR of the prover liveness audit, findings **3** and **4**. Stacked on #1351 → #1350; retarget to `usc-dev` as those merge.

## Finding 3: one stalled repair blocked every caller

`ReconnectingEthRpcProvider::reconnect` held the client **write** lock across `eth::Client::reconnect`, i.e. across the primary dial, every fallback dial and their chain-id reads. Every operation takes the read lock first, so one stalled repair blocked proof requests, backfill and health probes for that chain, and concurrent failures queued N separate repairs. The HTTP transport was alloy's default reqwest client, which has no timeout at all.

- Repairs dial on a **clone** of the client, outside the lock and under a 30 s deadline, then swap it in atomically. Readers are never queued behind network I/O.
- **Connection generations**: a caller that failed against generation N only dials if the live generation is still N; otherwise someone already repaired and it simply retries. Repairs are serialised on a mutex, so N simultaneous failures cost one dial.
- Every attempt of every operation runs under a call deadline (300 s default; `with_timeouts()` to override).
- The HTTP transport now has connect (10 s) and request (60 s) timeouts.

## Finding 4: a healthy fallback could not keep proofs flowing

`eth::Client::get_last_block` asked only the primary, and every proof validates its heights against that tip, so a healthy fallback plus a warm Merkle cache still could not serve when the primary failed. Startup also failed outright when any fallback was unreachable.

- `get_last_block` walks `[primary, fallbacks…]` the way block fetches already do. A lagging fallback reports a lower tip, which can only make the confirmation check stricter, never accept an unconfirmed block.
- An unreachable fallback at startup is logged and skipped. The configured URL list is retained and `reconnect()` re-dials from it, so the backup is picked up on the next repair instead of being forgotten. A fallback on the **wrong chain** remains fatal (misconfiguration).

## Tests

`proof-gen-api-server/tests/liveness_eth_rpc.rs` (wiremock on loopback):
- tip read served by the fallback when the primary's `eth_blockNumber` errors
- an unrelated caller gets its answer in < 2 s while another caller's repair dial hangs 10 s
- two concurrent failing callers → exactly one dial per retry round (2 `eth_chainId`, not 4), generation ends at 2
- dead fallback skipped at startup; wrong-chain fallback rejected

`cargo test -p eth -p continuity -p proof-gen-api-server` green (existing 21 eth, 81 + 27 prover); clippy `-D warnings` on eth, continuity, proof-gen-api-server, archiver; fmt.

The archiver's own dial helper (#1348) already tolerated a dead fallback by retrying primary-only; with this change `new_with_fallbacks` itself does, so that retry path becomes a no-op safety net.