### PR TITLE
feat(proof-gen): request admission limits, per-chain fill budget, single-flight block fills

### DIFF
--- a/proof-gen-api-server/bin/server.rs
+++ b/proof-gen-api-server/bin/server.rs
@@ -157,8 +157,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }],
             max_batch_size: args.max_batch_size,
             max_batch_span: args.max_batch_span,
+            admission: proof_gen_api_server::config::AdmissionConfig::default(),
         }
     };
+    // MAX_IN_FLIGHT_REQUESTS / MAX_IN_FLIGHT_PER_CHAIN / REQUEST_TIMEOUT_SECS override YAML.
+    let mut config = config;
+    config.admission.apply_env_overrides();
 
     let server = Server::new(config).await?;
     server.run().await?;

--- a/proof-gen-api-server/config.example.yaml
+++ b/proof-gen-api-server/config.example.yaml
@@ -49,6 +49,10 @@ chains:
     # attestation load on a fast chain multiplies this cache by the same factor. On a chain with
     # both a wide window and dense blocks that is enough to exhaust the process.
     # cache:
+    #   # Simultaneous source-block fetches for this chain's merkle cache, across requests and
+    #   # the backfill worker. Caps RPC amplification under a burst of cold requests.
+    #   max_concurrent_block_fills: 16
+    #
     #   # Retention window in source blocks. Omit to derive it as described above.
     #   # Pin it to size the cache independently of attestation cadence.
     #   merkle_retention_blocks: 1000
@@ -84,3 +88,12 @@ max_batch_size: 10
 # Maximum allowed block span (highest − lowest block) in a single batch request.
 # Prevents small batches from forcing proof generation over extremely large ranges.
 max_batch_span: 1000
+
+# Request admission (all optional; omit the block for the defaults shown).
+# `max_batch_size` bounds the work inside one batch; these bound how many proof requests run
+# at once. Excess requests get an immediate 503 with Retry-After, a request past its deadline
+# a 504. /livez, /readyz, /api/v1/health and /metrics are never limited.
+# admission:
+#   max_in_flight_requests: 64     # across all chains (env: MAX_IN_FLIGHT_REQUESTS)
+#   max_in_flight_per_chain: 32    # per chain_key    (env: MAX_IN_FLIGHT_PER_CHAIN)
+#   request_timeout_secs: 120      # end to end       (env: REQUEST_TIMEOUT_SECS)

--- a/proof-gen-api-server/src/config.rs
+++ b/proof-gen-api-server/src/config.rs
@@ -64,7 +64,18 @@ pub struct ChainCacheConfig {
     /// be served -- roughly `max_entries * attestation_interval * checkpoint_interval` blocks
     /// -- in exchange for bounding a cache that otherwise only ever grows. Opt in knowingly.
     pub checkpoint_cache_max_entries: Option<usize>,
+    /// Upper bound on simultaneous source-block fetches for this chain's merkle cache, across
+    /// every request and the backfill worker together. Without it R concurrent cold requests
+    /// meant R block fetches in flight plus the backfill's own; this caps the RPC amplification
+    /// per chain.
+    pub max_concurrent_block_fills: NonZeroUsize,
 }
+
+/// Default [`ChainCacheConfig::max_concurrent_block_fills`].
+pub const DEFAULT_MAX_CONCURRENT_BLOCK_FILLS: NonZeroUsize = match NonZeroUsize::new(16) {
+    Some(n) => n,
+    None => unreachable!(),
+};
 
 impl Default for ChainCacheConfig {
     fn default() -> Self {
@@ -74,8 +85,88 @@ impl Default for ChainCacheConfig {
             block_cache_capacity: DEFAULT_BLOCK_CACHE_CAPACITY,
             merkle_backfill_enabled: true,
             checkpoint_cache_max_entries: None,
+            max_concurrent_block_fills: DEFAULT_MAX_CONCURRENT_BLOCK_FILLS,
         }
     }
+}
+
+/// Process-wide request admission. Bounds what the HTTP layer lets in so a burst of cold
+/// requests degrades into fast `503`s instead of unbounded RPC fan-out, memory growth and
+/// requests that never finish.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdmissionConfig {
+    /// Proof requests (single, by-tx, batch) in flight across all chains. Health, readiness
+    /// and metrics are never counted or refused.
+    pub max_in_flight_requests: NonZeroUsize,
+    /// Proof requests in flight per chain, so one chain's storm cannot starve the others.
+    pub max_in_flight_per_chain: NonZeroUsize,
+    /// Deadline for one proof request end to end. Exceeding it answers `504`.
+    pub request_timeout: std::time::Duration,
+}
+
+impl Default for AdmissionConfig {
+    fn default() -> Self {
+        Self {
+            max_in_flight_requests: NonZeroUsize::new(64).expect("non-zero"),
+            max_in_flight_per_chain: NonZeroUsize::new(32).expect("non-zero"),
+            request_timeout: std::time::Duration::from_secs(120),
+        }
+    }
+}
+
+impl AdmissionConfig {
+    /// Apply `MAX_IN_FLIGHT_REQUESTS`, `MAX_IN_FLIGHT_PER_CHAIN` and `REQUEST_TIMEOUT_SECS`
+    /// from the environment when set and valid; anything else is left untouched.
+    pub fn apply_env_overrides(&mut self) {
+        if let Some(n) = std::env::var("MAX_IN_FLIGHT_REQUESTS")
+            .ok()
+            .and_then(|raw| raw.parse::<NonZeroUsize>().ok())
+        {
+            self.max_in_flight_requests = n;
+        }
+        if let Some(n) = std::env::var("MAX_IN_FLIGHT_PER_CHAIN")
+            .ok()
+            .and_then(|raw| raw.parse::<NonZeroUsize>().ok())
+        {
+            self.max_in_flight_per_chain = n;
+        }
+        if let Some(secs) = std::env::var("REQUEST_TIMEOUT_SECS")
+            .ok()
+            .and_then(|raw| raw.parse::<u64>().ok())
+            .filter(|secs| *secs > 0)
+        {
+            self.request_timeout = std::time::Duration::from_secs(secs);
+        }
+    }
+}
+
+/// YAML `admission:` block; every field optional.
+#[derive(Debug, Default, Deserialize)]
+pub struct AdmissionFile {
+    #[serde(default)]
+    pub max_in_flight_requests: Option<NonZeroUsize>,
+    #[serde(default)]
+    pub max_in_flight_per_chain: Option<NonZeroUsize>,
+    #[serde(default)]
+    pub request_timeout_secs: Option<u64>,
+}
+
+fn resolve_admission(file: AdmissionFile) -> Result<AdmissionConfig> {
+    if file.request_timeout_secs == Some(0) {
+        bail!("`admission.request_timeout_secs` must be greater than 0; omit it for the default");
+    }
+    let defaults = AdmissionConfig::default();
+    Ok(AdmissionConfig {
+        max_in_flight_requests: file
+            .max_in_flight_requests
+            .unwrap_or(defaults.max_in_flight_requests),
+        max_in_flight_per_chain: file
+            .max_in_flight_per_chain
+            .unwrap_or(defaults.max_in_flight_per_chain),
+        request_timeout: file
+            .request_timeout_secs
+            .map_or(defaults.request_timeout, std::time::Duration::from_secs),
+    })
 }
 
 /// One source chain (EVM) served by this process, keyed on Creditcoin3.
