### PR TITLE
feat(proof-gen): /livez + /readyz, snapshot-pinned startup with replay, fatal seed failures

### DIFF
--- a/common/cc-client/src/lib.rs
+++ b/common/cc-client/src/lib.rs
@@ -412,10 +412,11 @@ impl Client {
         Ok(RpcClient::new(client))
     }
 
-    /// Height of the node's current finalized head, read point-to-point (not from a
-    /// subscription). Used by stream watchdogs to tell "the chain stopped finalizing" from
-    /// "my subscription stopped delivering".
-    pub async fn finalized_head_number(&self) -> Result<u64, Error> {
+    /// Hash and height of the node's current finalized head, read point-to-point (not from a
+    /// subscription). Consumers pin their startup snapshot to this block and replay events
+    /// from it; watchdogs use the height to tell "the chain stopped finalizing" from "my
+    /// subscription stopped delivering".
+    pub async fn finalized_head(&self) -> Result<(H256, u64), Error> {
         let legacy = self.legacy();
         let hash = legacy.chain_get_finalized_head().await?;
         let header = legacy.chain_get_header(Some(hash)).await?.ok_or_else(|| {
@@ -423,7 +424,25 @@ impl Client {
                 "finalized head {hash:?} has no header"
             )))
         })?;
-        Ok(u64::from(header.number))
+        Ok((hash, u64::from(header.number)))
+    }
+
+    /// Height of the node's current finalized head. See [`Self::finalized_head`].
+    pub async fn finalized_head_number(&self) -> Result<u64, Error> {
+        Ok(self.finalized_head().await?.1)
+    }
+
+    /// Storage view at `at`, or at the latest block when `None`.
+    async fn storage_at(
+        &self,
+        at: Option<H256>,
+    ) -> Result<subxt::storage::Storage<SubstrateConfig, OnlineClient<SubstrateConfig>>, Error>
+    {
+        let storage = self.api().storage();
+        Ok(match at {
+            Some(hash) => storage.at(hash),
+            None => storage.at_latest().await?,
+        })
     }
 
     /// Atomically replace the live subxt connection with a freshly-opened one.
