### PR TITLE
fix(attestor): say 'not registered' instead of 'already registered' when status is None

### DIFF
--- a/attestor/attestor/src/startup.rs
+++ b/attestor/attestor/src/startup.rs
@@ -71,7 +71,11 @@ pub async fn register_bls(
             return Ok(());
         }
         Some(other) => {
-        tracing::info!(status = ?other, %account_id, "ℹ️ skipping attest() — already registered");
+            tracing::info!(
+                status = ?other,
+                %account_id,
+                "ℹ️ skipping attest() — already registered"
+            );
             return Ok(());
         }
     }

--- a/attestor/attestor/src/startup.rs
+++ b/attestor/attestor/src/startup.rs
@@ -55,9 +55,25 @@ pub async fn register_bls(
     bls_key: &bls_signatures::PrivateKey,
 ) -> Result<(), Error> {
     let status = cc3.get_attestor_status(chain_key).await?;
-    if status != Some(AttestorStatus::Idle) {
-        tracing::info!(?status, %account_id, "ℹ️ skipping attest() — already registered");
-        return Ok(());
+    match status {
+        Some(AttestorStatus::Idle) => {}
+        // Not in the attestor pool at all. `attest()` cannot be self-served
+        // from here — a stash has to call `register_attestor` first — so
+        // skipping is correct, but say why rather than reporting the opposite.
+        None => {
+            tracing::warn!(
+                %account_id,
+                chain_key,
+                "⚠️ not registered as an attestor for this chain — skipping attest(). \
+                 A stash account must call register_attestor(chain_key, attestor_id) \
+                 first, using an account other than the attestor itself."
+            );
+            return Ok(());
+        }
+        Some(other) => {
+        tracing::info!(status = ?other, %account_id, "ℹ️ skipping attest() — already registered");
+            return Ok(());
+        }
     }
 
     // bls_signatures uses BLS12-381 minimal-pubkey-size: public key is 48 bytes (G1),


### PR DESCRIPTION
## What's wrong

`register_bls` collapses two different situations into one message:

```rust
let status = cc3.get_attestor_status(chain_key).await?;
if status != Some(AttestorStatus::Idle) {
    tracing::info!(?status, %account_id, "ℹ️ skipping attest() — already registered");
    return Ok(());
}
```

- `Some(Waiting)` / `Some(Active)` — the attestor really is already registered, and the message is right.
- `None` — the attestor is **not in the pool at all**, and the message says exactly the opposite of the truth.

**The behaviour is correct either way** — `attest()` is only callable from `Idle`, and an account reaches `Idle` only through `register_attestor`, which a *stash* must call; an attestor cannot enrol itself. So skipping is right. Only the diagnosis is wrong.

## Why it is worth fixing

Bringing an attestor up against a new source chain produces a log that looks entirely healthy:

```
🔍 balance ok account_id=5FHneW46… balance=1000000000000000000000000
ℹ️ skipping attest() — already registered status=None account_id=5FHneW46…
⏲️ waiting on election...
⏲️ waiting on election...
```

Balance fine, "already registered", waiting for an election — nothing suggests a problem. In reality the attestor is not registered, no election will ever seat it, and it will wait forever. `status=None` is printed, but it reads as a detail rather than a contradiction of the sentence next to it.

This cost us the better part of a day while integrating a new source chain, and it is the kind of thing that costs every operator the same day once.

## What this changes

Replaces the equality check with a `match` that names the `None` case honestly, warns instead of informing, and says what to do about it:

```
⚠️ not registered as an attestor for this chain — skipping attest(). A stash account
   must call register_attestor(chain_key, attestor_id) first, using an account other
   than the attestor itself.
```

No behaviour change: every branch still returns `Ok(())` exactly as before, and the `Idle` path is untouched. One file, logging only.

## Context

Found while bringing up an attestor for exSat's EVM layer (chain id 7200) as part of a BUIDL CTC 2026 Fall project. A separate, more serious finding from the same work — the attestor cannot follow any chain that does not maintain a receipts trie, and reports that as a reorg — is filed as #1355.