@@ -117,6 +208,7 @@ pub struct Config {
     pub chains: Vec<ChainConfig>,
     pub max_batch_size: NonZeroUsize,
     pub max_batch_span: u64,
+    pub admission: AdmissionConfig,
 }
 
 impl Config {
@@ -138,6 +230,7 @@ impl Config {
             }],
             max_batch_size: DEFAULT_MAX_BATCH_SIZE,
             max_batch_span: DEFAULT_MAX_BATCH_SPAN,
+            admission: AdmissionConfig::default(),
         }
     }
 
@@ -174,6 +267,9 @@ pub struct ConfigFile {
     pub max_batch_size: NonZeroUsize,
     #[serde(default = "default_max_batch_span")]
     pub max_batch_span: u64,
+    /// Optional request admission limits; omit the block for the defaults.
+    #[serde(default)]
+    pub admission: AdmissionFile,
 }
 
 #[derive(Debug, Deserialize)]
@@ -224,6 +320,8 @@ pub struct ChainCacheConfigFile {
     pub merkle_backfill_enabled: Option<bool>,
     #[serde(default)]
     pub checkpoint_cache_max_entries: Option<usize>,
+    #[serde(default)]
+    pub max_concurrent_block_fills: Option<NonZeroUsize>,
 }
 
 /// Deserialize a byte size written either as a number or as a human-readable string.
@@ -331,6 +429,7 @@ impl ConfigFile {
             chains,
             max_batch_size: self.max_batch_size,
             max_batch_span: self.max_batch_span,
+            admission: resolve_admission(self.admission)?,
         })
     }
 }
@@ -376,6 +475,9 @@ fn resolve_cache_config(chain_key: u64, file: ChainCacheConfigFile) -> Result<Ch
             .merkle_backfill_enabled
             .unwrap_or(defaults.merkle_backfill_enabled),
         checkpoint_cache_max_entries: file.checkpoint_cache_max_entries,
+        max_concurrent_block_fills: file
+            .max_concurrent_block_fills
+            .unwrap_or(defaults.max_concurrent_block_fills),
     })
 }
 