@@ -1028,6 +1047,15 @@ impl Client {
         &self,
         chain_key: ChainKey,
     ) -> Result<Vec<SignedAttestation<Digest, AccountId32>>, Error> {
+        self.get_attestations_for_chain_at(chain_key, None).await
+    }
+
+    /// All retained attestations for `chain_key` as of block `at` (latest when `None`).
+    pub async fn get_attestations_for_chain_at(
+        &self,
+        chain_key: ChainKey,
+        at: Option<H256>,
+    ) -> Result<Vec<SignedAttestation<Digest, AccountId32>>, Error> {
         let mut attestations: Vec<SignedAttestation<Digest, AccountId32>> = Vec::new();
 
         // Address to the root of a storage entry that we'd like to iterate over
@@ -1035,13 +1063,7 @@ impl Client {
         // a ChainKey
         let address = cc3::storage().attestation().attestations_iter1(chain_key);
 
-        let mut iter = self
-            .api()
-            .storage()
-            .at_latest()
-            .await?
-            .iter(address)
-            .await?;
+        let mut iter = self.storage_at(at).await?.iter(address).await?;
 
         // Propagate iterator errors — a partial result silently truncated at the first error
         // would be indistinguishable from a complete one.
@@ -1067,6 +1089,15 @@ impl Client {
         &self,
         chain_key: ChainKey,
     ) -> Result<Vec<AttestationCheckpoint>, Error> {
+        self.get_checkpoints_for_chain_at(chain_key, None).await
+    }
+
+    /// All checkpoints for `chain_key` as of block `at` (latest when `None`).
+    pub async fn get_checkpoints_for_chain_at(
+        &self,
+        chain_key: ChainKey,
+        at: Option<H256>,
+    ) -> Result<Vec<AttestationCheckpoint>, Error> {
         let mut checkpoints = Vec::new();
 
         // Address to the root of a storage entry that we'd like to iterate over
@@ -1074,13 +1105,7 @@ impl Client {
         // a ChainKey.
         let address = cc3::storage().attestation().checkpoints_iter1(chain_key);
 
-        let mut iter = self
-            .api()
-            .storage()
-            .at_latest()
-            .await?
-            .iter(address)
-            .await?;
+        let mut iter = self.storage_at(at).await?.iter(address).await?;
 
         // Propagate iterator errors — a partial result silently truncated at the first error
         // would be indistinguishable from a complete one.
@@ -1295,17 +1320,21 @@ impl Client {
         &self,
         chain_key: ChainKey,
     ) -> Result<u64, Error> {
+        self.get_attestation_chain_genesis_block_number_at(chain_key, None)
+            .await
+    }
+
+    /// Attestation-chain genesis for `chain_key` as of block `at` (latest when `None`).
+    pub async fn get_attestation_chain_genesis_block_number_at(
+        &self,
+        chain_key: ChainKey,
+        at: Option<H256>,
+    ) -> Result<u64, Error> {
         let storage_query = cc3::storage()
             .attestation()
             .attestation_chain_genesis_block_number(chain_key);
 
-        let result = self
-            .api()
-            .storage()
-            .at_latest()
-            .await?
-            .fetch(&storage_query)
-            .await?;
+        let result = self.storage_at(at).await?.fetch(&storage_query).await?;
 
         Ok(result.unwrap_or_default())
     }

--- a/common/continuity/src/rpc.rs
+++ b/common/continuity/src/rpc.rs
@@ -276,6 +276,42 @@ pub trait CcRpcProvider: Send + Sync {
     /// Returns the number of attestations between checkpoints.
     /// For example, if checkpoints occur every 10 attestations, this returns `10`.
     async fn get_checkpoint_interval(&self, chain_key: u64) -> Result<Option<u64>>;
+
+    /// Hash and height of the Creditcoin node's current finalized head, so a caller can take
+    /// every startup read at one block and replay events from there. `None` when the provider
+    /// cannot pin reads to a block (mocks); callers then read latest state.
+    async fn finalized_head(&self) -> Result<Option<(H256, u64)>> {
+        Ok(None)
+    }
+
+    /// [`Self::get_attestations_for_chain`] as of block `at`. Defaults to the latest read for
+    /// providers that cannot pin.
+    async fn get_attestations_for_chain_at(
+        &self,
+        chain_key: u64,
+        _at: H256,
+    ) -> Result<Vec<SignedAttestation<H256, AccountId32>>> {
+        self.get_attestations_for_chain(chain_key).await
+    }
+
+    /// [`Self::get_checkpoints_for_chain`] as of block `at`.
+    async fn get_checkpoints_for_chain_at(
+        &self,
+        chain_key: u64,
+        _at: H256,
+    ) -> Result<Vec<AttestationCheckpoint>> {
+        self.get_checkpoints_for_chain(chain_key).await
+    }
+
+    /// [`Self::get_attestation_chain_genesis_block_number`] as of block `at`.
+    async fn get_attestation_chain_genesis_block_number_at(
+        &self,
+        chain_key: u64,
+        _at: H256,
+    ) -> Result<u64> {
+        self.get_attestation_chain_genesis_block_number(chain_key)
+            .await
+    }
 }
 
 /// Abstraction over source chain (Ethereum/EVM) RPC operations.
@@ -444,6 +480,48 @@ impl CcRpcProvider for CcClient {
             .await
             .map_err(|e| anyhow!("Failed to fetch checkpoint interval: {e}"))
     }
+
+    async fn finalized_head(&self) -> Result<Option<(H256, u64)>> {
+        let (hash, number) = CcClient::finalized_head(self)
+            .await
+            .map_err(|e| anyhow!("Failed to fetch finalized head: {e}"))?;
+        Ok(Some((H256::from_slice(hash.as_bytes()), number)))
+    }
+
+    async fn get_attestations_for_chain_at(
+        &self,
+        chain_key: u64,
+        at: H256,
+    ) -> Result<Vec<SignedAttestation<H256, AccountId32>>> {
+        CcClient::get_attestations_for_chain_at(self, chain_key, Some(cc_hash(at)))
+            .await
+            .context("Failed to fetch attestations at snapshot")
+    }
+
+    async fn get_checkpoints_for_chain_at(
+        &self,
+        chain_key: u64,
+        at: H256,
+    ) -> Result<Vec<AttestationCheckpoint>> {
+        CcClient::get_checkpoints_for_chain_at(self, chain_key, Some(cc_hash(at)))
+            .await
+            .context("Failed to fetch checkpoints at snapshot")
+    }
+
+    async fn get_attestation_chain_genesis_block_number_at(
+        &self,
+        chain_key: u64,
+        at: H256,
+    ) -> Result<u64> {
+        CcClient::get_attestation_chain_genesis_block_number_at(self, chain_key, Some(cc_hash(at)))
+            .await
+            .map_err(|e| anyhow!("Failed to fetch genesis block number at snapshot: {e}"))
+    }
+}
+
+/// `sp_core::H256` → the cc-client's (subxt) `H256`; same 32 bytes, different crates.
+fn cc_hash(hash: H256) -> cc_client::H256 {
+    cc_client::H256::from_slice(hash.as_bytes())
 }
 
 #[async_trait]

--- a/common/streams/cc3/src/lib.rs
+++ b/common/streams/cc3/src/lib.rs
@@ -62,7 +62,9 @@ pub struct Progress {
 }
 
 impl Progress {
-    fn note(&self, height: u64) {
+    /// Record that `height` has been processed. Driven by the stream; public so consumers
+    /// and tests can seed it.
+    pub fn note(&self, height: u64) {
         use std::sync::atomic::Ordering;
         self.height.store(height, Ordering::Release);
         self.advanced_at_unix_ms
@@ -158,6 +160,13 @@ pub struct Config {
     /// Optional shared progress record for health reporting.
     #[default(None)]
     progress: Option<std::sync::Arc<Progress>>,
+    /// Height the consumer's state is already consistent up to (typically the finalized
+    /// height its startup snapshot was read at). Blocks at or below it are not yielded; the
+    /// blocks between it and the first subscribed block are backfilled through the parent
+    /// walk, so nothing that landed between snapshot and subscription is skipped. `None`
+    /// starts from the first subscribed block.
+    #[default(None)]
+    resume_from: Option<u64>,
 }
 
 pub struct StreamCC3 {
@@ -174,6 +183,7 @@ impl StreamCC3 {
         let backfill_min_interval = config.backfill_min_interval;
         let progress_timeout = config.progress_timeout;
         let progress = config.progress;
+        let resume_from = config.resume_from;
 
         // Initial subscription + first-block seed, under the same unbounded
         // reconnect-and-re-subscribe policy as the steady-state repair loop below. A
@@ -182,7 +192,7 @@ impl StreamCC3 {
         // in place (and a crash-loop under a persistently flappy RPC). Cancellation point is
         // the sleep: callers race construction against the root token / the bounded shutdown
         // drain, so an endless outage cannot pin shutdown.
-        let (finalized, mut latest, first_events) = {
+        let (finalized, first) = {
             let mut backoff = RESUBSCRIBE_BACKOFF_START;
             loop {
                 let attempt = async {
@@ -202,9 +212,7 @@ impl StreamCC3 {
                         .map_err(|_| Error::NoProgress(progress_timeout))?
                         .map_err(Error::Subxt)?
                         .ok_or(Error::EndOfStream)?;
-                    let latest = first.number() as u64;
-                    let events = first.events().await.map_err(Error::Subxt)?;
-                    Ok::<_, Error>((finalized, latest, events))
+                    Ok::<_, Error>((finalized, first))
                 };
                 match attempt.await {
                     Ok(seed) => break seed,
@@ -221,14 +229,24 @@ impl StreamCC3 {
             }
         };
 
-        if let Some(p) = &progress {
-            p.note(latest);
+        // Everything at or below `latest` is already known to the consumer. With `resume_from`
+        // that is the consumer's snapshot height and the gap up to the first subscribed block
+        // is backfilled by the parent walk below like any reconnect gap; without it the first
+        // subscribed block is the first thing yielded (it goes through the same head path,
+        // so its events fetch gets the same retry policy as every later block).
+        let first_height = first.number() as u64;
+        let mut latest = resume_from.unwrap_or_else(|| first_height.saturating_sub(1));
+        if let Some(from) = resume_from {
+            tracing::info!(
+                from,
+                first = first_height,
+                "🛟 cc3 stream resuming from consumer snapshot"
+            );
         }
 
         let stream = async_stream::stream! {
-            yield StreamEvents::new(latest as attestor_primitives::Height, first_events, &chain_keys);
-
             let mut finalized = finalized;
+            let mut pending = Some(first);
             // Reusable scratch buffer for the parent-walk backfill. Capacity tuned for
             // typical disconnects of <16 blocks; grows if needed.
             let mut backfill: Vec<(u64, subxt::events::Events<subxt::SubstrateConfig>)> =
@@ -238,7 +256,9 @@ impl StreamCC3 {
                 // Progress watchdog. `try_next` alone can pend forever on a socket that is
                 // open but no longer delivering (subscription dropped server-side, a proxy
                 // that stopped forwarding, a peer that answers pings and nothing else).
-                let next = match tokio::time::timeout(progress_timeout, finalized.try_next()).await {
+                let next = if let Some(first) = pending.take() {
+                    Ok(Some(first))
+                } else { match tokio::time::timeout(progress_timeout, finalized.try_next()).await {
                     Ok(next) => next,
                     Err(_elapsed) => match cc3.finalized_head_number().await {
                         Ok(head) if head > latest => {
@@ -268,7 +288,7 @@ impl StreamCC3 {
                             Err(subxt::Error::Other(format!("progress probe failed: {err}")))
                         }
                     },
-                };
+                } };
                 match next {
                     Ok(Some(mut block)) => {
                         let n = block.number() as u64;

--- a/common/streams/cc3/src/lib.rs
+++ b/common/streams/cc3/src/lib.rs
@@ -242,6 +242,13 @@ impl StreamCC3 {
                 first = first_height,
                 "🛟 cc3 stream resuming from consumer snapshot"
             );
+            // The consumer is consistent up to `from` and the subscription is live: that is
+            // progress in its own right. Usually the first subscribed block *is* the snapshot
+            // height, gets skipped below, and nothing else arrives for a while; without this
+            // note the consumer would report "not caught up" until the next finalized block.
+            if let Some(p) = &progress {
+                p.note(from);
+            }
         }
 
         let stream = async_stream::stream! {

--- a/common/streams/cc3/tests/watchdog.rs
+++ b/common/streams/cc3/tests/watchdog.rs
@@ -119,3 +119,40 @@ async fn seed_does_not_hang_on_a_subscription_that_never_delivers() {
         .unwrap();
     assert_eq!(next_height(&mut stream).await, 1);
 }
+
+/// `resume_from` marks everything at or below it as already known: the node's catch-up
+/// pushes 1..=3 on subscribe, only 2 and 3 are yielded.
+#[tokio::test]
+async fn resume_from_skips_known_blocks_and_yields_the_rest() {
+    let fixture = WsFixture::start().await;
+    fixture.finalize(3);
+    let cc3 = Arc::new(
+        cc_client::Client::new_read_only(&fixture.url)
+            .await
+            .unwrap(),
+    );
+    let progress = Arc::new(stream_cc3::Progress::default());
+    let config = stream_cc3::ConfigBuilder::new()
+        .with_cc3(cc3)
+        .with_chain_keys(vec![1])
+        .with_progress(Some(progress.clone()))
+        .with_resume_from(Some(1))
+        .build();
+    let mut stream = stream_cc3::StreamCC3::new(config).await.unwrap();
+    assert_eq!(next_height(&mut stream).await, 2);
+    assert_eq!(next_height(&mut stream).await, 3);
+    assert_eq!(progress.height(), Some(3));
+    let idle = tokio::time::timeout(Duration::from_millis(300), stream.next()).await;
+    assert!(idle.is_err(), "nothing else to yield");
+}
+
+/// Without `resume_from` the first subscribed block is yielded as before.
+#[tokio::test]
+async fn without_resume_from_the_first_block_is_yielded() {
+    let fixture = WsFixture::start().await;
+    fixture.finalize(2);
+    let (mut stream, progress) = stream_with(&fixture, Duration::from_secs(5)).await;
+    assert_eq!(next_height(&mut stream).await, 1);
+    assert_eq!(next_height(&mut stream).await, 2);
+    assert_eq!(progress.height(), Some(2));
+}

--- a/common/streams/cc3/tests/watchdog.rs
+++ b/common/streams/cc3/tests/watchdog.rs
@@ -139,6 +139,11 @@ async fn resume_from_skips_known_blocks_and_yields_the_rest() {
         .with_resume_from(Some(1))
         .build();
     let mut stream = stream_cc3::StreamCC3::new(config).await.unwrap();
+    assert_eq!(
+        progress.height(),
+        Some(1),
+        "the snapshot height itself counts as progress once subscribed"
+    );
     assert_eq!(next_height(&mut stream).await, 2);
     assert_eq!(next_height(&mut stream).await, 3);
     assert_eq!(progress.height(), Some(3));

--- a/proof-gen-api-server/src/events/mod.rs
+++ b/proof-gen-api-server/src/events/mod.rs
@@ -34,11 +34,16 @@ pub fn get_last_attestation(chain_key: u64) -> Option<LastAttestation> {
 
 /// Start a single CC3 event subscription for all configured chain keys (one finalized-block stream).
 /// Will automatically reconnect to the CC3 node if the connection is lost.
+///
+/// `resume_from` is the Creditcoin finalized height the service's caches were snapshotted at;
+/// events after it are replayed before the live flow so nothing between snapshot and
+/// subscription is skipped.
 pub async fn start_cc3_event_subscription(
     cc3_client: Arc<CcClient>,
     checkpoint_intervals: CheckpointIntervalMap,
     last_checkpoint_blocks: LastCheckpointBlockMap,
     service: Arc<ContinuityService>,
+    resume_from: Option<u64>,
 ) -> Result<()> {
     let chain_keys = service.configured_chain_keys();
 
@@ -54,6 +59,7 @@ pub async fn start_cc3_event_subscription(
         // per-block signal of its own, and attestation writes are too sparse on a quiet
         // chain to tell "subscription dead" from "nothing attested lately".
         .with_progress(Some(service.cc3_progress()))
+        .with_resume_from(resume_from)
         .build();
     let mut events = stream::cc3::StreamCC3::new(config).await?.flatten();
 

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -397,6 +397,7 @@ impl Server {
             checkpoint_intervals_clone,
             last_checkpoint_blocks_clone,
             service.clone(),
+            service.cc3_snapshot_height(),
         ));
 
         supervise(

--- a/proof-gen-api-server/src/networking/mod.rs
+++ b/proof-gen-api-server/src/networking/mod.rs
@@ -42,6 +42,8 @@ pub fn build_app(
     let router = Router::new()
         .route("/", get(|| async { Redirect::permanent("/api/swagger") }))
         .route("/api/v1/health", get(health::health_check))
+        .route("/livez", get(health::livez))
+        .route("/readyz", get(health::readyz))
         .route(
             "/api/v1/attested-height/{chain_key}",
             get(attested_height::attested_height),

--- a/proof-gen-api-server/src/networking/openapi.rs
+++ b/proof-gen-api-server/src/networking/openapi.rs
@@ -21,6 +21,8 @@ use super::routes::{continuity, health};
     ),
     paths(
         health::health_check,
+        health::livez,
+        health::readyz,
         continuity::get_proof_with_tx,
         continuity::get_proof_by_tx_hash,
         continuity::get_proof_batch,
@@ -35,6 +37,7 @@ use super::routes::{continuity, health};
         ErrorResponse,
         ProofQuery,
         health::HealthCheckResponse,
+        health::ReadinessResponse,
         attested_height::AttestedHeightResponse,
     ))
 )]

--- a/proof-gen-api-server/src/networking/routes/health.rs
+++ b/proof-gen-api-server/src/networking/routes/health.rs
@@ -168,7 +168,13 @@ pub async fn health_check(
 
     let event_stream_dead = service.event_stream_dead();
     let progress = service.cc3_progress();
-    let readiness = service.readiness();
+    let mut readiness = service.readiness();
+    if !eth_connected {
+        readiness.ready = false;
+        readiness
+            .reasons
+            .push("source-chain RPC probe failed on at least one chain".to_owned());
+    }
     let status = if freshness.fresh && eth_connected && event_stream_dead.is_none() {
         "healthy".to_string()
     } else {
@@ -185,7 +191,7 @@ pub async fn health_check(
         cc3_finalized_age_seconds: progress.age_seconds(),
         cc3_silent_recoveries: progress.silent_recoveries(),
         cc3_event_stream_dead: event_stream_dead,
-        ready: readiness.ready && eth_connected,
+        ready: readiness.ready,
         not_ready_reasons: readiness.reasons,
         uptime_seconds: service.uptime_seconds(),
     })

--- a/proof-gen-api-server/src/networking/routes/health.rs
+++ b/proof-gen-api-server/src/networking/routes/health.rs
@@ -1,3 +1,4 @@
+use axum::http::StatusCode;
 use axum::{Extension, Json};
 use serde::Serialize;
 use std::sync::Arc;
@@ -38,7 +39,78 @@ pub struct HealthCheckResponse {
     /// about to exit; it must not receive new traffic.
     #[serde(skip_serializing_if = "Option::is_none")]
     cc3_event_stream_dead: Option<String>,
+    /// Same verdict `/readyz` encodes in its status code. This endpoint always answers 200
+    /// for compatibility; point traffic-withdrawal checks at `/readyz`.
+    ready: bool,
+    not_ready_reasons: Vec<String>,
     uptime_seconds: u64,
+}
+
+/// `/readyz` body.
+#[derive(Serialize, ToSchema)]
+pub struct ReadinessResponse {
+    ready: bool,
+    /// Why the replica is not ready; empty when it is.
+    reasons: Vec<String>,
+    eth_rpc_connected: bool,
+    cc3_finalized_height: Option<u64>,
+    cc3_finalized_age_seconds: Option<u64>,
+    /// Creditcoin finalized height the startup snapshot was pinned to.
+    cc3_snapshot_height: Option<u64>,
+}
+
+/// Liveness: the process answers HTTP. Nothing else is judged here on purpose. A dependency
+/// outage must withdraw readiness, not restart every replica at once; an internal wedge that
+/// stops the event task exits the process by itself (see `Server::run`).
+#[utoipa::path(
+    get,
+    path = "/livez",
+    responses((status = 200, description = "Process is alive"))
+)]
+pub async fn livez() -> Json<serde_json::Value> {
+    Json(serde_json::json!({"status": "alive"}))
+}
+
+/// Readiness: 200 only while this replica can serve current proofs, 503 otherwise with the
+/// reasons in the body. Point Kubernetes readiness probes and load-balancer health checks
+/// here. Ready means the cc3 event task is alive and caught up to the startup snapshot, a
+/// Creditcoin finalized block was processed recently, and the source-chain RPC answers.
+#[utoipa::path(
+    get,
+    path = "/readyz",
+    responses(
+        (status = 200, description = "Ready to serve proofs", body = ReadinessResponse),
+        (status = 503, description = "Not ready; see reasons", body = ReadinessResponse),
+    )
+)]
+pub async fn readyz(
+    Extension(service): Extension<Arc<ContinuityService>>,
+) -> (StatusCode, Json<ReadinessResponse>) {
+    let eth_connected = probe("eth_rpc", service.check_eth_connectivity()).await;
+    let mut readiness = service.readiness();
+    if !eth_connected {
+        readiness.ready = false;
+        readiness
+            .reasons
+            .push("source-chain RPC probe failed on at least one chain".to_owned());
+    }
+    let progress = service.cc3_progress();
+    let code = if readiness.ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (
+        code,
+        Json(ReadinessResponse {
+            ready: readiness.ready,
+            reasons: readiness.reasons,
+            eth_rpc_connected: eth_connected,
+            cc3_finalized_height: progress.height(),
+            cc3_finalized_age_seconds: progress.age_seconds(),
+            cc3_snapshot_height: service.cc3_snapshot_height(),
+        }),
+    )
 }
 
 /// Run one upstream probe under the shared timeout, logging why it failed if it does.
@@ -96,6 +168,7 @@ pub async fn health_check(
 
     let event_stream_dead = service.event_stream_dead();
     let progress = service.cc3_progress();
+    let readiness = service.readiness();
     let status = if freshness.fresh && eth_connected && event_stream_dead.is_none() {
         "healthy".to_string()
     } else {
@@ -112,6 +185,8 @@ pub async fn health_check(
         cc3_finalized_age_seconds: progress.age_seconds(),
         cc3_silent_recoveries: progress.silent_recoveries(),
         cc3_event_stream_dead: event_stream_dead,
+        ready: readiness.ready && eth_connected,
+        not_ready_reasons: readiness.reasons,
         uptime_seconds: service.uptime_seconds(),
     })
 }

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -193,8 +193,12 @@ pub struct ContinuityService {
     /// the in-flight drain window and diagnostics.
     event_stream_dead: std::sync::Mutex<Option<String>>,
     /// Finalized-block progress of the cc3 event stream (height + when it last advanced),
-    /// written by the stream's watchdog, read by `/health`.
+    /// written by the stream's watchdog, read by `/health` and `/readyz`.
     cc3_progress: Arc<stream::cc3::Progress>,
+    /// Creditcoin finalized height every startup read was pinned to, when the provider could
+    /// pin. The event stream resumes from here; the replica is not ready before the stream
+    /// has caught up to it.
+    cc3_snapshot_height: Option<u64>,
     /// Prometheus metrics for instrumentation (uses NoopMetrics when disabled).
     metrics: Metrics,
     /// Maximum amount of concurrent futures spawned when generating proofs for batch requests or when extracting transaction indexes from transaction hashes.
@@ -208,6 +212,55 @@ pub struct ContinuityService {
 /// How long the caches may go without an event-driven write before the cc3 subscription is
 /// considered dead for health purposes. See [`ContinuityService::cc3_cache_freshness`].
 pub const CC3_CACHE_STALE_AFTER: Duration = Duration::from_secs(10 * 60);
+
+/// How long the event stream may go without processing a Creditcoin finalized block before
+/// the replica withdraws readiness. Finality lands every 5-15 s; the stream's own watchdog
+/// replaces a silent subscription after 90 s, so 180 s only trips when recovery itself is
+/// failing.
+pub const CC3_FINALIZED_STALE_AFTER: Duration = Duration::from_secs(180);
+
+/// Result of [`ContinuityService::readiness`].
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Readiness {
+    pub ready: bool,
+    /// Human-readable reasons when `ready` is false; empty otherwise.
+    pub reasons: Vec<String>,
+}
+
+/// Bounded retry for the startup snapshot reads. A transient cc3 blip must not turn into an
+/// empty cache; a persistent failure is fatal so the orchestrator restarts a replica that
+/// cannot seed instead of it serving wrong `BlockNotReady`s until someone notices.
+async fn retry_startup<T, F, Fut>(what: &str, mut op: F) -> anyhow::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<T>>,
+{
+    const ATTEMPTS: usize = 5;
+    let mut delay = Duration::from_millis(250);
+    let mut last_err = None;
+    for attempt in 1..=ATTEMPTS {
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                tracing::warn!(
+                    what,
+                    attempt,
+                    max = ATTEMPTS,
+                    error = %err,
+                    "⚠️ 🔗 startup read failed"
+                );
+                last_err = Some(err);
+                if attempt < ATTEMPTS {
+                    tokio::time::sleep(delay).await;
+                    delay = (delay * 2).min(Duration::from_secs(2));
+                }
+            }
+        }
+    }
+    Err(last_err
+        .unwrap_or_else(|| anyhow::anyhow!("no error captured"))
+        .context(format!("{what}: failed after {ATTEMPTS} attempts")))
+}
 
 /// Result of [`ContinuityService::cc3_cache_freshness`].
 #[derive(Debug, Clone)]
@@ -268,26 +321,71 @@ impl ContinuityService {
             anyhow::bail!("ContinuityService requires at least one ContinuityBuilder");
         }
 
+        // One consistent snapshot for every chain: read the finalized head once and take every
+        // startup read at that block. The event stream then replays from that height
+        // (`resume_from`), so an event landing between snapshot and subscription is never
+        // skipped and old boundaries never go missing for the life of the process. A provider
+        // that cannot pin reads (mocks) reports no head; reads fall back to latest state.
+        let snapshot = {
+            let provider = builders[0].cc_provider.clone();
+            retry_startup("cc3 finalized head", || {
+                let provider = provider.clone();
+                async move { provider.finalized_head().await }
+            })
+            .await?
+        };
+        let snapshot_hash = snapshot.map(|(hash, _)| hash);
+        let snapshot_height = snapshot.map(|(_, height)| height);
+        match snapshot {
+            Some((hash, height)) => tracing::info!(
+                ?hash,
+                height,
+                "🚀 📸 startup snapshot pinned to cc3 finalized head"
+            ),
+            None => tracing::debug!(
+                "🚀 📸 cc3 provider cannot pin a block; startup reads use latest state"
+            ),
+        }
+
         let mut chains = HashMap::new();
         for builder in builders {
             let chain_key = builder.config.chain_key;
             if chains.contains_key(&chain_key) {
                 anyhow::bail!("duplicate ContinuityBuilder for chain_key {chain_key}");
             }
+            let provider = builder.cc_provider.clone();
 
-            // Fetch genesis block at startup - fail fast if RPC is unavailable
+            // Every startup read is retried a bounded number of times and is fatal if it
+            // still fails. The previous behaviour - warn and start with an empty cache - made
+            // a transient cc3 blip into a replica that answered `BlockNotReady` for already
+            // attested data until someone restarted it.
             tracing::debug!(
                 chain_key,
                 "🚀 🔗 [startup] ContinuityService: fetching attestation genesis block from CC3"
             );
-            let attestation_genesis_block = builder
-                .get_attestation_genesis_block()
-                .await
-                .with_context(|| {
-                    format!(
-                        "Failed to fetch attestation genesis block during ContinuityService init (chain_key={chain_key}); CC3 RPC used by this builder may be down or misconfigured"
-                    )
-                })?;
+            let attestation_genesis_block = retry_startup("attestation genesis block", || {
+                let provider = provider.clone();
+                async move {
+                    match snapshot_hash {
+                        Some(at) => {
+                            provider
+                                .get_attestation_chain_genesis_block_number_at(chain_key, at)
+                                .await
+                        }
+                        None => {
+                            provider
+                                .get_attestation_chain_genesis_block_number(chain_key)
+                                .await
+                        }
+                    }
+                }
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to fetch attestation genesis block during ContinuityService init (chain_key={chain_key}); CC3 RPC used by this builder may be down or misconfigured"
+                )
+            })?;
 
             tracing::debug!(
                 chain_key,
@@ -300,17 +398,19 @@ impl ContinuityService {
                 chain_key,
                 "🚀 ⏳ 📝 Populating checkpoint cache from CC3 (this may take a while)..."
             );
-            let checkpoints = builder
-                .cc_provider
-                .get_checkpoints_for_chain(chain_key)
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::warn!(
-                        chain_key,
-                        "⚠️ 🔗 Failed to fetch checkpoints on startup: {e}, starting with empty cache"
-                    );
-                    Vec::new()
-                });
+            let checkpoints = retry_startup("checkpoints", || {
+                let provider = provider.clone();
+                async move {
+                    match snapshot_hash {
+                        Some(at) => provider.get_checkpoints_for_chain_at(chain_key, at).await,
+                        None => provider.get_checkpoints_for_chain(chain_key).await,
+                    }
+                }
+            })
+            .await
+            .with_context(|| {
+                format!("Failed to fetch checkpoints on startup (chain_key={chain_key})")
+            })?;
             let checkpoint_map: BTreeMap<u64, H256> = checkpoints
                 .into_iter()
                 .map(|cp| (cp.block_number, cp.digest))
@@ -329,17 +429,19 @@ impl ContinuityService {
                 chain_key,
                 "🚀 ⏳ 📜 Populating attestation cache from CC3 (this may take a while)..."
             );
-            let attestations = builder
-                .cc_provider
-                .get_attestations_for_chain(chain_key)
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::warn!(
-                        chain_key,
-                        "⚠️ 🔗 Failed to fetch attestations on startup: {e}, starting with empty cache"
-                    );
-                    Vec::new()
-                });
+            let attestations = retry_startup("attestations", || {
+                let provider = provider.clone();
+                async move {
+                    match snapshot_hash {
+                        Some(at) => provider.get_attestations_for_chain_at(chain_key, at).await,
+                        None => provider.get_attestations_for_chain(chain_key).await,
+                    }
+                }
+            })
+            .await
+            .with_context(|| {
+                format!("Failed to fetch attestations on startup (chain_key={chain_key})")
+            })?;
             let attestation_map: BTreeMap<u64, H256> = attestations
                 .into_iter()
                 .map(|att| (att.attestation.header_number, att.attestation.digest()))
@@ -377,6 +479,7 @@ impl ContinuityService {
             start_time: Instant::now(),
             event_stream_dead: std::sync::Mutex::new(None),
             cc3_progress: Arc::new(stream::cc3::Progress::default()),
+            cc3_snapshot_height: snapshot_height,
             metrics,
             max_batch_size,
             max_batch_span,
@@ -843,6 +946,52 @@ impl ContinuityService {
     /// Shared finalized-block progress record for the cc3 event stream.
     pub fn cc3_progress(&self) -> Arc<stream::cc3::Progress> {
         self.cc3_progress.clone()
+    }
+
+    /// Creditcoin finalized height the startup snapshot was read at, if the provider could pin
+    /// one. Hand it to the event stream as `resume_from`.
+    pub fn cc3_snapshot_height(&self) -> Option<u64> {
+        self.cc3_snapshot_height
+    }
+
+    /// Whether this replica should receive traffic, and why not if it should not.
+    ///
+    /// Ready means: the event task is alive, it has caught up to (at least) the startup
+    /// snapshot, and it processed a finalized block within [`CC3_FINALIZED_STALE_AFTER`].
+    /// Freshness is judged on finalized-block progress, not on attestation writes: a quiet
+    /// chain attests rarely but still finalizes, and a dead subscription does neither. The
+    /// source-chain probe is the caller's to add (it is async and per chain).
+    pub fn readiness(&self) -> Readiness {
+        let mut reasons = Vec::new();
+        if let Some(reason) = self.event_stream_dead() {
+            reasons.push(format!("cc3 event stream ended: {reason}"));
+        }
+        match self.cc3_progress.height() {
+            None => {
+                reasons.push("cc3 event stream has not processed a finalized block yet".to_owned())
+            }
+            Some(height) => {
+                if let Some(snapshot) = self.cc3_snapshot_height {
+                    if height < snapshot {
+                        reasons.push(format!(
+                            "catching up: processed finalized block {height}, startup snapshot was taken at {snapshot}"
+                        ));
+                    }
+                }
+                if let Some(age) = self.cc3_progress.age_seconds() {
+                    if age > CC3_FINALIZED_STALE_AFTER.as_secs() {
+                        reasons.push(format!(
+                            "no finalized block processed for {age} s (stale after {} s)",
+                            CC3_FINALIZED_STALE_AFTER.as_secs()
+                        ));
+                    }
+                }
+            }
+        }
+        Readiness {
+            ready: reasons.is_empty(),
+            reasons,
+        }
     }
 
     /// Why the cc3 event task ended, if it has. `None` while it is (believed) running.

--- a/proof-gen-api-server/tests/liveness_event_task.rs
+++ b/proof-gen-api-server/tests/liveness_event_task.rs
@@ -102,6 +102,7 @@ async fn pruned_history_makes_the_event_task_return_an_error() {
             Arc::default(),
             Arc::default(),
             service.clone(),
+            None,
         ),
     )
     .await

--- a/proof-gen-api-server/tests/liveness_readiness.rs
+++ b/proof-gen-api-server/tests/liveness_readiness.rs
@@ -197,6 +197,10 @@ async fn startup_reads_are_pinned_to_one_finalized_block_and_readiness_waits_for
     let (status, body) = get(&app, "/api/v1/health").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["ready"], false);
+    assert!(
+        !body["not_ready_reasons"].as_array().unwrap().is_empty(),
+        "ready=false always comes with at least one reason: {body}"
+    );
     assert_eq!(
         body["status"], "healthy",
         "legacy status is unchanged by readiness"

--- a/proof-gen-api-server/tests/liveness_readiness.rs
+++ b/proof-gen-api-server/tests/liveness_readiness.rs
@@ -1,0 +1,257 @@
+//! Readiness and consistent-startup regression tests. Deterministic in-process providers only.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use attestor_primitives::{AttestationCheckpoint, SignedAttestation};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use cc_client::AccountId32;
+use continuity::mocks::MockCcRpcProvider;
+use continuity::rpc::CcRpcProvider;
+use proof_gen_api_server::prom::ProofGenMetrics;
+use proof_gen_api_server::{build_app, ContinuityService};
+use serde_json::Value;
+use sp_core::H256;
+use tower::ServiceExt;
+
+const CHAIN: u64 = 2;
+const SNAPSHOT_HEIGHT: u64 = 42;
+
+fn snapshot_hash() -> H256 {
+    H256::from_low_u64_be(0xC0FFEE)
+}
+
+/// Mock cc3 provider that can pin reads to a block and records which block each read used.
+struct PinningCc {
+    inner: MockCcRpcProvider,
+    pinned_reads: Mutex<Vec<H256>>,
+    fail_checkpoints: bool,
+}
+
+impl PinningCc {
+    fn new(fail_checkpoints: bool) -> Self {
+        Self {
+            inner: MockCcRpcProvider::new(CHAIN),
+            pinned_reads: Mutex::new(Vec::new()),
+            fail_checkpoints,
+        }
+    }
+}
+
+#[async_trait]
+impl CcRpcProvider for PinningCc {
+    async fn get_attestations_for_chain(
+        &self,
+        chain_key: u64,
+    ) -> anyhow::Result<Vec<SignedAttestation<H256, AccountId32>>> {
+        self.inner.get_attestations_for_chain(chain_key).await
+    }
+    async fn get_last_checkpoint(
+        &self,
+        chain_key: u64,
+    ) -> anyhow::Result<Option<AttestationCheckpoint>> {
+        self.inner.get_last_checkpoint(chain_key).await
+    }
+    async fn get_checkpoints_for_chain(
+        &self,
+        chain_key: u64,
+    ) -> anyhow::Result<Vec<AttestationCheckpoint>> {
+        if self.fail_checkpoints {
+            anyhow::bail!("cc3 unavailable");
+        }
+        self.inner.get_checkpoints_for_chain(chain_key).await
+    }
+    async fn get_checkpoint_by_height(
+        &self,
+        chain_key: u64,
+        block_number: u64,
+    ) -> anyhow::Result<Option<AttestationCheckpoint>> {
+        self.inner
+            .get_checkpoint_by_height(chain_key, block_number)
+            .await
+    }
+    async fn get_attestation_chain_genesis_block_number(
+        &self,
+        chain_key: u64,
+    ) -> anyhow::Result<u64> {
+        self.inner
+            .get_attestation_chain_genesis_block_number(chain_key)
+            .await
+    }
+    async fn fetch_last_digest(&self, chain_key: u64) -> anyhow::Result<Option<H256>> {
+        self.inner.fetch_last_digest(chain_key).await
+    }
+    async fn get_attestation_by_digest(
+        &self,
+        chain_key: u64,
+        digest: H256,
+    ) -> anyhow::Result<Option<SignedAttestation<H256, AccountId32>>> {
+        self.inner
+            .get_attestation_by_digest(chain_key, digest)
+            .await
+    }
+    async fn get_attestation_interval(&self, chain_key: u64) -> anyhow::Result<Option<u64>> {
+        self.inner.get_attestation_interval(chain_key).await
+    }
+    async fn get_checkpoint_interval(&self, chain_key: u64) -> anyhow::Result<Option<u64>> {
+        self.inner.get_checkpoint_interval(chain_key).await
+    }
+
+    async fn finalized_head(&self) -> anyhow::Result<Option<(H256, u64)>> {
+        Ok(Some((snapshot_hash(), SNAPSHOT_HEIGHT)))
+    }
+    async fn get_attestations_for_chain_at(
+        &self,
+        chain_key: u64,
+        at: H256,
+    ) -> anyhow::Result<Vec<SignedAttestation<H256, AccountId32>>> {
+        self.pinned_reads.lock().unwrap().push(at);
+        self.get_attestations_for_chain(chain_key).await
+    }
+    async fn get_checkpoints_for_chain_at(
+        &self,
+        chain_key: u64,
+        at: H256,
+    ) -> anyhow::Result<Vec<AttestationCheckpoint>> {
+        self.pinned_reads.lock().unwrap().push(at);
+        self.get_checkpoints_for_chain(chain_key).await
+    }
+    async fn get_attestation_chain_genesis_block_number_at(
+        &self,
+        chain_key: u64,
+        at: H256,
+    ) -> anyhow::Result<u64> {
+        self.pinned_reads.lock().unwrap().push(at);
+        self.get_attestation_chain_genesis_block_number(chain_key)
+            .await
+    }
+}
+
+async fn service_with(cc: Arc<dyn CcRpcProvider>) -> anyhow::Result<Arc<ContinuityService>> {
+    let (_, eth) = continuity::mocks::make_mock_providers(CHAIN);
+    let cfg = continuity::ContinuityConfig::builder()
+        .cc3_rpc_url("ws://mock")
+        .eth_rpc_url("http://mock")
+        .chain_key(CHAIN)
+        .attestation_interval(10)
+        .checkpoint_interval(10)
+        .build();
+    let builder = Arc::new(continuity::ContinuityBuilder::new_with_providers(
+        cfg, cc, eth,
+    ));
+    let metrics = Arc::new(ProofGenMetrics::new(&[CHAIN]));
+    Ok(Arc::new(
+        ContinuityService::new(vec![builder], metrics, 10, 1000).await?,
+    ))
+}
+
+async fn get(app: &axum::Router, uri: &str) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), 1 << 16)
+        .await
+        .unwrap();
+    let json = if body.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&body).unwrap()
+    };
+    (status, json)
+}
+
+#[tokio::test]
+async fn startup_reads_are_pinned_to_one_finalized_block_and_readiness_waits_for_catch_up() {
+    let cc = Arc::new(PinningCc::new(false));
+    let service = service_with(cc.clone()).await.unwrap();
+
+    let reads = cc.pinned_reads.lock().unwrap().clone();
+    assert_eq!(reads.len(), 3, "genesis, checkpoints, attestations");
+    assert!(reads.iter().all(|h| *h == snapshot_hash()), "{reads:?}");
+    assert_eq!(service.cc3_snapshot_height(), Some(SNAPSHOT_HEIGHT));
+
+    let app = build_app(
+        service.clone(),
+        [CHAIN].into_iter().collect(),
+        Arc::new(ProofGenMetrics::new(&[CHAIN])),
+    );
+
+    let (status, body) = get(&app, "/livez").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "alive");
+
+    // Nothing processed yet: not ready, and /health keeps answering 200 with the verdict.
+    let (status, body) = get(&app, "/readyz").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+    assert_eq!(body["ready"], false);
+    assert!(body["reasons"][0]
+        .as_str()
+        .unwrap()
+        .contains("not processed a finalized block"));
+    assert_eq!(body["cc3_snapshot_height"], SNAPSHOT_HEIGHT);
+    let (status, body) = get(&app, "/api/v1/health").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ready"], false);
+    assert_eq!(
+        body["status"], "healthy",
+        "legacy status is unchanged by readiness"
+    );
+
+    // Behind the snapshot: still catching up.
+    service.cc3_progress().note(SNAPSHOT_HEIGHT - 1);
+    let (status, body) = get(&app, "/readyz").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(body["reasons"][0].as_str().unwrap().contains("catching up"));
+
+    // Caught up: ready.
+    service.cc3_progress().note(SNAPSHOT_HEIGHT);
+    let (status, body) = get(&app, "/readyz").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["ready"], true);
+    assert_eq!(body["cc3_finalized_height"], SNAPSHOT_HEIGHT);
+
+    // A dead event stream withdraws readiness again.
+    service.mark_event_stream_dead("End of unbounded event stream");
+    let (status, body) = get(&app, "/readyz").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(body["reasons"][0]
+        .as_str()
+        .unwrap()
+        .contains("cc3 event stream ended"));
+}
+
+#[tokio::test]
+async fn a_failing_startup_read_is_retried_then_fatal_instead_of_an_empty_cache() {
+    let cc = Arc::new(PinningCc::new(true));
+    let started = std::time::Instant::now();
+    let err = match service_with(cc).await {
+        Ok(_) => panic!("a persistent snapshot failure must fail startup"),
+        Err(err) => err,
+    };
+    let text = format!("{err:#}");
+    assert!(text.contains("checkpoints"), "{text}");
+    assert!(text.contains("failed after 5 attempts"), "{text}");
+    assert!(
+        started.elapsed() >= Duration::from_secs(3),
+        "retries with backoff must have happened"
+    );
+}
+
+#[tokio::test]
+async fn providers_that_cannot_pin_still_start_and_become_ready_on_first_progress() {
+    let (cc, _) = continuity::mocks::make_mock_providers(CHAIN);
+    let service = service_with(cc).await.unwrap();
+    assert_eq!(service.cc3_snapshot_height(), None);
+    assert!(!service.readiness().ready);
+    service.cc3_progress().note(1);
+    assert!(
+        service.readiness().ready,
+        "{:?}",
+        service.readiness().reasons
+    );
+}


### PR DESCRIPTION
Fourth PR of the prover liveness audit, findings **5** and **8**. Stacked on #1352 → #1351 → #1350; retarget to `usc-dev` as those merge.

## Finding 5: health could not withdraw traffic

`/api/v1/health` returned 200 for `degraded`, freshness started at construction time and was based on attestation writes (a quiet chain looked stale, a dead subscription with a recent attestation looked fresh).

- **`/livez`**: the process answers HTTP. Nothing else, on purpose: a dependency outage must withdraw readiness, not restart every replica at once; an internal wedge that ends the event task already exits the process (#1350).
- **`/readyz`**: 200 only while this replica can serve current proofs, else **503** with the reasons in the body. Ready means: event task alive, caught up to the startup snapshot, a Creditcoin finalized block processed within 180 s (from the stream progress record of #1351), and the source-chain RPC probe answers.
- `/api/v1/health` keeps answering 200 for compatibility (external checker, existing dashboards) and now carries `ready` + `not_ready_reasons`. Point Kubernetes readiness probes and LB checks at `/readyz`; the proof-gen chart has no probes today (IaC follow-up).

## Finding 8: startup could permanently omit boundaries

Cache snapshots were read sequentially at "latest" with no shared block, snapshot errors became empty caches with a warning, and the subscription started afterwards from whatever block arrived first.

- Every startup read (genesis, checkpoints, attestations) is pinned to **one** Creditcoin finalized block read up front. `cc_client::Client` gains `finalized_head()` and `*_at(hash)` storage readers; `CcRpcProvider` gains `finalized_head()` / `*_at()` with defaults for providers that cannot pin (mocks read latest).
- The event stream **resumes from that height** (`StreamCC3::with_resume_from`): blocks between the snapshot and the first subscribed block are backfilled by the existing parent walk, so an event landing in that window is replayed, not skipped. Readiness stays 503 until the stream has caught up to the snapshot.
- Snapshot reads are retried 5× with backoff and are **fatal** after that. The previous "warn and start with an empty cache" turned a cc3 blip into a replica serving `BlockNotReady` for already-attested data until someone restarted it.

## Tests

- `stream_cc3/tests/watchdog.rs`: `resume_from = 1` on a node at 3 yields exactly 2 and 3; without it the first block is yielded as before.
- `proof-gen-api-server/tests/liveness_readiness.rs`: all three startup reads use the snapshot hash and `cc3_snapshot_height` is exposed; `/livez` 200; `/readyz` 503 "not processed a finalized block" → 503 "catching up" → 200 once caught up → 503 "cc3 event stream ended"; `/api/v1/health` stays 200 with `ready:false`; a persistently failing read fails startup after 5 attempts (with backoff); mock providers that cannot pin still start and become ready on first progress.
- `cargo test -p cc-client -p continuity -p stream_cc3 -p proof-gen-api-server` green; clippy `-D warnings` on cc-client (both feature sets), continuity, stream_cc3, proof-gen-api-server, attestor, archiver; fmt.