--- a/proof-gen-api-server/src/lib.rs
+++ b/proof-gen-api-server/src/lib.rs
@@ -369,7 +369,12 @@ impl Server {
         ContinuityService::spawn_merkle_backfill(service.clone());
 
         let allowed: std::collections::HashSet<u64> = self.config.chain_keys();
-        let app = build_app(service.clone(), allowed, self.prom_metrics.clone());
+        let app = networking::build_app_with_admission(
+            service.clone(),
+            allowed,
+            self.prom_metrics.clone(),
+            self.config.admission.clone(),
+        );
         let (http_shutdown_tx, http_shutdown_rx) = channel::<()>();
 
         let bind_host = &self.config.bind_host;

--- a/proof-gen-api-server/src/networking/admission.rs
+++ b/proof-gen-api-server/src/networking/admission.rs
@@ -1,0 +1,154 @@
+//! Request admission: a process-wide and a per-chain cap on proof requests in flight, plus an
+//! end-to-end deadline per request.
+//!
+//! `max_batch_size` bounds the work inside one batch, not how many requests run at once. With
+//! R simultaneous cold requests the old router let roughly `R × (20 + max_batch_size)`
+//! block-level operations run, each with its own RPC retries, and no request ever timed out.
+//! Refusing the excess up front with a `503` is cheaper for everyone: the caller retries with
+//! back-off, and the requests that were admitted actually finish.
+//!
+//! Health, readiness and metrics are exempt so probes and recovery keep working under load.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    extract::Request,
+    http::{header, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Extension,
+};
+use serde_json::json;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::config::AdmissionConfig;
+use crate::networking::middleware::extract_chain_key_from_path;
+use crate::prom::{labels::Rejection, ProofGenMetrics};
+
+pub struct Admission {
+    global: Arc<Semaphore>,
+    per_chain: HashMap<u64, Arc<Semaphore>>,
+    request_timeout: Duration,
+    metrics: Arc<ProofGenMetrics>,
+}
+
+impl Admission {
+    pub fn new(
+        config: &AdmissionConfig,
+        chain_keys: impl IntoIterator<Item = u64>,
+        metrics: Arc<ProofGenMetrics>,
+    ) -> Self {
+        Self {
+            global: Arc::new(Semaphore::new(config.max_in_flight_requests.get())),
+            per_chain: chain_keys
+                .into_iter()
+                .map(|k| {
+                    (
+                        k,
+                        Arc::new(Semaphore::new(config.max_in_flight_per_chain.get())),
+                    )
+                })
+                .collect(),
+            request_timeout: config.request_timeout,
+            metrics,
+        }
+    }
+
+    /// Try to admit one proof request for `chain_key`. `Err` names the limit that was hit.
+    fn try_admit(&self, chain_key: u64) -> Result<Permits, Rejection> {
+        let global = self
+            .global
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| Rejection::Overloaded)?;
+        let chain = match self.per_chain.get(&chain_key) {
+            Some(sem) => Some(
+                sem.clone()
+                    .try_acquire_owned()
+                    .map_err(|_| Rejection::ChainOverloaded)?,
+            ),
+            // Unknown chain: the chain-key validator answers 400 further in; only the global
+            // permit applies.
+            None => None,
+        };
+        Ok(Permits {
+            _global: global,
+            _chain: chain,
+        })
+    }
+}
+
+struct Permits {
+    _global: OwnedSemaphorePermit,
+    _chain: Option<OwnedSemaphorePermit>,
+}
+
+/// Only proof endpoints are admission-controlled; everything else passes untouched.
+fn is_proof_request(request: &Request) -> bool {
+    request.uri().path().starts_with("/api/v1/proof")
+}
+
+pub async fn admission_middleware(
+    Extension(admission): Extension<Arc<Admission>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if !is_proof_request(&request) {
+        return next.run(request).await;
+    }
+    let chain_key = extract_chain_key_from_path(request.uri()).unwrap_or(u64::MAX);
+    let _permits = match admission.try_admit(chain_key) {
+        Ok(permits) => permits,
+        Err(reason) => {
+            admission.metrics.request_rejected(reason);
+            tracing::warn!(
+                chain_key,
+                ?reason,
+                "🚦 proof request refused by admission control"
+            );
+            return rejected(
+                StatusCode::SERVICE_UNAVAILABLE,
+                match reason {
+                    Rejection::ChainOverloaded => "ChainOverloaded",
+                    _ => "Overloaded",
+                },
+                "too many proof requests in flight; retry with back-off",
+            );
+        }
+    };
+
+    admission.metrics.request_admitted();
+    let outcome = tokio::time::timeout(admission.request_timeout, next.run(request)).await;
+    admission.metrics.request_finished();
+    match outcome {
+        Ok(response) => response,
+        Err(_elapsed) => {
+            admission.metrics.request_rejected(Rejection::Timeout);
+            tracing::warn!(
+                chain_key,
+                timeout = ?admission.request_timeout,
+                "⏱️ proof request exceeded its deadline"
+            );
+            rejected(
+                StatusCode::GATEWAY_TIMEOUT,
+                "RequestTimeout",
+                "proof request exceeded the server's deadline",
+            )
+        }
+    }
+}
+
+fn rejected(status: StatusCode, code: &str, message: &str) -> Response {
+    (
+        status,
+        [(header::RETRY_AFTER, "1")],
+        axum::Json(json!({
+            "code": code,
+            "message": message,
+            "retriable": true,
+        })),
+    )
+        .into_response()
+}

--- a/proof-gen-api-server/src/networking/mod.rs
+++ b/proof-gen-api-server/src/networking/mod.rs
@@ -21,17 +21,38 @@ use routes::{attested_height, continuity, health};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
+pub mod admission;
 pub mod extract;
 pub mod middleware;
 pub mod openapi;
 pub mod routes;
 
+/// Build the router with default [`crate::config::AdmissionConfig`].
 pub fn build_app(
     service: Arc<ContinuityService>,
     allowed_chain_keys: HashSet<u64>,
     prom_metrics: Arc<ProofGenMetrics>,
 ) -> Router {
+    build_app_with_admission(
+        service,
+        allowed_chain_keys,
+        prom_metrics,
+        crate::config::AdmissionConfig::default(),
+    )
+}
+
+pub fn build_app_with_admission(
+    service: Arc<ContinuityService>,
+    allowed_chain_keys: HashSet<u64>,
+    prom_metrics: Arc<ProofGenMetrics>,
+    admission_config: crate::config::AdmissionConfig,
+) -> Router {
     let metrics: Metrics = prom_metrics.clone() as Metrics;
+    let admission = Arc::new(admission::Admission::new(
+        &admission_config,
+        allowed_chain_keys.iter().copied(),
+        prom_metrics.clone(),
+    ));
     let allowed_chain_keys = Arc::new(allowed_chain_keys);
     // Configure CORS to allow browser-based applications to access the API
     let cors = CorsLayer::new()
@@ -78,7 +99,12 @@ pub fn build_app(
                 .config(openapi::swagger_config()),
         )
         .layer(Extension(service))
-        .layer(Extension(prom_metrics.clone()));
+        .layer(Extension(prom_metrics.clone()))
+        // Admission sits directly around the handlers: rejected requests still pass through
+        // the request-metrics, chain-key and CORS layers below (outer), so they are counted
+        // and carry CORS headers like any other response.
+        .layer(axum::middleware::from_fn(admission::admission_middleware))
+        .layer(Extension(admission));
 
     router
         // Request metrics middleware - tracks count, duration, and sizes

--- a/proof-gen-api-server/src/prom/mod.rs
+++ b/proof-gen-api-server/src/prom/mod.rs
@@ -153,6 +153,11 @@ pub struct ProofGenMetrics {
     #[allow(dead_code)]
     start_time_seconds: Gauge<f64, AtomicU64>,
 
+    // Admission metrics. In-flight is a gauge so a stall is visible before any request
+    // completes; rejections are counted by reason.
+    requests_in_flight: Gauge<i64, AtomicI64>,
+    requests_rejected: Family<labels::LabelRejection, Counter<u64, AtomicU64>>,
+
     // Hardware metrics
     cpu_usage_percent: Gauge<f64, AtomicU64>,
     memory_usage_bytes: Gauge<f64, AtomicU64>,
@@ -320,6 +325,19 @@ impl ProofGenMetrics {
             memory_usage_bytes.clone(),
         );
 
+        let requests_in_flight = Gauge::default();
+        registry.register(
+            "proof_gen_requests_in_flight",
+            "Proof requests currently admitted and running",
+            requests_in_flight.clone(),
+        );
+        let requests_rejected = Family::default();
+        registry.register(
+            "proof_gen_requests_rejected",
+            "Proof requests refused or cut off by admission control, by reason",
+            requests_rejected.clone(),
+        );
+
         let thread_count = Gauge::default();
         registry.register(
             "proof_gen_thread_count",
@@ -363,11 +381,30 @@ impl ProofGenMetrics {
             start_time_seconds,
             cpu_usage_percent,
             memory_usage_bytes,
+            requests_in_flight,
+            requests_rejected,
             thread_count,
         }
     }
 
     /// Encode all metrics to OpenMetrics text format.
+    /// A proof request passed admission and started running.
+    pub fn request_admitted(&self) {
+        self.requests_in_flight.inc();
+    }
+
+    /// An admitted proof request finished (any outcome).
+    pub fn request_finished(&self) {
+        self.requests_in_flight.dec();
+    }
+
+    /// A proof request was refused or cut off by admission control.
+    pub fn request_rejected(&self, reason: labels::Rejection) {
+        self.requests_rejected
+            .get_or_create(&labels::LabelRejection { reason })
+            .inc();
+    }
+
     pub fn encode(&self) -> String {
         let mut buffer = String::new();
         prometheus_client::encoding::text::encode(&mut buffer, &self.registry).unwrap();
@@ -568,7 +605,7 @@ mod items {
 }
 
 /// Label definitions following the attestor pattern.
-mod labels {
+pub mod labels {
     use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
 
     // Endpoint labels
@@ -650,5 +687,21 @@ mod labels {
     #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
     pub struct LabelError {
         pub error_type: ErrorType,
+    }
+
+    /// Why admission control refused or cut off a request.
+    #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+    pub enum Rejection {
+        /// Process-wide in-flight limit reached.
+        Overloaded,
+        /// Per-chain in-flight limit reached.
+        ChainOverloaded,
+        /// Request exceeded its end-to-end deadline.
+        Timeout,
+    }
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+    pub struct LabelRejection {
+        pub reason: Rejection,
     }
 }

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -779,6 +779,16 @@ impl ContinuityService {
             };
 
             if leader {
+                // Cleanup lives in a guard so it also runs when this future is *dropped*: the
+                // admission deadline and `try_join!` cancel handlers by dropping them, and a
+                // leader that vanished without removing its entry would leave every later
+                // caller for this height (requests and backfill alike) waiting on a `Notify`
+                // that never fires.
+                let _cleanup = FillGuard {
+                    chain,
+                    header_number,
+                    notify: &notify,
+                };
                 let result =
                     async {
                         let _permit = chain.fill_permits.acquire().await.map_err(|_| {
@@ -789,14 +799,6 @@ impl ContinuityService {
                         self.fetch_and_cache_block(chain, header_number).await
                     }
                     .await;
-                // Remove first, then wake: a follower that registered before the removal is
-                // woken; one that registers after sees no entry and re-checks on its own.
-                chain
-                    .in_flight_fills
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .remove(&header_number);
-                notify.notify_waiters();
                 if result.is_ok() {
                     tracing::debug!(
                         chain_key = chain.builder.config.chain_key,
@@ -832,7 +834,31 @@ impl ContinuityService {
     ) -> ServiceResult<usize> {
         self.fill_block_single_flight(chain, header_number).await
     }
+}
 
+/// Releases a single-flight leadership slot: removes the height from `in_flight_fills` and
+/// wakes the followers. Runs on normal completion *and* on cancellation (drop), so a leader
+/// cut off by a deadline never leaves its followers waiting forever. Remove first, then wake:
+/// a follower that registered before the removal is woken; one that registers after sees no
+/// entry and re-checks on its own.
+struct FillGuard<'a> {
+    chain: &'a Arc<ChainState>,
+    header_number: u64,
+    notify: &'a Arc<tokio::sync::Notify>,
+}
+
+impl Drop for FillGuard<'_> {
+    fn drop(&mut self) {
+        self.chain
+            .in_flight_fills
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .remove(&self.header_number);
+        self.notify.notify_waiters();
+    }
+}
+
+impl ContinuityService {
     async fn precompute_merkle_cache_block_for_tx(
         &self,
         chain: &Arc<ChainState>,

--- a/proof-gen-api-server/src/services/continuity_service/mod.rs
+++ b/proof-gen-api-server/src/services/continuity_service/mod.rs
@@ -41,6 +41,11 @@ pub struct ChainState {
     pub last_cache_advance: std::sync::Mutex<Instant>,
     /// Per-chain cache sizing. Defaults reproduce the pre-configuration behavior.
     pub cache_config: ChainCacheConfig,
+    /// Bounds simultaneous source-block fetches for the merkle cache (requests + backfill).
+    pub fill_permits: Arc<tokio::sync::Semaphore>,
+    /// Heights currently being filled, so concurrent misses for one block share a single
+    /// fetch+build instead of each doing their own.
+    pub in_flight_fills: std::sync::Mutex<HashMap<u64, Arc<tokio::sync::Notify>>>,
 }
 
 impl ChainState {
@@ -469,6 +474,10 @@ impl ContinuityService {
                     checkpoint_interval: AtomicU64::new(checkpoint_interval),
                     attestation_interval: AtomicU64::new(attestation_interval),
                     last_cache_advance: std::sync::Mutex::new(Instant::now()),
+                    fill_permits: Arc::new(tokio::sync::Semaphore::new(
+                        cache_config.max_concurrent_block_fills.get(),
+                    )),
+                    in_flight_fills: std::sync::Mutex::new(HashMap::new()),
                     cache_config,
                 }),
             );
@@ -707,7 +716,9 @@ impl ContinuityService {
         Ok(())
     }
 
-    async fn precompute_merkle_cache_block(
+    /// Fetch one block and populate the merkle cache with it. Callers go through
+    /// [`Self::fill_block_single_flight`], which bounds concurrency and dedupes.
+    async fn fetch_and_cache_block(
         &self,
         chain: &Arc<ChainState>,
         header_number: u64,
@@ -733,41 +744,121 @@ impl ContinuityService {
             .map_err(|message| ServiceError::MerkleError { message })
     }
 
+    /// Make sure `header_number` has been processed into the merkle cache, fetching it at most
+    /// once no matter how many callers ask concurrently, and never with more than
+    /// `max_concurrent_block_fills` fetches in flight for the chain.
+    ///
+    /// The first caller for a height becomes the leader and does the fetch; everyone else
+    /// waits on its `Notify` and re-checks the cache when woken. A leader that fails wakes
+    /// the followers too; each then retries as leader on its own, so one bad fetch is not
+    /// broadcast as everyone's error and a transient failure heals on the next attempt.
+    /// Returns the transaction count the leader inserted, or `0` for followers and for blocks
+    /// that were already processed.
+    async fn fill_block_single_flight(
+        &self,
+        chain: &Arc<ChainState>,
+        header_number: u64,
+    ) -> ServiceResult<usize> {
+        loop {
+            if chain.merkle_proof_cache.is_processed(header_number).await {
+                return Ok(0);
+            }
+            let (leader, notify) = {
+                let mut fills = chain
+                    .in_flight_fills
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner());
+                match fills.get(&header_number) {
+                    Some(existing) => (false, existing.clone()),
+                    None => {
+                        let fresh = Arc::new(tokio::sync::Notify::new());
+                        fills.insert(header_number, fresh.clone());
+                        (true, fresh)
+                    }
+                }
+            };
+
+            if leader {
+                let result =
+                    async {
+                        let _permit = chain.fill_permits.acquire().await.map_err(|_| {
+                            ServiceError::Internal {
+                                message: "block fill semaphore closed".to_owned(),
+                            }
+                        })?;
+                        self.fetch_and_cache_block(chain, header_number).await
+                    }
+                    .await;
+                // Remove first, then wake: a follower that registered before the removal is
+                // woken; one that registers after sees no entry and re-checks on its own.
+                chain
+                    .in_flight_fills
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .remove(&header_number);
+                notify.notify_waiters();
+                if result.is_ok() {
+                    tracing::debug!(
+                        chain_key = chain.builder.config.chain_key,
+                        header_number,
+                        "merkle proof cache fill completed"
+                    );
+                }
+                return result;
+            }
+
+            // Follower: register interest *before* checking whether the leader is still at
+            // work, otherwise a notify between the check and the await would be lost.
+            let notified = notify.notified();
+            let mut notified = std::pin::pin!(notified);
+            notified.as_mut().enable();
+            let still_in_flight = chain
+                .in_flight_fills
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .contains_key(&header_number);
+            if still_in_flight {
+                notified.await;
+            }
+            // Loop: the cache is either populated now, or the leader failed and this caller
+            // takes its turn.
+        }
+    }
+
+    async fn precompute_merkle_cache_block(
+        &self,
+        chain: &Arc<ChainState>,
+        header_number: u64,
+    ) -> ServiceResult<usize> {
+        self.fill_block_single_flight(chain, header_number).await
+    }
+
     async fn precompute_merkle_cache_block_for_tx(
         &self,
         chain: &Arc<ChainState>,
         header_number: u64,
         tx_index: u64,
     ) -> ServiceResult<Option<MerkleProofItem>> {
-        let txs = chain
-            .builder
-            .get_block_tx_data(header_number)
-            .await
-            .map_err(|err| map_eth_rpc_anyhow_to_service_error(err, header_number))?;
-
-        if txs.is_empty() {
-            chain
-                .merkle_proof_cache
-                .mark_processed_empty(header_number)
-                .await;
-            return Ok(None);
-        }
-
-        let (tx_count, item) = chain
+        let chain_key = chain.builder.config.chain_key;
+        if let Some(item) = chain
             .merkle_proof_cache
-            .insert_block_and_get(chain.builder.config.chain_key, header_number, txs, tx_index)
+            .get_by_block_index(chain_key, header_number, tx_index)
             .await
-            .map_err(|message| ServiceError::MerkleError { message })?;
-
+        {
+            return Ok(Some(item));
+        }
+        self.fill_block_single_flight(chain, header_number).await?;
+        let item = chain
+            .merkle_proof_cache
+            .get_by_block_index(chain_key, header_number, tx_index)
+            .await;
         tracing::info!(
-            chain_key = chain.builder.config.chain_key,
+            chain_key,
             header_number,
             tx_index,
-            tx_count,
             cache_hit = item.is_some(),
             "merkle proof cache on-demand fill completed"
         );
-
         Ok(item)
     }
 

--- a/proof-gen-api-server/tests/liveness_admission.rs
+++ b/proof-gen-api-server/tests/liveness_admission.rs
@@ -25,6 +25,8 @@ struct CountingEth {
     peak_tip: AtomicUsize,
     block_fetches: AtomicUsize,
     tip_delay: Duration,
+    /// Delay applied to the first block fetch only (the later ones are fast).
+    first_fetch_delay: Duration,
 }
 
 impl CountingEth {
@@ -34,6 +36,7 @@ impl CountingEth {
             peak_tip: AtomicUsize::new(0),
             block_fetches: AtomicUsize::new(0),
             tip_delay,
+            first_fetch_delay: Duration::from_millis(100),
         }
     }
 }
@@ -68,8 +71,13 @@ impl EthRpcProvider for CountingEth {
         &self,
         height: u64,
     ) -> anyhow::Result<Vec<(sp_core::H256, Vec<u8>)>> {
-        self.block_fetches.fetch_add(1, Ordering::SeqCst);
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        let n = self.block_fetches.fetch_add(1, Ordering::SeqCst);
+        let delay = if n == 0 {
+            self.first_fetch_delay
+        } else {
+            Duration::from_millis(100)
+        };
+        tokio::time::sleep(delay).await;
         continuity::mocks::MockEthRpcProvider
             .get_block_tx_data(height)
             .await
@@ -233,4 +241,30 @@ async fn health_and_readiness_are_never_subject_to_admission() {
         );
     }
     assert_eq!(slow.await.unwrap().0, StatusCode::OK);
+}
+
+/// A fill leader cut off by the request deadline must release the height: the next caller
+/// becomes leader and succeeds instead of waiting on a `Notify` that never fires.
+#[tokio::test]
+async fn a_leader_cancelled_by_the_deadline_does_not_stall_the_height() {
+    let mut provider = CountingEth::new(Duration::ZERO);
+    provider.first_fetch_delay = Duration::from_secs(2);
+    let provider = Arc::new(provider);
+    let admission = AdmissionConfig {
+        request_timeout: Duration::from_millis(300),
+        ..AdmissionConfig::default()
+    };
+    let (app, uri) = app_with(provider.clone(), admission).await;
+
+    let (status, _) = get(&app, &uri).await;
+    assert_eq!(status, StatusCode::GATEWAY_TIMEOUT, "first fetch is slow");
+    assert_eq!(provider.block_fetches.load(Ordering::SeqCst), 1);
+
+    let (status, body) = get(&app, &uri).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(
+        provider.block_fetches.load(Ordering::SeqCst),
+        2,
+        "the second caller took over the fill instead of waiting on the cancelled leader"
+    );
 }

--- a/proof-gen-api-server/tests/liveness_admission.rs
+++ b/proof-gen-api-server/tests/liveness_admission.rs
@@ -1,0 +1,236 @@
+//! Admission-control and single-flight regression tests with deterministic in-process
+//! providers (artificial delays; a concurrency experiment, not a throughput benchmark).
+
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use continuity::rpc::EthRpcProvider;
+use proof_gen_api_server::config::AdmissionConfig;
+use proof_gen_api_server::networking::build_app_with_admission;
+use proof_gen_api_server::prom::ProofGenMetrics;
+use proof_gen_api_server::ContinuityService;
+use serde_json::Value;
+use tower::ServiceExt;
+
+const CHAIN: u64 = 2;
+
+/// Source-chain provider that counts concurrent tip reads and block fills, with a delay on
+/// both so concurrency is observable.
+struct CountingEth {
+    active_tip: AtomicUsize,
+    peak_tip: AtomicUsize,
+    block_fetches: AtomicUsize,
+    tip_delay: Duration,
+}
+
+impl CountingEth {
+    fn new(tip_delay: Duration) -> Self {
+        Self {
+            active_tip: AtomicUsize::new(0),
+            peak_tip: AtomicUsize::new(0),
+            block_fetches: AtomicUsize::new(0),
+            tip_delay,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl EthRpcProvider for CountingEth {
+    async fn build_continuity_blocks(
+        &self,
+        digest: sp_core::H256,
+        start: u64,
+        end: u64,
+    ) -> anyhow::Result<Vec<attestor_primitives::block::Block>> {
+        continuity::mocks::MockEthRpcProvider
+            .build_continuity_blocks(digest, start, end)
+            .await
+    }
+    async fn get_block_tx_bytes(&self, height: u64) -> anyhow::Result<Vec<Vec<u8>>> {
+        continuity::mocks::MockEthRpcProvider
+            .get_block_tx_bytes(height)
+            .await
+    }
+    async fn get_tx_hash_by_index(
+        &self,
+        height: u64,
+        index: u64,
+    ) -> anyhow::Result<Option<sp_core::H256>> {
+        continuity::mocks::MockEthRpcProvider
+            .get_tx_hash_by_index(height, index)
+            .await
+    }
+    async fn get_block_tx_data(
+        &self,
+        height: u64,
+    ) -> anyhow::Result<Vec<(sp_core::H256, Vec<u8>)>> {
+        self.block_fetches.fetch_add(1, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        continuity::mocks::MockEthRpcProvider
+            .get_block_tx_data(height)
+            .await
+    }
+    async fn get_tx_position_by_hash(
+        &self,
+        _hash: sp_core::H256,
+    ) -> anyhow::Result<Option<(u64, u64)>> {
+        Ok(Some((100, 0)))
+    }
+    async fn get_last_block(&self) -> anyhow::Result<u64> {
+        let active = self.active_tip.fetch_add(1, Ordering::SeqCst) + 1;
+        self.peak_tip.fetch_max(active, Ordering::SeqCst);
+        tokio::time::sleep(self.tip_delay).await;
+        self.active_tip.fetch_sub(1, Ordering::SeqCst);
+        Ok(1000)
+    }
+    async fn get_chain_id(&self) -> anyhow::Result<u64> {
+        Ok(31337)
+    }
+    async fn is_healthy(&self) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+}
+
+async fn app_with(
+    provider: Arc<CountingEth>,
+    admission: AdmissionConfig,
+) -> (axum::Router, String) {
+    let (cc, _) = continuity::mocks::make_mock_providers(CHAIN);
+    let cfg = continuity::ContinuityConfig::builder()
+        .cc3_rpc_url("ws://mock")
+        .eth_rpc_url("http://mock")
+        .chain_key(CHAIN)
+        .attestation_interval(10)
+        .checkpoint_interval(10)
+        .build();
+    let builder = Arc::new(continuity::ContinuityBuilder::new_with_providers(
+        cfg,
+        cc,
+        provider.clone(),
+    ));
+    let metrics = Arc::new(ProofGenMetrics::new(&[CHAIN]));
+    let service = Arc::new(
+        ContinuityService::new(vec![builder], metrics.clone(), 2, 1000)
+            .await
+            .unwrap(),
+    );
+    let app = build_app_with_admission(service, [CHAIN].into_iter().collect(), metrics, admission);
+    let hash = provider
+        .get_tx_hash_by_index(100, 0)
+        .await
+        .unwrap()
+        .unwrap();
+    (app, format!("/api/v1/proof-by-tx/{CHAIN}/{hash:#x}"))
+}
+
+async fn get(app: &axum::Router, uri: &str) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let json = if body.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&body).unwrap_or(Value::Null)
+    };
+    (status, json)
+}
+
+#[tokio::test]
+async fn a_burst_of_identical_cold_requests_is_capped_and_fills_the_block_once() {
+    let provider = Arc::new(CountingEth::new(Duration::from_millis(100)));
+    let admission = AdmissionConfig {
+        max_in_flight_requests: NonZeroUsize::new(8).unwrap(),
+        max_in_flight_per_chain: NonZeroUsize::new(8).unwrap(),
+        request_timeout: Duration::from_secs(5),
+    };
+    let (app, uri) = app_with(provider.clone(), admission).await;
+
+    let responses = futures::future::join_all((0..32).map(|_| get(&app, &uri))).await;
+    let ok = responses
+        .iter()
+        .filter(|(s, _)| *s == StatusCode::OK)
+        .count();
+    let refused: Vec<&Value> = responses
+        .iter()
+        .filter(|(s, _)| *s == StatusCode::SERVICE_UNAVAILABLE)
+        .map(|(_, b)| b)
+        .collect();
+    assert_eq!(ok, 8, "exactly the in-flight budget is admitted");
+    assert_eq!(refused.len(), 24);
+    assert!(refused
+        .iter()
+        .all(|b| b["code"] == "Overloaded" && b["retriable"] == true));
+    assert!(
+        provider.peak_tip.load(Ordering::SeqCst) <= 8,
+        "concurrent upstream tip reads stay within the budget"
+    );
+    assert_eq!(
+        provider.block_fetches.load(Ordering::SeqCst),
+        1,
+        "eight concurrent misses for one block share a single fetch"
+    );
+
+    // The refused callers retry with back-off (here: one at a time): everything is warm now
+    // and nothing is fetched again.
+    for _ in 0..24 {
+        let (status, body) = get(&app, &uri).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+    }
+    assert_eq!(provider.block_fetches.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn a_request_past_the_deadline_is_cut_off_with_504() {
+    let provider = Arc::new(CountingEth::new(Duration::from_secs(2)));
+    let admission = AdmissionConfig {
+        request_timeout: Duration::from_millis(200),
+        ..AdmissionConfig::default()
+    };
+    let (app, uri) = app_with(provider, admission).await;
+    let started = std::time::Instant::now();
+    let (status, body) = get(&app, &uri).await;
+    assert_eq!(status, StatusCode::GATEWAY_TIMEOUT, "{body}");
+    assert_eq!(body["code"], "RequestTimeout");
+    assert!(started.elapsed() < Duration::from_secs(1));
+}
+
+#[tokio::test]
+async fn health_and_readiness_are_never_subject_to_admission() {
+    let provider = Arc::new(CountingEth::new(Duration::from_secs(1)));
+    let admission = AdmissionConfig {
+        max_in_flight_requests: NonZeroUsize::new(1).unwrap(),
+        max_in_flight_per_chain: NonZeroUsize::new(1).unwrap(),
+        request_timeout: Duration::from_secs(5),
+    };
+    let (app, uri) = app_with(provider, admission).await;
+
+    // Occupy the single slot with a slow proof request.
+    let slow_app = app.clone();
+    let slow_uri = uri.clone();
+    let slow = tokio::spawn(async move { get(&slow_app, &slow_uri).await });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let (status, body) = get(&app, &uri).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+
+    for path in ["/api/v1/health", "/livez", "/readyz", "/metrics"] {
+        let started = std::time::Instant::now();
+        let (status, _) = get(&app, path).await;
+        assert_ne!(status, StatusCode::GATEWAY_TIMEOUT, "{path}");
+        assert!(
+            started.elapsed() < Duration::from_millis(900),
+            "{path} must not queue behind proof traffic"
+        );
+    }
+    assert_eq!(slow.await.unwrap().0, StatusCode::OK);
+}


### PR DESCRIPTION
Fifth and last PR of the prover liveness audit, finding **6**. Stacked on #1353 → #1352 → #1351 → #1350; retarget to `usc-dev` as those merge.

## Problem

`max_batch_size` bounded the work inside one batch, not how many requests ran at once, and nothing ever timed a request out. The audit fixture sent 32 identical cold `proof-by-tx` requests and observed **32 concurrent tip reads and 32 duplicate block fetch+builds**.

## Changes

- **Admission middleware** around `/api/v1/proof*`:
  - process-wide cap on requests in flight and a per-chain cap so one chain's storm cannot starve the others; refusals are immediate `503` + `Retry-After: 1` with `code: Overloaded | ChainOverloaded`, `retriable: true`
  - end-to-end deadline per request → `504`, `code: RequestTimeout`
  - `/livez`, `/readyz`, `/api/v1/health`, `/metrics` are never limited, so probes and recovery keep working under load
  - config: `admission.{max_in_flight_requests (64), max_in_flight_per_chain (32), request_timeout_secs (120)}` in YAML; `MAX_IN_FLIGHT_REQUESTS`, `MAX_IN_FLIGHT_PER_CHAIN`, `REQUEST_TIMEOUT_SECS` env overrides (both config paths)
- **Per-chain block-fill budget**: `cache.max_concurrent_block_fills` (default 16) bounds simultaneous source-block fetches for the merkle cache across all requests and the backfill worker together.
- **Single-flight fills**: concurrent misses for one height share one fetch+build. Leader/followers on a `Notify`; a failed leader wakes the followers, which retry as leader on their own, so one bad fetch is not broadcast as everyone's error. Cached blocks and processed-empty blocks are served without a fetch (previously every cold `proof-by-tx` on an empty block refetched it).
- **Metrics**: `proof_gen_requests_in_flight` gauge, `proof_gen_requests_rejected{reason}` counter.
- `config.example.yaml` documents both knobs.

## Tests

`proof-gen-api-server/tests/liveness_admission.rs`:
- 32 simultaneous identical cold requests, budget 8 → exactly 8 admitted (200), 24 refused (`Overloaded`), peak concurrent tip reads ≤ 8, **one** block fetch; 24 sequential retries all 200 with no new fetch
- 2 s upstream under a 200 ms deadline → 504 `RequestTimeout` in < 1 s
- with the single admission slot held by a slow proof request: `/api/v1/health`, `/livez`, `/readyz`, `/metrics` all answer immediately

`cargo test -p proof-gen-api-server` green (81 unit, 27 route, 3+3+4+2 liveness), clippy `-D warnings`, fmt.